### PR TITLE
fix: text rendering draws to pixmap directly (issue #11)

### DIFF
--- a/pixmap.go
+++ b/pixmap.go
@@ -3,11 +3,21 @@ package gg
 import (
 	"image"
 	"image/color"
+	"image/draw"
 	"image/png"
 	"os"
 )
 
+// Compile-time interface checks.
+var (
+	_ image.Image = (*Pixmap)(nil)
+	_ draw.Image  = (*Pixmap)(nil)
+)
+
 // Pixmap represents a rectangular pixel buffer.
+// It implements both image.Image (read-only) and draw.Image (read-write)
+// interfaces, making it compatible with Go's standard image ecosystem
+// including text rendering via golang.org/x/image/font.
 type Pixmap struct {
 	width  int
 	height int
@@ -120,6 +130,13 @@ func (p *Pixmap) SavePNG(path string) error {
 // At implements the image.Image interface.
 func (p *Pixmap) At(x, y int) color.Color {
 	return p.GetPixel(x, y).Color()
+}
+
+// Set implements the draw.Image interface.
+// This allows Pixmap to be used as a destination for image drawing operations,
+// including text rendering via golang.org/x/image/font.
+func (p *Pixmap) Set(x, y int, c color.Color) {
+	p.SetPixel(x, y, FromColor(c))
 }
 
 // Bounds implements the image.Image interface.

--- a/text.go
+++ b/text.go
@@ -31,7 +31,7 @@ func (c *Context) DrawString(s string, x, y float64) {
 	if c.face == nil {
 		return
 	}
-	text.Draw(c.pixmap.ToImage(), s, c.face, x, y, c.currentColor())
+	text.Draw(c.pixmap, s, c.face, x, y, c.currentColor())
 }
 
 // DrawStringAnchored draws text with an anchor point.
@@ -55,7 +55,7 @@ func (c *Context) DrawStringAnchored(s string, x, y, ax, ay float64) {
 	y += h * ay // Note: y is baseline, so we adjust upward for top alignment
 
 	// Draw the text
-	text.Draw(c.pixmap.ToImage(), s, c.face, x, y, c.currentColor())
+	text.Draw(c.pixmap, s, c.face, x, y, c.currentColor())
 }
 
 // MeasureString returns the dimensions of text in pixels.


### PR DESCRIPTION
## Summary

Fixes blank image output when drawing text. The bug was caused by `text.Draw()` receiving a **copy** of the pixmap via `ToImage()` instead of the actual pixmap.

**Root cause:** `Pixmap.ToImage()` creates a new `image.RGBA` with copied data. Text was drawn to this copy, which was then discarded.

## Changes

- Add `Set(x, y int, c color.Color)` method to `Pixmap` to implement `draw.Image` interface
- Update `text.go` to pass pixmap directly to `text.Draw()`
- Add `TestTextDrawsPixels` regression test that verifies pixels are actually modified
- Add compile-time interface checks for `image.Image` and `draw.Image`

## Why this is the correct fix

Go's image ecosystem uses two interfaces:
- `image.Image` — read-only (At, Bounds, ColorModel)
- `draw.Image` — read-write (adds Set method)

`Pixmap` is a mutable pixel buffer and **should** implement `draw.Image`. This follows how `image.RGBA` in the standard library works.

## Test plan

- [x] `TestTextDrawsPixels` verifies 441 non-white pixels are drawn
- [x] All existing tests pass
- [x] `golangci-lint` passes with 0 issues
- [x] `pre-release-check.sh` passes

Fixes #11