### PR TITLE
chore(deps): update wgpu v0.9.0 → v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.17.0] - 2026-01-05
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.9.0 → v0.9.2
+  - v0.9.1: Vulkan vkDestroyDevice fix, features and limits mapping
+  - v0.9.2: Metal NSString double-free fix on autorelease pool drain
+
 ## [0.16.0] - 2026-01-05
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 
 ---
 
-## Current State: v0.16.0
+## Current State: v0.17.0
 
 | Milestone | Focus |
 |-----------|-------|

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/gogpu/naga v0.8.3
-	github.com/gogpu/wgpu v0.9.0
+	github.com/gogpu/wgpu v0.9.2
 	golang.org/x/image v0.34.0
 	golang.org/x/text v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/gogpu/naga v0.8.3 h1:HcJ1dlIzANnqGSeowDNrOv9W/96KVExxPH4iXUWxtno=
 github.com/gogpu/naga v0.8.3/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.9.0 h1:KuFSn81uwJOUzkf+NpnoSqzSPt+gAOILF2O4CFz1aYw=
-github.com/gogpu/wgpu v0.9.0/go.mod h1:YvNpvYzZnN5s3tZK/CTwbxXiJiQ6RoMagWUS9NkPthA=
+github.com/gogpu/wgpu v0.9.2 h1:IHJ9/6Rf72MDB//wOqivbyCa99atoSrYOnrFLR4wGek=
+github.com/gogpu/wgpu v0.9.2/go.mod h1:YvNpvYzZnN5s3tZK/CTwbxXiJiQ6RoMagWUS9NkPthA=
 golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
 golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=


### PR DESCRIPTION
## Summary
- Update wgpu dependency to v0.9.2
- v0.9.1: Vulkan vkDestroyDevice fix, features and limits mapping
- v0.9.2: Metal NSString double-free fix on autorelease pool drain

## Related
- gogpu/wgpu#38, gogpu/wgpu#39