### PR TITLE
fix(ggcanvas): use shared TextureUpdater interface with error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **ggcanvas texture updates silently failing** ([#79](https://github.com/gogpu/gg/issues/79))
+  - Root cause: local `textureUpdater` interface expected `UpdateData(data []byte)` (no error return), but `gogpu.Texture.UpdateData` returns `error` — type assertion failed silently
+  - Fix: use shared `gpucontext.TextureUpdater` interface with proper error handling
+  - Added auto-dirty in `RenderToEx()` — calling `RenderTo` now always uploads current content
+  - Compile-time interface check for mock in tests
+
 ### Planned for v1.0.0
 - API Review and cleanup
 - Comprehensive documentation

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/go-webgpu/webgpu v0.2.1
-	github.com/gogpu/gpucontext v0.6.0
+	github.com/gogpu/gpucontext v0.7.0
 	github.com/gogpu/gputypes v0.2.0
 	github.com/gogpu/naga v0.10.0
 	github.com/gogpu/wgpu v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/go-webgpu/webgpu v0.2.1 h1:i4kzvI4oq+ETsMRNbdIIz0eakoUes0yCIlUQgusulb
 github.com/go-webgpu/webgpu v0.2.1/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
 github.com/gogpu/gpucontext v0.6.0 h1:ZQdKGl7oLvtM9sPg6O/SJQaZs9D2jddAXNQWU0HcLnA=
 github.com/gogpu/gpucontext v0.6.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
+github.com/gogpu/gpucontext v0.7.0 h1:6ev64ycEsrkHVeBzdaaiUW+K9eBH9WyL83WsXPPeCoA=
+github.com/gogpu/gpucontext v0.7.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.10.0 h1:TmCTTkgjZyFppyCEUtcz5E6yl9x3E76ZhpYkoGTt1HI=

--- a/integration/ggcanvas/canvas_test.go
+++ b/integration/ggcanvas/canvas_test.go
@@ -58,15 +58,19 @@ type mockTexture struct {
 func (m *mockTexture) Width() int  { return m.width }
 func (m *mockTexture) Height() int { return m.height }
 
-func (m *mockTexture) UpdateData(data []byte) {
+func (m *mockTexture) UpdateData(data []byte) error {
 	m.data = make([]byte, len(data))
 	copy(m.data, data)
 	m.updated++
+	return nil
 }
 
 func (m *mockTexture) Destroy() {
 	m.destroyed = true
 }
+
+// Compile-time check: mockTexture must implement TextureUpdater.
+var _ gpucontext.TextureUpdater = (*mockTexture)(nil)
 
 // mockRenderer implements gpucontext.TextureCreator for testing.
 type mockRenderer struct {

--- a/integration/ggcanvas/render.go
+++ b/integration/ggcanvas/render.go
@@ -85,6 +85,9 @@ func (c *Canvas) RenderToEx(dc gpucontext.TextureDrawer, opts RenderOptions) err
 		return ErrCanvasClosed
 	}
 
+	// Auto-dirty: calling RenderTo implies intent to display current content
+	c.dirty = true
+
 	// Flush canvas to ensure pixmap is up-to-date
 	tex, err := c.Flush()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix ggcanvas texture updates silently failing ([#79](https://github.com/gogpu/gg/issues/79))
- Root cause: local `textureUpdater` interface expected `UpdateData(data []byte)` (no error), but `gogpu.Texture.UpdateData` returns `error` — type assertion failed silently
- Replace local interface with shared `gpucontext.TextureUpdater` (v0.7.0)
- Add proper error handling in `Flush()`
- Add auto-dirty in `RenderToEx()` — no manual `MarkDirty()` needed
- Add compile-time interface check for test mock

## Test plan

- [x] `go test ./integration/ggcanvas/...` passes
- [x] `go test ./...` all tests pass
- [x] `golangci-lint run` — 0 issues
- [x] CI validates cross-platform
