### PR TITLE
chore(deps): update wgpu v0.10.0 → v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.18.1] - 2026-01-16
+
+### Changed
+- Updated dependency: `github.com/gogpu/wgpu` v0.10.0 → v0.10.1
+  - Non-blocking swapchain acquire (16ms timeout)
+  - Window responsiveness fix during resize/drag
+  - ErrNotReady for skip-frame handling
+
 ## [0.18.0] - 2026-01-15
 
 ### Added
@@ -989,7 +997,8 @@ Key benefits:
 - Scanline rasterization engine
 - fogleman/gg API compatibility layer
 
-[Unreleased]: https://github.com/gogpu/gg/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/gogpu/gg/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/gogpu/gg/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/gogpu/gg/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/gogpu/gg/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/gogpu/gg/compare/v0.16.0...v0.17.0

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.25
 require (
 	github.com/go-webgpu/webgpu v0.1.4
 	github.com/gogpu/naga v0.8.4
-	github.com/gogpu/wgpu v0.10.0
-	golang.org/x/image v0.34.0
-	golang.org/x/text v0.32.0
+	github.com/gogpu/wgpu v0.10.1
+	golang.org/x/image v0.35.0
+	golang.org/x/text v0.33.0
 )
 
 require github.com/go-webgpu/goffi v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,11 @@ github.com/go-webgpu/webgpu v0.1.4 h1:ryaKVNDXzrdE4VInxkzpgs9sLD8IDothoWVxhIltli
 github.com/go-webgpu/webgpu v0.1.4/go.mod h1:hi9vqLHfaHeTYZ/R+03WQAs5ovRu6Oi1UL7n9lRFr60=
 github.com/gogpu/naga v0.8.4 h1:Ge+bOVriIqozna1sStcEqvcP5sygZdxs8DjM8cLt2d8=
 github.com/gogpu/naga v0.8.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.10.0 h1:/qFpYa1dPeZ4W8645Dn/czWa1Krwnn3StSahVZlMb8I=
-github.com/gogpu/wgpu v0.10.0/go.mod h1:Pd6a9AOk0kQFWMG1gzQBnF+cejWQ/+FyN4uTCNjwLpY=
-golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
-golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
+github.com/gogpu/wgpu v0.10.1 h1:KR6XD9bZFMBa4dZWEKblP1vexpfXB+TJ1QR4aZnQPLw=
+github.com/gogpu/wgpu v0.10.1/go.mod h1:Pd6a9AOk0kQFWMG1gzQBnF+cejWQ/+FyN4uTCNjwLpY=
+golang.org/x/image v0.35.0 h1:LKjiHdgMtO8z7Fh18nGY6KDcoEtVfsgLDPeLyguqb7I=
+golang.org/x/image v0.35.0/go.mod h1:MwPLTVgvxSASsxdLzKrl8BRFuyqMyGhLwmC+TO1Sybk=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
-golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
-golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
+golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=
+golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=


### PR DESCRIPTION
## Summary
- Update `github.com/gogpu/wgpu` v0.10.0 → v0.10.1
- Window responsiveness fix: non-blocking swapchain acquire (16ms timeout)
- Skip-frame handling via ErrNotReady

## Changes
- `go.mod`: wgpu v0.10.1
- `CHANGELOG.md`: v0.18.1 entry

## Test plan
- CI runs tests
- Manual verification: window drag/resize should not lag