### PR TITLE
chore(deps): update wgpu v0.8.3 for Metal macOS fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.15.4] - 2025-12-29
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.8.1 → v0.8.3
+  - Metal macOS blank window fix (Issue gogpu/gogpu#24)
+  - Metal present timing: schedule `presentDrawable:` before `commit`
+  - TextureView NSRange parameters fix
+
 ## [0.15.3] - 2025-12-29
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 
 ---
 
-## Current State: v0.15.1
+## Current State: v0.15.4
 
 | Version | Focus |
 |---------|-------|
@@ -47,7 +47,8 @@
 | v0.13.0 | Go 1.25+ Modernization |
 | v0.14.0 | Advanced Features |
 | v0.15.0 | GPU Compute Shaders |
-| **v0.15.1** | **Dependency update (wgpu v0.7.1)** |
+| v0.15.3 | Dependency update (wgpu v0.8.1, DX12) |
+| **v0.15.4** | **Metal macOS blank window fix** |
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 // Pure Go 2D graphics library with GPU acceleration (v0.9.0+)
 
 require (
-	github.com/gogpu/wgpu v0.8.1
+	github.com/gogpu/wgpu v0.8.3
 	golang.org/x/image v0.34.0
 	golang.org/x/text v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/gogpu/naga v0.8.0 h1:swdhwuKBfovTqDSXhuKRNCGK+ZQtJ4zlAI7VrTomoMM=
 github.com/gogpu/naga v0.8.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.8.1 h1:UpEQ88EQ52LqHzhR67xaB+mvw8lWBexBhQu1CSQSuTU=
-github.com/gogpu/wgpu v0.8.1/go.mod h1:cvliTk43ayrSOB1C40t9C6gY9XoWV0vE/+wcPJEyj6M=
+github.com/gogpu/wgpu v0.8.3 h1:WBMgCvN7tPxyLTHiQtHiub+CMdIPac5afIw3qDGU538=
+github.com/gogpu/wgpu v0.8.3/go.mod h1:K7rZ9/wF9XeYEzHwgVMGeKpniDgdt/+lPaRxA2G1CHA=
 golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
 golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=


### PR DESCRIPTION
## Summary

Update wgpu dependency to v0.8.3 for Metal macOS blank window fixes.

## Changes

- `github.com/gogpu/wgpu` v0.8.1 → v0.8.3
  - Metal macOS blank window fix (Issue gogpu/gogpu#24)
  - Metal present timing: schedule `presentDrawable:` before `commit`
  - TextureView NSRange parameters fix

## Related

- Upstream: gogpu/wgpu#26 (v0.8.3)
- Root issue: gogpu/gogpu#24