### PR TITLE
fix(stroke): correct round join arc starting point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - Performance benchmarks
 
+## [0.22.1] - 2026-01-30
+
+### Fixed
+
+- **LineJoinRound rendering** ([#62](https://github.com/gogpu/gg/issues/62))
+  - Round join arc now correctly starts from previous segment's normal
+  - Fixes angular/incorrect appearance when using `LineJoinRound`
+
 ## [0.22.0] - 2026-01-30
 
 ### Added

--- a/internal/stroke/expander.go
+++ b/internal/stroke/expander.go
@@ -370,14 +370,19 @@ func (e *StrokeExpander) computeMiterPoint(p0 Point, norm, ab, cd Vec2, cross fl
 }
 
 // applyRoundJoin applies a round join at the given point.
+// The arc goes from the previous segment's normal (lastNorm) to the current normal (norm).
 func (e *StrokeExpander) applyRoundJoin(p0 Point, norm Vec2, cross, dot float64) {
+	// Compute lastNorm from lastTan (same pattern as computeMiterPoint)
+	lastScale := 0.5 * e.style.Width / e.lastTan.Length()
+	lastNorm := e.lastTan.Perp().Scale(lastScale)
+
 	angle := math.Atan2(cross, dot)
 	if angle > 0.0 {
 		e.backward.lineTo(p0.Add(norm))
-		e.roundJoin(e.forward, p0, norm.Neg(), angle)
+		e.roundJoin(e.forward, p0, lastNorm.Neg(), angle)
 	} else {
 		e.forward.lineTo(p0.Add(norm.Neg()))
-		e.roundJoinRev(e.backward, p0, norm, -angle)
+		e.roundJoinRev(e.backward, p0, lastNorm, -angle)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #62 — LineJoinRound render is incorrect

### Root Cause

In `applyRoundJoin()`, the round join arc was starting from the **current segment's normal** (`norm`) instead of the **previous segment's normal** (`lastNorm`).

This caused the arc to 'jump' to the wrong position, resulting in angular/incorrect round joins.

### The Fix

Compute `lastNorm` from `lastTan` (same pattern as `computeMiterPoint`) and use it as the arc starting point:

```go
// Before (incorrect):
e.roundJoin(e.forward, p0, norm.Neg(), angle)

// After (correct):
lastScale := 0.5 * e.style.Width / e.lastTan.Length()
lastNorm := e.lastTan.Perp().Scale(lastScale)
e.roundJoin(e.forward, p0, lastNorm.Neg(), angle)
```

### Test

Added `TestRoundJoin_VShape` test case using the exact coordinates from the issue report.
