### PR TITLE
chore(deps): update wgpu v0.9.2 → v0.9.3, naga v0.8.3 → v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.17.1] - 2026-01-10
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.9.2 → v0.9.3
+  - Intel Vulkan compatibility: VkRenderPass, wgpu-style swapchain sync
+  - Triangle rendering works on Intel Iris Xe Graphics
+- Updated dependency: `github.com/gogpu/naga` v0.8.3 → v0.8.4
+  - SPIR-V instruction ordering fix for Intel Vulkan
+
 ## [0.17.0] - 2026-01-05
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 
 ---
 
-## Current State: v0.17.0
+## Current State: v0.17.1
 
 | Milestone | Focus |
 |-----------|-------|

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/gogpu/gg
 go 1.25
 
 require (
-	github.com/gogpu/naga v0.8.3
-	github.com/gogpu/wgpu v0.9.2
+	github.com/gogpu/naga v0.8.4
+	github.com/gogpu/wgpu v0.9.3
 	golang.org/x/image v0.34.0
 	golang.org/x/text v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/gogpu/naga v0.8.3 h1:HcJ1dlIzANnqGSeowDNrOv9W/96KVExxPH4iXUWxtno=
-github.com/gogpu/naga v0.8.3/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.9.2 h1:IHJ9/6Rf72MDB//wOqivbyCa99atoSrYOnrFLR4wGek=
-github.com/gogpu/wgpu v0.9.2/go.mod h1:YvNpvYzZnN5s3tZK/CTwbxXiJiQ6RoMagWUS9NkPthA=
+github.com/gogpu/naga v0.8.4 h1:Ge+bOVriIqozna1sStcEqvcP5sygZdxs8DjM8cLt2d8=
+github.com/gogpu/naga v0.8.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.9.3 h1:sIYinDi+ELkq0ncPYcsz2ITZ65wV4Wbim4IsmQNWHc4=
+github.com/gogpu/wgpu v0.9.3/go.mod h1:Pd6a9AOk0kQFWMG1gzQBnF+cejWQ/+FyN4uTCNjwLpY=
 golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
 golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=


### PR DESCRIPTION
## Summary
Update dependencies with Intel Vulkan compatibility fixes.

## Dependencies
- `github.com/gogpu/wgpu` v0.9.2 → v0.9.3
  - Intel Vulkan: VkRenderPass, wgpu-style swapchain sync
  - Triangle rendering works on Intel Iris Xe Graphics
- `github.com/gogpu/naga` v0.8.3 → v0.8.4
  - SPIR-V instruction ordering fix

## Testing
- All tests pass locally
- Linter passes