### PR TITLE
docs: v0.9.1 hotfix + v0.10.0 planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Planned for v0.10.0
-- GPU text rendering (glyph atlas, SDF fonts)
-- WebGL2 backend support
+- GPU text rendering with hybrid architecture:
+  - Glyph-as-Path rendering through sparse strips
+  - MSDF atlas for performance
+  - Bitmap atlas for emoji (COLRv1)
+- Text shaping via go-text/typesetting (Pure Go HarfBuzz)
+
+## [0.9.1] - 2025-12-19
+
+### Fixed
+- **Text rendering blank images** — Text was drawn to a copy of the pixmap instead of the actual pixmap ([#11](https://github.com/gogpu/gg/issues/11), [#12](https://github.com/gogpu/gg/pull/12))
+  - Added `Set()` method to `Pixmap` to implement `draw.Image` interface
+  - Added `TestTextDrawsPixels` regression test
 
 ## [0.9.0] - 2025-12-18
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,12 +163,50 @@ See section below for details.
 
 ## Planned
 
-### v0.10.0 — GPU Text Rendering
+### v0.10.0 — GPU Text Rendering (~9,600 LOC)
 
-- [ ] Glyph atlas on GPU
-- [ ] SDF (Signed Distance Field) fonts
-- [ ] Text layout on GPU
-- [ ] Font caching and management
+Enterprise-grade GPU text rendering with hybrid architecture.
+
+**Included:**
+- [x] TASK-049: Curve Integration (~3,300 LOC) — **MERGED**
+
+**P0 — Critical:**
+- [ ] TASK-050a: Text Shaping Integration (go-text/typesetting) — 1,500 LOC
+- [ ] TASK-050b: Glyph-as-Path Rendering (sparse strips) — 2,000 LOC
+- [ ] TASK-050c: Glyph Cache (LRU, 64-frame lifetime) — 800 LOC
+- [ ] TASK-050d: Text Benchmarks — 600 LOC
+- [ ] TASK-050e: Visual Regression Tests — 500 LOC
+
+**P1 — Important:**
+- [ ] TASK-050f: MSDF Generator (Pure Go) — 1,500 LOC
+- [ ] TASK-050g: MSDF Atlas Manager — 1,000 LOC
+- [ ] TASK-050h: MSDF WGSL Shader — 200 LOC
+- [ ] TASK-050i: Bitmap/Emoji Support (COLRv1, ZWJ) — 1,000 LOC
+
+**P2 — Nice to have:**
+- [ ] TASK-050j: Subpixel Text Positioning — 400 LOC
+
+**Architecture:**
+```
+Text Input → go-text/typesetting (Pure Go HarfBuzz)
+                     │
+     ┌───────────────┼───────────────┐
+     │               │               │
+Vector Path    MSDF Atlas    Bitmap Atlas
+(quality)     (performance)    (emoji)
+     │               │               │
+     └───────────────┴───────────────┘
+                     │
+          Sparse Strips Pipeline
+```
+
+**Performance Targets:**
+- Shape 100 chars: < 100µs
+- Cache hit: < 50ns
+- Render 1000 glyphs: < 1ms
+- 60fps with 10,000+ glyphs
+
+**Research:** `docs/dev/research/RESEARCH-009-gpu-text-rendering.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Updates documentation for v0.9.1 hotfix and v0.10.0 planning.

## CHANGELOG

- **v0.9.1** — Hotfix for issue #11 (blank text images)
- **v0.10.0 Planned** — GPU Text Rendering features

## ROADMAP

- Detailed v0.10.0 task breakdown (~9,600 LOC)
- P0/P1/P2 priorities
- Architecture diagram
- Performance targets