### PR TITLE
fix(deps): update wgpu v0.8.8, naga v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.15.9] - 2026-01-04
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.8.7 → v0.8.8
+  - Skip Metal tests on CI (Metal unavailable in virtualized macOS)
+  - MSL `[[position]]` attribute fix via naga v0.8.3
+- Updated dependency: `github.com/gogpu/naga` v0.8.2 → v0.8.3
+  - Fixes MSL `[[position]]` attribute placement (now on struct member, not function)
+
 ## [0.15.8] - 2026-01-04
 
 ### Changed
@@ -910,7 +919,9 @@ Key benefits:
 - Scanline rasterization engine
 - fogleman/gg API compatibility layer
 
-[Unreleased]: https://github.com/gogpu/gg/compare/v0.15.7...HEAD
+[Unreleased]: https://github.com/gogpu/gg/compare/v0.15.9...HEAD
+[0.15.9]: https://github.com/gogpu/gg/compare/v0.15.8...v0.15.9
+[0.15.8]: https://github.com/gogpu/gg/compare/v0.15.7...v0.15.8
 [0.15.7]: https://github.com/gogpu/gg/compare/v0.15.6...v0.15.7
 [0.15.6]: https://github.com/gogpu/gg/compare/v0.15.5...v0.15.6
 [0.15.5]: https://github.com/gogpu/gg/compare/v0.15.4...v0.15.5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 
 ---
 
-## Current State: v0.15.4
+## Current State: v0.15.9
 
 | Milestone | Focus |
 |-----------|-------|

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,10 @@ module github.com/gogpu/gg
 
 go 1.25
 
-// Pure Go 2D graphics library with GPU acceleration (v0.9.0+)
-
 require (
-	github.com/gogpu/wgpu v0.8.7
+	github.com/gogpu/wgpu v0.8.8
 	golang.org/x/image v0.34.0
 	golang.org/x/text v0.32.0
 )
 
-require github.com/gogpu/naga v0.8.2
+require github.com/gogpu/naga v0.8.3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/gogpu/naga v0.8.2 h1:1HH2a2LlfTCSZcDQAVX7N6XrGKejWZLlUwpuzLA0NuM=
-github.com/gogpu/naga v0.8.2/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.8.7 h1:hFJkcpRYKkpgprJb16jdr9vTTGyoI3+EYhSjTNmCvSw=
-github.com/gogpu/wgpu v0.8.7/go.mod h1:MEKwHKuoxc67W3kTOx7CJZz3/TfgOQirE8DJBPtG4ds=
+github.com/gogpu/naga v0.8.3 h1:HcJ1dlIzANnqGSeowDNrOv9W/96KVExxPH4iXUWxtno=
+github.com/gogpu/naga v0.8.3/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.8.8 h1:26iAsTR67wWQScieaVCHj0grULz7x/1v5iiJR5FypyI=
+github.com/gogpu/wgpu v0.8.8/go.mod h1:YvNpvYzZnN5s3tZK/CTwbxXiJiQ6RoMagWUS9NkPthA=
 golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
 golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=


### PR DESCRIPTION
## Summary
Dependency update for ecosystem hotfix releases.

## Changes
- Update `github.com/gogpu/wgpu` v0.8.7 → v0.8.8
  - Skip Metal tests on CI (Metal unavailable in virtualized macOS)
  - MSL `[[position]]` attribute fix via naga v0.8.3
- Update `github.com/gogpu/naga` v0.8.2 → v0.8.3
  - Fixes MSL `[[position]]` attribute placement (now on struct member, not function)

## Documentation
- CHANGELOG.md — v0.15.9 entry
- ROADMAP.md — Current state updated to v0.15.9

## References
- naga v0.8.3: https://github.com/gogpu/naga/releases/tag/v0.8.3
- wgpu v0.8.8: https://github.com/gogpu/wgpu/releases/tag/v0.8.8
- gogpu v0.8.9: https://github.com/gogpu/gogpu/releases/tag/v0.8.9