### PR TITLE
docs: fix incorrect API examples in render/ package

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -216,7 +216,8 @@ Enterprise-grade architecture for gogpu/ui integration following Skia, Vello, Ca
 
 ```go
 // New: Device integration with gogpu
-renderer := render.NewGPURenderer(app.DeviceHandle())
+provider := app.GPUContextProvider() // gpucontext.DeviceProvider
+renderer, _ := render.NewGPURenderer(provider)
 scene := render.NewScene()
 scene.Rectangle(10, 10, 100, 50)
 scene.SetFillColor(color.Red)

--- a/render/doc.go
+++ b/render/doc.go
@@ -37,21 +37,28 @@
 //	app := gogpu.NewApp(gogpu.Config{...})
 //	var renderer render.Renderer
 //	var scene *Scene
+//	var initialized bool
 //
-//	app.OnInit(func(gc *gogpu.Context) {
-//	    // gg receives GPU device from gogpu (zero overhead)
-//	    renderer, _ = render.NewGPURenderer(gc.DeviceHandle())
+//	app.OnDraw(func(dc *gogpu.Context) {
+//	    if !initialized {
+//	        // Get gpucontext.DeviceProvider from gogpu
+//	        provider := app.GPUContextProvider()
+//	        if provider != nil {
+//	            // gg receives GPU device from gogpu (zero overhead)
+//	            renderer, _ = render.NewGPURenderer(provider)
 //
-//	    // Build scene (retained mode)
-//	    scene = NewScene()
-//	    scene.SetFillColor(Red)
-//	    scene.Circle(100, 100, 50)
-//	    scene.Fill()
-//	})
+//	            // Build scene (retained mode)
+//	            scene = NewScene()
+//	            scene.SetFillColor(Red)
+//	            scene.Circle(100, 100, 50)
+//	            scene.Fill()
+//	            initialized = true
+//	        }
+//	    }
 //
-//	app.OnDraw(func(gc *gogpu.Context) {
-//	    // Render scene to window surface (zero-copy)
-//	    renderer.Render(gc.SurfaceTarget(), scene)
+//	    // Render scene to CPU target (GPU targets in Phase 3)
+//	    target := render.NewPixmapTarget(800, 600)
+//	    renderer.Render(target, scene)
 //	})
 //
 // Software rendering fallback:

--- a/render/gpu_renderer.go
+++ b/render/gpu_renderer.go
@@ -19,17 +19,20 @@ import (
 // Example:
 //
 //	app := gogpu.NewApp(gogpu.Config{...})
+//	var renderer *render.GPURenderer
+//	var initialized bool
 //
-//	app.OnInit(func(gc *gogpu.Context) {
-//	    // Create GPU renderer with device from gogpu
-//	    renderer, err := render.NewGPURenderer(gc.DeviceHandle())
-//	    if err != nil {
-//	        log.Fatal(err)
+//	app.OnDraw(func(dc *gogpu.Context) {
+//	    if !initialized {
+//	        provider := app.GPUContextProvider()
+//	        if provider != nil {
+//	            renderer, _ = render.NewGPURenderer(provider)
+//	            initialized = true
+//	        }
 //	    }
-//	})
-//
-//	app.OnDraw(func(gc *gogpu.Context) {
-//	    renderer.Render(gc.SurfaceTarget(), scene)
+//	    // Render scene (CPU target for now, GPU targets in Phase 3)
+//	    target := render.NewPixmapTarget(800, 600)
+//	    renderer.Render(target, scene)
 //	})
 type GPURenderer struct {
 	// handle is the GPU device handle from the host application.


### PR DESCRIPTION
## Summary

- Update documentation to use correct gogpu API
- `app.GPUContextProvider()` instead of non-existent `gc.DeviceHandle()`
- Remove non-existent `app.OnInit()` — use flag pattern in `OnDraw`
- Remove non-existent `gc.SurfaceTarget()` — GPU targets in Phase 3

## Context

Discussion #47: @amortaza reported sample code doesn't compile.

## Files Changed

- `render/doc.go` — package documentation example
- `render/gpu_renderer.go` — GPURenderer doc comment
- `ROADMAP.md` — v0.21.0 example code