### PR TITLE
fix: update wgpu v0.10.2 for CGO build tag fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.20.1] - 2026-01-24
+
+### Changed
+
+- **wgpu v0.10.2** — FFI build tag fix
+  - Clear error message when CGO enabled: `undefined: GOFFI_REQUIRES_CGO_ENABLED_0`
+  - See [wgpu v0.10.2 release](https://github.com/gogpu/wgpu/releases/tag/v0.10.2)
+
 ## [0.20.0] - 2026-01-22
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 
 ---
 
-## Current State: v0.20.0 (In Progress)
+## Current State: v0.20.1
 
 | Milestone | Focus | Status |
 |-----------|-------|--------|
@@ -197,9 +197,15 @@ Professional-grade anti-aliasing using the tiny-skia algorithm.
 
 **Fixes:** [#43](https://github.com/gogpu/gg/issues/43) — Pixelated circles
 
+### v0.20.1 — Dependency Update (Current)
+
+**Status:** Released | **Date:** 2026-01-24
+
+- **wgpu v0.10.2** — FFI build tag fix for CGO compatibility
+
 ### v0.20.0 — GPU Backend Completion
 
-**Status:** In Progress | **Date:** 2026-01-22
+**Status:** Released | **Date:** 2026-01-22
 
 Enterprise-grade GPU backend implementation following wgpu-rs and vello patterns.
 
@@ -295,7 +301,8 @@ PushLayer(blend, opacity) → Draw operations → PopLayer() → Composite
 
 | Version | Date | Highlights | LOC |
 |---------|------|------------|-----|
-| **v0.20.0** | **2026-01-22** | **GPU Backend Completion (enterprise-grade)** | **+8,700** |
+| **v0.20.1** | **2026-01-24** | **wgpu v0.10.2 (CGO fix)** | **—** |
+| v0.20.0 | 2026-01-22 | GPU Backend Completion (enterprise-grade) | +8,700 |
 | v0.19.0 | 2026-01-22 | Anti-Aliased Rendering (tiny-skia) | +700 |
 | v0.18.x | 2026-01 | Renderer DI, Backend refactoring | +400 |
 | v0.17.x | 2026-01 | Dependency updates | — |

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.25
 require (
 	github.com/go-webgpu/webgpu v0.1.4
 	github.com/gogpu/naga v0.8.4
-	github.com/gogpu/wgpu v0.10.1
+	github.com/gogpu/wgpu v0.10.2
 	golang.org/x/image v0.35.0
 	golang.org/x/text v0.33.0
 )
 
-require github.com/go-webgpu/goffi v0.3.7 // indirect
+require github.com/go-webgpu/goffi v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-github.com/go-webgpu/goffi v0.3.7 h1:JqzV4l7PUhJRSsmeyP2vJaIK5ZtSWITwG78iA1E4/AQ=
-github.com/go-webgpu/goffi v0.3.7/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM=
+github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.1.4 h1:ryaKVNDXzrdE4VInxkzpgs9sLD8IDothoWVxhIltliE=
 github.com/go-webgpu/webgpu v0.1.4/go.mod h1:hi9vqLHfaHeTYZ/R+03WQAs5ovRu6Oi1UL7n9lRFr60=
 github.com/gogpu/naga v0.8.4 h1:Ge+bOVriIqozna1sStcEqvcP5sygZdxs8DjM8cLt2d8=
 github.com/gogpu/naga v0.8.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.10.1 h1:KR6XD9bZFMBa4dZWEKblP1vexpfXB+TJ1QR4aZnQPLw=
-github.com/gogpu/wgpu v0.10.1/go.mod h1:Pd6a9AOk0kQFWMG1gzQBnF+cejWQ/+FyN4uTCNjwLpY=
+github.com/gogpu/wgpu v0.10.2 h1:jSLJcXZWsuY1YQaVmj/XAqv7Fi5PRLRWIQ/kPr7ckFM=
+github.com/gogpu/wgpu v0.10.2/go.mod h1:0CWKEi2ps1sLZLV7FFi3qm9lgLXJB+FS3kNCclAz5Cs=
 golang.org/x/image v0.35.0 h1:LKjiHdgMtO8z7Fh18nGY6KDcoEtVfsgLDPeLyguqb7I=
 golang.org/x/image v0.35.0/go.mod h1:MwPLTVgvxSASsxdLzKrl8BRFuyqMyGhLwmC+TO1Sybk=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=


### PR DESCRIPTION
## Summary

- Updates wgpu v0.10.1 → v0.10.2
- Updates goffi v0.3.7 → v0.3.8 (indirect)

## Changes

- **go.mod/go.sum** — Dependency updates
- **CHANGELOG.md** — v0.20.1 entry
- **ROADMAP.md** — v0.20.1 milestone

## Why

wgpu v0.10.2 fixes CGO build tag inconsistency that caused confusing errors on Linux with GCC installed:

```
undefined: dl.Dlopen
undefined: dl.Dlsym
```

Now shows clear error:

```
undefined: GOFFI_REQUIRES_CGO_ENABLED_0
```

See [wgpu v0.10.2 release](https://github.com/gogpu/wgpu/releases/tag/v0.10.2)