### PR TITLE
refactor: standardize gg.Context variable naming to cc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,10 @@ canvas, _ := ggcanvas.New(app.GPUContextProvider(), 800, 600)
 defer canvas.Close()
 
 // Draw with gg API
-ctx := canvas.Context()
-ctx.SetRGB(1, 0, 0)
-ctx.DrawCircle(400, 300, 100)
-ctx.Fill()
+cc := canvas.Context()
+cc.SetRGB(1, 0, 0)
+cc.DrawCircle(400, 300, 100)
+cc.Fill()
 
 // Render to gogpu window
 canvas.RenderTo(dc)

--- a/integration/ggcanvas/doc.go
+++ b/integration/ggcanvas/doc.go
@@ -25,10 +25,10 @@
 //	defer canvas.Close()
 //
 //	// Draw with gg API
-//	ctx := canvas.Context()
-//	ctx.SetRGB(1, 0, 0)
-//	ctx.DrawCircle(400, 300, 100)
-//	ctx.Fill()
+//	cc := canvas.Context()
+//	cc.SetRGB(1, 0, 0)
+//	cc.DrawCircle(400, 300, 100)
+//	cc.Fill()
 //
 //	// Render to gogpu window
 //	canvas.RenderTo(dc)


### PR DESCRIPTION
## Summary
- Standardize variable naming for integration examples
- `dc` = `*gogpu.Context` (draw context)
- `cc` = `*gg.Context` (canvas context)

## Changes
- `CHANGELOG.md`: `ctx` → `cc`
- `integration/ggcanvas/doc.go`: `ctx` → `cc`