### PR TITLE
fix(raster): compute edge direction before point swap

### DIFF
--- a/internal/raster/edge.go
+++ b/internal/raster/edge.go
@@ -15,20 +15,17 @@ type Edge struct {
 
 // NewEdge creates a new edge from two points.
 func NewEdge(p0, p1 Point) Edge {
-	// Ensure y0 < y1
+	// Determine direction BEFORE swap (for non-zero winding rule)
+	dir := 1
 	if p0.Y > p1.Y {
-		p0, p1 = p1, p0
+		dir = -1
+		p0, p1 = p1, p0 // Swap to ensure y0 < y1
 	}
 
 	dy := p1.Y - p0.Y
 	var dx float64
 	if dy != 0 {
 		dx = (p1.X - p0.X) / dy
-	}
-
-	dir := 1
-	if p0.Y > p1.Y {
-		dir = -1
 	}
 
 	return Edge{


### PR DESCRIPTION
## Summary

Fixes the software rasterizer's non-zero winding rule implementation.

**Root cause:** The edge direction (`dir`) was computed AFTER swapping points to ensure `y0 < y1`, which always resulted in `dir=1`. This broke the non-zero winding rule because edges going upward were never marked as `dir=-1`.

**The fix:** Compute direction BEFORE the swap:
- Original order `p0.Y > p1.Y` → downward edge → `dir=-1`, then swap
- Original order `p0.Y <= p1.Y` → upward edge → `dir=+1`, no swap needed

## Impact

- Software backend (CPU rasterizer) on Linux now correctly fills paths
- GPU backend (WGPU) was already correct and unaffected
- Users on Linux without GPU will see correct renders

## Test Plan

- [x] Pre-release check passes (83.8% coverage)
- [x] All existing tests pass with race detector
- [x] golangci-lint passes

Fixes #11