### PR TITLE
fix: dashed strokes with scale transformation (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.21.1] - 2026-01-28
+
+### Fixed
+
+- **Dashed strokes with scale** (BUG-002, [#54](https://github.com/gogpu/gg/issues/54))
+  - Root cause: `path.Flatten()` lost subpath boundaries, causing rasterizer to create incorrect "connecting edges" between separate subpaths
+  - Solution: New `path.EdgeIter` following tiny-skia pattern — iterates over edges directly without creating inter-subpath connections
+  - Added `raster.FillAAFromEdges()` for correct edge-based rasterization
+
 ## [0.21.0] - 2026-01-27
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 
 ---
 
-## Current State: v0.21.0
+## Current State: v0.21.1
 
 | Milestone | Focus | Status |
 |-----------|-------|--------|
@@ -244,6 +244,23 @@ layered.Composite() // Blend all layers
 - **FEAT-001**: Direct Matrix API ([#51](https://github.com/gogpu/gg/issues/51))
 - **Context.Resize()**: Frame reuse without allocation
 
+### v0.21.1 — Subpath Fix (Current)
+
+**Status:** Released | **Date:** 2026-01-28
+
+Critical fix for dashed strokes with scale transformation.
+
+| Feature | Pattern Source | Description |
+|---------|---------------|-------------|
+| **EdgeIter** | tiny-skia | Edge iterator with proper subpath handling |
+| **FillAAFromEdges** | tiny-skia | Edge-based rasterization without subpath leaks |
+
+**Fixes:** [#54](https://github.com/gogpu/gg/issues/54) — Dashed strokes with scale rendered incorrectly
+
+**Root Cause:** `path.Flatten()` returned flat point list, losing subpath boundaries. Rasterizer created incorrect "connecting edges" between separate subpaths.
+
+**Solution:** New `path.EdgeIter` following tiny-skia pattern — iterates over edges directly, tracks `moveTo` per subpath, never creates inter-subpath edges.
+
 ### v0.20.1 — Dependency Update
 
 **Status:** Released | **Date:** 2026-01-24
@@ -348,7 +365,8 @@ PushLayer(blend, opacity) → Draw operations → PopLayer() → Composite
 
 | Version | Date | Highlights | LOC |
 |---------|------|------------|-----|
-| **v0.21.0** | **2026-01-26** | **Analytic AA for smooth bezier curves** | **+8,163** |
+| **v0.21.1** | **2026-01-28** | **Subpath fix for dashed strokes ([#54](https://github.com/gogpu/gg/issues/54))** | **+200** |
+| v0.21.0 | 2026-01-26 | Enterprise Architecture, UI integration | +8,163 |
 | v0.20.1 | 2026-01-24 | wgpu v0.10.2 (CGO fix) | — |
 | v0.20.0 | 2026-01-22 | GPU Backend Completion (enterprise-grade) | +8,700 |
 | v0.19.0 | 2026-01-22 | Anti-Aliased Rendering (tiny-skia) | +700 |

--- a/internal/path/edge_iter.go
+++ b/internal/path/edge_iter.go
@@ -1,0 +1,175 @@
+// Package path provides internal path processing utilities.
+package path
+
+// Edge represents a line segment from P0 to P1.
+type Edge struct {
+	P0, P1 Point
+}
+
+// EdgeIter iterates over edges in a path, correctly handling subpath boundaries.
+// Unlike Flatten which returns a flat []Point list, EdgeIter never creates
+// edges between separate subpaths - it properly closes each subpath to its
+// own start point before moving to the next.
+//
+// This follows the same pattern as tiny-skia's PathEdgeIter.
+type EdgeIter struct {
+	elements       []PathElement
+	index          int
+	current        Point
+	moveTo         Point // Start of current subpath
+	needsCloseLine bool
+}
+
+// NewEdgeIter creates a new edge iterator for the given path elements.
+func NewEdgeIter(elements []PathElement) *EdgeIter {
+	return &EdgeIter{
+		elements: elements,
+	}
+}
+
+// Next returns the next edge in the path, or nil when iteration is complete.
+// Curves (QuadTo, CubicTo) are flattened to line segments automatically.
+func (iter *EdgeIter) Next() *Edge {
+	for iter.index < len(iter.elements) {
+		elem := iter.elements[iter.index]
+		iter.index++
+
+		switch e := elem.(type) {
+		case MoveTo:
+			if edge := iter.handleMoveTo(e); edge != nil {
+				return edge
+			}
+
+		case LineTo:
+			if edge := iter.handleLineTo(e); edge != nil {
+				return edge
+			}
+
+		case QuadTo:
+			if edge := iter.handleQuadTo(e); edge != nil {
+				return edge
+			}
+
+		case CubicTo:
+			if edge := iter.handleCubicTo(e); edge != nil {
+				return edge
+			}
+
+		case Close:
+			if iter.needsCloseLine {
+				return iter.closeLine()
+			}
+		}
+	}
+
+	// End of elements - close final subpath if needed
+	if iter.needsCloseLine {
+		return iter.closeLine()
+	}
+
+	return nil
+}
+
+// handleMoveTo processes a MoveTo element.
+func (iter *EdgeIter) handleMoveTo(e MoveTo) *Edge {
+	// If we need to close the previous subpath, do it first
+	if iter.needsCloseLine {
+		iter.index-- // Reprocess this MoveTo next time
+		return iter.closeLine()
+	}
+	// Start new subpath
+	iter.moveTo = e.Point
+	iter.current = e.Point
+	return nil
+}
+
+// handleLineTo processes a LineTo element and returns an edge if valid.
+func (iter *EdgeIter) handleLineTo(e LineTo) *Edge {
+	iter.needsCloseLine = true
+	p0 := iter.current
+	iter.current = e.Point
+	// Skip zero-length edges
+	if p0.X == iter.current.X && p0.Y == iter.current.Y {
+		return nil
+	}
+	return &Edge{P0: p0, P1: iter.current}
+}
+
+// handleQuadTo flattens a quadratic curve and returns the first edge.
+func (iter *EdgeIter) handleQuadTo(e QuadTo) *Edge {
+	iter.needsCloseLine = true
+	segments := flattenQuadratic(iter.current, e.Control, e.Point, Tolerance)
+	return iter.processFlattened(segments)
+}
+
+// handleCubicTo flattens a cubic curve and returns the first edge.
+func (iter *EdgeIter) handleCubicTo(e CubicTo) *Edge {
+	iter.needsCloseLine = true
+	segments := flattenCubic(iter.current, e.Control1, e.Control2, e.Point, Tolerance)
+	return iter.processFlattened(segments)
+}
+
+// processFlattened handles flattened curve segments.
+func (iter *EdgeIter) processFlattened(segments []Point) *Edge {
+	if len(segments) == 0 {
+		return nil
+	}
+
+	p0 := iter.current
+	iter.current = segments[0]
+
+	// Insert remaining segments as LineTo elements
+	if len(segments) > 1 {
+		remaining := make([]PathElement, len(segments)-1)
+		for i := 1; i < len(segments); i++ {
+			remaining[i-1] = LineTo{Point: segments[i]}
+		}
+		iter.insertElements(remaining)
+	}
+
+	// Skip zero-length edges
+	if p0.X == iter.current.X && p0.Y == iter.current.Y {
+		return nil
+	}
+	return &Edge{P0: p0, P1: iter.current}
+}
+
+// closeLine returns an edge from current position back to subpath start.
+func (iter *EdgeIter) closeLine() *Edge {
+	iter.needsCloseLine = false
+	p0 := iter.current
+	iter.current = iter.moveTo
+	// Skip zero-length close edges
+	if p0.X == iter.moveTo.X && p0.Y == iter.moveTo.Y {
+		return iter.Next() // Continue to next edge
+	}
+	return &Edge{P0: p0, P1: iter.moveTo}
+}
+
+// insertElements inserts elements at the current position for processing.
+func (iter *EdgeIter) insertElements(elems []PathElement) {
+	if len(elems) == 0 {
+		return
+	}
+	// Insert at current index position
+	newElements := make([]PathElement, 0, len(iter.elements)+len(elems))
+	newElements = append(newElements, iter.elements[:iter.index]...)
+	newElements = append(newElements, elems...)
+	newElements = append(newElements, iter.elements[iter.index:]...)
+	iter.elements = newElements
+}
+
+// CollectEdges returns all edges from the path elements.
+// This is a convenience function for cases where all edges are needed at once.
+func CollectEdges(elements []PathElement) []Edge {
+	var edges []Edge
+	iter := NewEdgeIter(elements)
+	for {
+		edge := iter.Next()
+		if edge == nil {
+			break
+		}
+		edges = append(edges, *edge)
+	}
+	return edges
+}

--- a/internal/path/edge_iter_test.go
+++ b/internal/path/edge_iter_test.go
@@ -1,0 +1,191 @@
+package path
+
+import (
+	"testing"
+)
+
+func TestEdgeIterSingleSubpath(t *testing.T) {
+	// Simple triangle - single subpath
+	elements := []PathElement{
+		MoveTo{Point{0, 0}},
+		LineTo{Point{100, 0}},
+		LineTo{Point{50, 100}},
+		Close{},
+	}
+
+	edges := CollectEdges(elements)
+
+	// Should have 3 edges (including close edge back to start)
+	if len(edges) != 3 {
+		t.Errorf("Expected 3 edges, got %d", len(edges))
+	}
+
+	// Verify edges
+	expected := []Edge{
+		{Point{0, 0}, Point{100, 0}},
+		{Point{100, 0}, Point{50, 100}},
+		{Point{50, 100}, Point{0, 0}}, // Close edge
+	}
+
+	for i, e := range edges {
+		if i >= len(expected) {
+			break
+		}
+		if e.P0 != expected[i].P0 || e.P1 != expected[i].P1 {
+			t.Errorf("Edge %d: expected (%v,%v)->(%v,%v), got (%v,%v)->(%v,%v)",
+				i, expected[i].P0.X, expected[i].P0.Y, expected[i].P1.X, expected[i].P1.Y,
+				e.P0.X, e.P0.Y, e.P1.X, e.P1.Y)
+		}
+	}
+}
+
+func TestEdgeIterMultipleSubpaths(t *testing.T) {
+	// Two separate rectangles (like stroke expansion creates)
+	elements := []PathElement{
+		// First rectangle
+		MoveTo{Point{0, 0}},
+		LineTo{Point{100, 0}},
+		LineTo{Point{100, 50}},
+		LineTo{Point{0, 50}},
+		Close{},
+		// Second rectangle (separate subpath)
+		MoveTo{Point{10, 10}},
+		LineTo{Point{90, 10}},
+		LineTo{Point{90, 40}},
+		LineTo{Point{10, 40}},
+		Close{},
+	}
+
+	edges := CollectEdges(elements)
+
+	// Should have 8 edges (4 per rectangle), NO connecting edge between subpaths
+	if len(edges) != 8 {
+		t.Errorf("Expected 8 edges, got %d", len(edges))
+	}
+
+	// Check that there is NO edge connecting (0,0) area to (10,10) area
+	// This is the key test for BUG-002 fix
+	for i, e := range edges {
+		// Check for "connecting" edge between subpaths
+		if (e.P0.Y <= 0 && e.P1.Y >= 10) || (e.P0.Y >= 10 && e.P1.Y <= 0) {
+			// Allow vertical edges within a subpath, but not between them
+			if e.P0.X != e.P1.X { // Not a pure vertical edge
+				t.Errorf("Found connecting edge between subpaths at index %d: (%v,%v)->(%v,%v)",
+					i, e.P0.X, e.P0.Y, e.P1.X, e.P1.Y)
+			}
+		}
+	}
+
+	// Verify first rectangle closes to (0,0)
+	foundFirstClose := false
+	for _, e := range edges {
+		if e.P1.X == 0 && e.P1.Y == 0 && e.P0.X == 0 && e.P0.Y == 50 {
+			foundFirstClose = true
+			break
+		}
+	}
+	if !foundFirstClose {
+		t.Error("First rectangle should close back to (0,0)")
+	}
+
+	// Verify second rectangle closes to (10,10)
+	foundSecondClose := false
+	for _, e := range edges {
+		if e.P1.X == 10 && e.P1.Y == 10 && e.P0.X == 10 && e.P0.Y == 40 {
+			foundSecondClose = true
+			break
+		}
+	}
+	if !foundSecondClose {
+		t.Error("Second rectangle should close back to (10,10)")
+	}
+}
+
+func TestEdgeIterNoConnectingEdge(t *testing.T) {
+	// Simulates stroke expansion output - outer and inner perimeters
+	// The key is that Close should return to each subpath's own start
+	elements := []PathElement{
+		// Outer perimeter (starts at 0,0)
+		MoveTo{Point{0, 0}},
+		LineTo{Point{100, 0}},
+		LineTo{Point{100, 100}},
+		LineTo{Point{0, 100}},
+		Close{},
+		// Inner perimeter (starts at 10,10)
+		MoveTo{Point{10, 10}},
+		LineTo{Point{10, 90}},
+		LineTo{Point{90, 90}},
+		LineTo{Point{90, 10}},
+		Close{},
+	}
+
+	edges := CollectEdges(elements)
+
+	// Count edges that would connect the two subpaths
+	connectingEdges := 0
+	for _, e := range edges {
+		// An edge from outer perimeter boundary to inner perimeter boundary
+		isFromOuter := e.P0.X == 0 || e.P0.Y == 0 || e.P0.X == 100 || e.P0.Y == 100
+		isToInner := e.P1.X == 10 || e.P1.Y == 10 || e.P1.X == 90 || e.P1.Y == 90
+
+		isFromInner := e.P0.X == 10 || e.P0.Y == 10 || e.P0.X == 90 || e.P0.Y == 90
+		isToOuter := e.P1.X == 0 || e.P1.Y == 0 || e.P1.X == 100 || e.P1.Y == 100
+
+		if (isFromOuter && isToInner) || (isFromInner && isToOuter) {
+			// Check if this is actually a connecting edge (crosses boundary)
+			if (e.P0.X < 10 && e.P1.X >= 10) || (e.P0.X > 90 && e.P1.X <= 90) ||
+				(e.P0.Y < 10 && e.P1.Y >= 10) || (e.P0.Y > 90 && e.P1.Y <= 90) {
+				connectingEdges++
+			}
+		}
+	}
+
+	if connectingEdges > 0 {
+		t.Errorf("Found %d connecting edges between subpaths (should be 0)", connectingEdges)
+	}
+}
+
+func TestEdgeIterZeroLengthEdges(t *testing.T) {
+	// Path where close point equals start point (zero-length close edge)
+	elements := []PathElement{
+		MoveTo{Point{0, 0}},
+		LineTo{Point{100, 0}},
+		LineTo{Point{100, 100}},
+		LineTo{Point{0, 100}},
+		LineTo{Point{0, 0}}, // Explicitly returns to start
+		Close{},             // Close should skip zero-length edge
+	}
+
+	edges := CollectEdges(elements)
+
+	// Zero-length edges should be skipped
+	for i, e := range edges {
+		if e.P0 == e.P1 {
+			t.Errorf("Found zero-length edge at index %d: (%v,%v)->(%v,%v)",
+				i, e.P0.X, e.P0.Y, e.P1.X, e.P1.Y)
+		}
+	}
+}
+
+func TestEdgeIterImplicitClose(t *testing.T) {
+	// Path without explicit Close - should still close automatically
+	elements := []PathElement{
+		MoveTo{Point{0, 0}},
+		LineTo{Point{100, 0}},
+		LineTo{Point{50, 100}},
+		// No Close - should auto-close
+	}
+
+	edges := CollectEdges(elements)
+
+	// Should have 3 edges including implicit close
+	if len(edges) != 3 {
+		t.Errorf("Expected 3 edges (with implicit close), got %d", len(edges))
+	}
+
+	// Last edge should close back to start
+	lastEdge := edges[len(edges)-1]
+	if lastEdge.P1.X != 0 || lastEdge.P1.Y != 0 {
+		t.Errorf("Last edge should close to (0,0), got (%v,%v)", lastEdge.P1.X, lastEdge.P1.Y)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #54 — Dashed strokes with scale transformation rendered incorrectly.

**Root Cause:** `path.Flatten()` returned flat `[]Point` list losing subpath boundaries. Rasterizer created incorrect "connecting edges" between separate subpaths.

**Solution:** New `path.EdgeIter` following tiny-skia pattern:
- Iterates over path elements and returns edges directly
- Tracks `moveTo` per subpath for correct Close handling  
- Never creates edges between separate subpaths

## Changes

- `internal/path/edge_iter.go` — EdgeIter implementation
- `internal/path/edge_iter_test.go` — 5 unit tests
- `internal/raster/raster_aa.go` — FillAAFromEdges, PathEdge type
- `software.go` — Updated fillSupersampled to use EdgeIter
- `CHANGELOG.md` — v0.21.1 entry
- `ROADMAP.md` — v0.21.1 section

## Test Plan

- [x] Unit tests for EdgeIter (5 tests pass)
- [x] Visual test: two dashed rectangles render correctly
- [x] Regression test: single rectangle still renders correctly
- [x] All existing tests pass
- [x] Linter passes (0 issues)