### PR TITLE
chore(deps): update wgpu v0.8.5 (DX12 backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.15.5] - 2025-12-29
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.8.4 → v0.8.5
+  - DX12 backend now auto-registers on Windows
+  - Windows backend priority: Vulkan → DX12 → GLES → Software
+
 ## [0.15.4] - 2025-12-29
 
 ### Changed
@@ -871,7 +878,10 @@ Key benefits:
 - Scanline rasterization engine
 - fogleman/gg API compatibility layer
 
-[Unreleased]: https://github.com/gogpu/gg/compare/v0.15.2...HEAD
+[Unreleased]: https://github.com/gogpu/gg/compare/v0.15.5...HEAD
+[0.15.5]: https://github.com/gogpu/gg/compare/v0.15.4...v0.15.5
+[0.15.4]: https://github.com/gogpu/gg/compare/v0.15.3...v0.15.4
+[0.15.3]: https://github.com/gogpu/gg/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/gogpu/gg/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/gogpu/gg/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/gogpu/gg/compare/v0.14.0...v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 // Pure Go 2D graphics library with GPU acceleration (v0.9.0+)
 
 require (
-	github.com/gogpu/wgpu v0.8.4
+	github.com/gogpu/wgpu v0.8.5
 	golang.org/x/image v0.34.0
 	golang.org/x/text v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/gogpu/naga v0.8.1 h1:0lp9rHoWlVVJTZ/F5mH5HKRaL8GqA2bNSbN1tCQxcHA=
 github.com/gogpu/naga v0.8.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.8.4 h1:Ca6PygrEU/u5uMYiA8xMzibBqnSaL81Z/UOA7LDNUbw=
-github.com/gogpu/wgpu v0.8.4/go.mod h1:DyC3gTNzwYR6ru70iGbCNNtd+EH7cpnLELe2vVWl9cY=
+github.com/gogpu/wgpu v0.8.5 h1:fEH1n6zvwnR8hAguNTkUm2zUoxwTG6auwTJVQ3SVWSs=
+github.com/gogpu/wgpu v0.8.5/go.mod h1:DyC3gTNzwYR6ru70iGbCNNtd+EH7cpnLELe2vVWl9cY=
 golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
 golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=


### PR DESCRIPTION
## Summary

- Update wgpu dependency v0.8.4 → v0.8.5
- DX12 backend now auto-registers on Windows
- Fix CHANGELOG footer links for recent versions

## Changes

| File | Description |
|------|-------------|
| `go.mod` | wgpu v0.8.4 → v0.8.5 |
| `CHANGELOG.md` | Add v0.15.5 entry, fix footer links |

## wgpu v0.8.5 Highlights

- DX12 backend auto-registers via `hal/dx12/init.go`
- Windows backend priority: Vulkan → DX12 → GLES → Software
- All 5 HAL backends fully integrated

## Test Plan

- [x] `go build ./...` passes
- [ ] CI passes
