### PR TITLE
chore(deps): update wgpu v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.15.2] - 2025-12-26
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.7.1 → v0.7.2
+  - Fixes Metal CommandEncoder state bug (wgpu Issue #24)
+  - Metal backend properly tracks recording state via `cmdBuffer != 0`
+
 ## [0.15.1] - 2025-12-26
 
 ### Changed
@@ -847,7 +854,10 @@ Key benefits:
 - Scanline rasterization engine
 - fogleman/gg API compatibility layer
 
-[Unreleased]: https://github.com/gogpu/gg/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/gogpu/gg/compare/v0.15.2...HEAD
+[0.15.2]: https://github.com/gogpu/gg/compare/v0.15.1...v0.15.2
+[0.15.1]: https://github.com/gogpu/gg/compare/v0.15.0...v0.15.1
+[0.15.0]: https://github.com/gogpu/gg/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/gogpu/gg/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/gogpu/gg/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/gogpu/gg/compare/v0.11.0...v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 // Pure Go 2D graphics library with GPU acceleration (v0.9.0+)
 
 require (
-	github.com/gogpu/wgpu v0.7.1
+	github.com/gogpu/wgpu v0.7.2
 	golang.org/x/image v0.34.0
 	golang.org/x/text v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/gogpu/naga v0.6.0 h1:hGfNo1F9e+r6eqZDuEl6Y9TgB7jvhLz0ii2wML7ERnw=
 github.com/gogpu/naga v0.6.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.7.1 h1:V9d0H0P3TkK1Wgeanl7Ksca9ePToxno9E7epdUeogJ4=
-github.com/gogpu/wgpu v0.7.1/go.mod h1:MRBA/7wAukW6orOEB/8wPG3T4h7fVywF8TlgoIjKczc=
+github.com/gogpu/wgpu v0.7.2 h1:KZkCiIqcM0mlFHHC4jhVbViQiT1EoSOESoqFHkVfbm0=
+github.com/gogpu/wgpu v0.7.2/go.mod h1:cvliTk43ayrSOB1C40t9C6gY9XoWV0vE/+wcPJEyj6M=
 golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
 golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=


### PR DESCRIPTION
## Summary

Dependency update to pick up Metal backend fix.

## Changes

- **wgpu** v0.7.1 → v0.7.2
  - Fixes Metal CommandEncoder state bug (wgpu Issue #24)
  - Recording state now tracked via `cmdBuffer != 0`

## Documentation

- CHANGELOG.md: Added v0.15.2 entry
- Fixed version links (0.15.0, 0.15.1, 0.15.2)

## Test Plan

- [x] `go mod tidy` — OK

## Release

After merge, tag as **v0.15.2**