### PR TITLE
deps: update wgpu v0.6.0 → v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.15.1] - 2025-12-26
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.6.0 → v0.7.1
+  - Includes `ErrZeroArea` validation for zero-dimension surfaces
+  - Fixes macOS timing issue when window initially has zero dimensions
+
 ## [0.15.0] - 2025-12-26
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 // Pure Go 2D graphics library with GPU acceleration (v0.9.0+)
 
 require (
-	github.com/gogpu/wgpu v0.6.0
+	github.com/gogpu/wgpu v0.7.1
 	golang.org/x/image v0.34.0
 	golang.org/x/text v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/gogpu/naga v0.6.0 h1:hGfNo1F9e+r6eqZDuEl6Y9TgB7jvhLz0ii2wML7ERnw=
 github.com/gogpu/naga v0.6.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.6.0 h1:Km0hl+3fpDYBTOyYau+mW6Bp7CJgM3sQv3e8L2GiK7s=
-github.com/gogpu/wgpu v0.6.0/go.mod h1:LM+xYpxVOZ0U2D+RmMYoLQcZXu4h96LJJM0z+BpXkuE=
+github.com/gogpu/wgpu v0.7.1 h1:V9d0H0P3TkK1Wgeanl7Ksca9ePToxno9E7epdUeogJ4=
+github.com/gogpu/wgpu v0.7.1/go.mod h1:MRBA/7wAukW6orOEB/8wPG3T4h7fVywF8TlgoIjKczc=
 golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
 golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=


### PR DESCRIPTION
## Summary
- Updated dependency: github.com/gogpu/wgpu v0.6.0 → v0.7.1

## Changes in wgpu v0.7.1
- Added ErrZeroArea sentinel error matching wgpu-core pattern
- Validate dimensions in all Surface.Configure() implementations
- Fixes macOS timing issue when window initially has zero dimensions

## Related
- Fixes gogpu/gogpu#20
- wgpu v0.7.1 release: https://github.com/gogpu/wgpu/releases/tag/v0.7.1