### PR TITLE
fix: custom Pattern rendering black (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Custom Pattern implementations always render black** ([#75](https://github.com/gogpu/gg/issues/75))
+  - Root cause 1: `getColorFromPaint()` only handled `*SolidPattern`, returned Black for everything else
+  - Root cause 2: `SetFillPattern()`/`SetStrokePattern()` didn't sync `paint.Brush`, breaking `ColorAt()` precedence
+  - Fix: New `painterPixmapAdapter` samples `paint.ColorAt(x,y)` per-pixel for non-solid paints
+  - Solid paints still use fast single-color path (no performance regression)
+  - New `Painter` interface (`painter.go`) for future span-based optimizations
+
 - **ggcanvas texture updates silently failing** ([#79](https://github.com/gogpu/gg/issues/79))
   - Root cause: local `textureUpdater` interface expected `UpdateData(data []byte)` (no error return), but `gogpu.Texture.UpdateData` returns `error` — type assertion failed silently
   - Fix: use shared `gpucontext.TextureUpdater` interface with proper error handling

--- a/context_image.go
+++ b/context_image.go
@@ -234,13 +234,17 @@ func (c *Context) CreateImagePattern(img *ImageBuf, x, y, w, h int) Pattern {
 }
 
 // SetFillPattern sets the fill pattern.
+// It also updates the Brush field for consistency with ColorAt precedence.
 func (c *Context) SetFillPattern(pattern Pattern) {
 	c.paint.Pattern = pattern
+	c.paint.Brush = BrushFromPattern(pattern)
 }
 
 // SetStrokePattern sets the stroke pattern.
+// It also updates the Brush field for consistency with ColorAt precedence.
 func (c *Context) SetStrokePattern(pattern Pattern) {
 	c.paint.Pattern = pattern
+	c.paint.Brush = BrushFromPattern(pattern)
 }
 
 // ImagePattern represents an image-based pattern.

--- a/painter.go
+++ b/painter.go
@@ -1,0 +1,59 @@
+package gg
+
+// Painter generates colors for rendering operations.
+// For simple use cases, implement Pattern instead — it auto-wraps via PainterFromPaint.
+// For maximum performance, implement Painter directly with span-based color generation.
+type Painter interface {
+	// PaintSpan fills dest with colors for pixels starting at (x, y) for length pixels.
+	PaintSpan(dest []RGBA, x, y, length int)
+}
+
+// SolidPainter fills all pixels with a single color (fastest path).
+type SolidPainter struct {
+	Color RGBA
+}
+
+// PaintSpan fills the destination buffer with the solid color.
+func (p *SolidPainter) PaintSpan(dest []RGBA, _, _ int, length int) {
+	for i := 0; i < length && i < len(dest); i++ {
+		dest[i] = p.Color
+	}
+}
+
+// FuncPainter wraps a ColorAt function as a Painter (per-pixel sampling).
+type FuncPainter struct {
+	Fn func(x, y float64) RGBA
+}
+
+// PaintSpan samples the color function at each pixel center.
+func (p *FuncPainter) PaintSpan(dest []RGBA, x, y, length int) {
+	fy := float64(y) + 0.5
+	for i := 0; i < length && i < len(dest); i++ {
+		dest[i] = p.Fn(float64(x+i)+0.5, fy)
+	}
+}
+
+// PainterFromPaint creates the appropriate Painter for a Paint.
+// Solid paints return SolidPainter (fast). Non-solid paints return FuncPainter
+// that samples paint.ColorAt per pixel.
+func PainterFromPaint(paint *Paint) Painter {
+	// Check Brush first (takes precedence)
+	if paint.Brush != nil {
+		if sb, ok := paint.Brush.(SolidBrush); ok {
+			return &SolidPainter{Color: sb.Color}
+		}
+		// Check if the Brush itself implements Painter (power-user opt-in)
+		if p, ok := paint.Brush.(Painter); ok {
+			return p
+		}
+		return &FuncPainter{Fn: paint.Brush.ColorAt}
+	}
+	// Fall back to Pattern
+	if paint.Pattern != nil {
+		if sp, ok := paint.Pattern.(*SolidPattern); ok {
+			return &SolidPainter{Color: sp.Color}
+		}
+		return &FuncPainter{Fn: paint.Pattern.ColorAt}
+	}
+	return &SolidPainter{Color: Black}
+}

--- a/painter_test.go
+++ b/painter_test.go
@@ -1,0 +1,121 @@
+package gg
+
+import (
+	"testing"
+)
+
+func TestPainterFromPaint_Solid(t *testing.T) {
+	paint := NewPaint()
+	paint.SetBrush(Solid(Red))
+
+	painter := PainterFromPaint(paint)
+	sp, ok := painter.(*SolidPainter)
+	if !ok {
+		t.Fatalf("expected *SolidPainter, got %T", painter)
+	}
+	if sp.Color != Red {
+		t.Errorf("SolidPainter.Color = %v, want Red", sp.Color)
+	}
+}
+
+func TestPainterFromPaint_SolidPattern(t *testing.T) {
+	paint := &Paint{
+		Pattern: NewSolidPattern(Blue),
+	}
+
+	painter := PainterFromPaint(paint)
+	sp, ok := painter.(*SolidPainter)
+	if !ok {
+		t.Fatalf("expected *SolidPainter, got %T", painter)
+	}
+	if sp.Color != Blue {
+		t.Errorf("SolidPainter.Color = %v, want Blue", sp.Color)
+	}
+}
+
+func TestPainterFromPaint_CustomBrush(t *testing.T) {
+	paint := NewPaint()
+	paint.SetBrush(NewCustomBrush(func(x, y float64) RGBA {
+		return Green
+	}))
+
+	painter := PainterFromPaint(paint)
+	_, ok := painter.(*FuncPainter)
+	if !ok {
+		t.Fatalf("expected *FuncPainter, got %T", painter)
+	}
+}
+
+func TestPainterFromPaint_CustomPattern(t *testing.T) {
+	paint := &Paint{
+		Pattern: &testPattern{colorFn: func(_, _ float64) RGBA { return Green }},
+	}
+
+	painter := PainterFromPaint(paint)
+	fp, ok := painter.(*FuncPainter)
+	if !ok {
+		t.Fatalf("expected *FuncPainter, got %T", painter)
+	}
+	// Verify it samples the pattern correctly
+	c := fp.Fn(0, 0)
+	if c != Green {
+		t.Errorf("FuncPainter.Fn returned %v, want Green", c)
+	}
+}
+
+func TestPainterFromPaint_Empty(t *testing.T) {
+	paint := &Paint{}
+
+	painter := PainterFromPaint(paint)
+	sp, ok := painter.(*SolidPainter)
+	if !ok {
+		t.Fatalf("expected *SolidPainter, got %T", painter)
+	}
+	if sp.Color != Black {
+		t.Errorf("SolidPainter.Color = %v, want Black", sp.Color)
+	}
+}
+
+func TestSolidPainter_PaintSpan(t *testing.T) {
+	sp := &SolidPainter{Color: Red}
+	dest := make([]RGBA, 5)
+	sp.PaintSpan(dest, 10, 20, 5)
+
+	for i, c := range dest {
+		if c != Red {
+			t.Errorf("dest[%d] = %v, want Red", i, c)
+		}
+	}
+}
+
+func TestFuncPainter_PaintSpan(t *testing.T) {
+	// Pattern that returns different colors based on x
+	fp := &FuncPainter{
+		Fn: func(x, _ float64) RGBA {
+			if int(x)%2 == 0 {
+				return Red
+			}
+			return Blue
+		},
+	}
+
+	dest := make([]RGBA, 4)
+	fp.PaintSpan(dest, 0, 0, 4)
+
+	// x=0 -> Red (center 0.5, int(0.5)=0, even)
+	// x=1 -> Blue (center 1.5, int(1.5)=1, odd)
+	// x=2 -> Red (center 2.5, int(2.5)=2, even)
+	// x=3 -> Blue (center 3.5, int(3.5)=3, odd)
+	if dest[0] != Red {
+		t.Errorf("dest[0] = %v, want Red", dest[0])
+	}
+	if dest[1] != Blue {
+		t.Errorf("dest[1] = %v, want Blue", dest[1])
+	}
+	if dest[2] != Red {
+		t.Errorf("dest[2] = %v, want Red", dest[2])
+	}
+	if dest[3] != Blue {
+		t.Errorf("dest[3] = %v, want Blue", dest[3])
+	}
+}

--- a/pattern_render_test.go
+++ b/pattern_render_test.go
@@ -1,0 +1,205 @@
+package gg
+
+import (
+	"testing"
+)
+
+// TestCustomPatternFill reproduces the original bug: custom Pattern
+// implementations should produce non-black pixels when used as fill.
+func TestCustomPatternFill(t *testing.T) {
+	dc := NewContext(100, 100)
+
+	// Create a custom pattern that returns Green everywhere
+	pattern := &testPattern{colorFn: func(_, _ float64) RGBA { return Green }}
+	dc.SetFillPattern(pattern)
+
+	// Draw and fill a rectangle
+	dc.DrawRectangle(10, 10, 80, 80)
+	dc.Fill()
+
+	// Check center pixel — should be Green, not Black
+	center := dc.pixmap.GetPixel(50, 50)
+	if center.R < 0.01 && center.G < 0.01 && center.B < 0.01 {
+		t.Errorf("center pixel is black (%v), custom pattern was not rendered", center)
+	}
+	if center.G < 0.9 {
+		t.Errorf("center pixel G = %v, want ~1.0 (Green)", center.G)
+	}
+}
+
+// TestCustomBrushFill verifies that CustomBrush (gradient, checkerboard, etc.)
+// produces non-black pixels when used as fill.
+func TestCustomBrushFill(t *testing.T) {
+	dc := NewContext(100, 100)
+
+	// Use a horizontal gradient from Red to Blue
+	dc.SetFillBrush(HorizontalGradient(Red, Blue, 0, 100))
+
+	dc.DrawRectangle(0, 0, 100, 100)
+	dc.Fill()
+
+	// Left side should be reddish
+	left := dc.pixmap.GetPixel(5, 50)
+	if left.R < 0.5 {
+		t.Errorf("left pixel R = %v, want > 0.5 (reddish)", left.R)
+	}
+
+	// Right side should be bluish
+	right := dc.pixmap.GetPixel(95, 50)
+	if right.B < 0.5 {
+		t.Errorf("right pixel B = %v, want > 0.5 (bluish)", right.B)
+	}
+
+	// There should be color variation across the gradient
+	if colorDistance(left, right) < 0.3 {
+		t.Error("gradient fill shows no color variation between left and right")
+	}
+}
+
+// TestCheckerboardFill verifies checkerboard brush produces alternating colors.
+func TestCheckerboardFill(t *testing.T) {
+	dc := NewContext(100, 100)
+
+	checker := Checkerboard(White, Black, 10)
+	dc.SetFillBrush(checker)
+
+	dc.DrawRectangle(0, 0, 100, 100)
+	dc.Fill()
+
+	// Pixel at (5, 5) — first square (should be White or Black)
+	p1 := dc.pixmap.GetPixel(5, 5)
+	// Pixel at (15, 5) — second square (should be opposite)
+	p2 := dc.pixmap.GetPixel(15, 5)
+
+	// The two pixels should be different (one White, one Black)
+	dist := colorDistance(p1, p2)
+	if dist < 0.5 {
+		t.Errorf("checkerboard squares are too similar: p1=%v, p2=%v, dist=%v", p1, p2, dist)
+	}
+}
+
+// TestSolidFillStillWorks ensures solid colors still use the fast path.
+func TestSolidFillStillWorks(t *testing.T) {
+	dc := NewContext(100, 100)
+	dc.SetRGB(1, 0, 0) // Red
+
+	dc.DrawRectangle(10, 10, 80, 80)
+	dc.Fill()
+
+	center := dc.pixmap.GetPixel(50, 50)
+	if center.R < 0.9 || center.G > 0.1 || center.B > 0.1 {
+		t.Errorf("solid fill center = %v, want approximately Red", center)
+	}
+}
+
+// TestSetFillPatternUpdatesBrush verifies SetFillPattern keeps Brush in sync.
+func TestSetFillPatternUpdatesBrush(t *testing.T) {
+	dc := NewContext(100, 100)
+
+	pattern := &testPattern{colorFn: func(_, _ float64) RGBA { return Cyan }}
+	dc.SetFillPattern(pattern)
+
+	// Brush should now reflect the pattern
+	brush := dc.paint.Brush
+	if brush == nil {
+		t.Fatal("Brush is nil after SetFillPattern")
+	}
+
+	c := brush.ColorAt(0, 0)
+	if c != Cyan {
+		t.Errorf("Brush.ColorAt = %v, want Cyan", c)
+	}
+}
+
+// TestSetStrokePatternUpdatesBrush verifies SetStrokePattern keeps Brush in sync.
+func TestSetStrokePatternUpdatesBrush(t *testing.T) {
+	dc := NewContext(100, 100)
+
+	pattern := &testPattern{colorFn: func(_, _ float64) RGBA { return Magenta }}
+	dc.SetStrokePattern(pattern)
+
+	brush := dc.paint.Brush
+	if brush == nil {
+		t.Fatal("Brush is nil after SetStrokePattern")
+	}
+
+	c := brush.ColorAt(0, 0)
+	if c != Magenta {
+		t.Errorf("Brush.ColorAt = %v, want Magenta", c)
+	}
+}
+
+// TestGradientFillVariation verifies gradient fills have actual color variation.
+func TestGradientFillVariation(t *testing.T) {
+	dc := NewContext(100, 100)
+
+	dc.SetFillBrush(VerticalGradient(White, Black, 0, 100))
+	dc.DrawRectangle(0, 0, 100, 100)
+	dc.Fill()
+
+	// Top should be bright, bottom should be dark
+	top := dc.pixmap.GetPixel(50, 5)
+	bottom := dc.pixmap.GetPixel(50, 95)
+
+	if top.R < 0.5 {
+		t.Errorf("top pixel R = %v, want > 0.5 (bright)", top.R)
+	}
+	if bottom.R > 0.5 {
+		t.Errorf("bottom pixel R = %v, want < 0.5 (dark)", bottom.R)
+	}
+}
+
+// TestSolidColorFromPaint tests the internal solidColorFromPaint function.
+func TestSolidColorFromPaint(t *testing.T) {
+	t.Run("solid brush", func(t *testing.T) {
+		paint := NewPaint()
+		paint.SetBrush(Solid(Red))
+		color, ok := solidColorFromPaint(paint)
+		if !ok {
+			t.Fatal("expected ok=true for solid brush")
+		}
+		if color != Red {
+			t.Errorf("color = %v, want Red", color)
+		}
+	})
+
+	t.Run("solid pattern", func(t *testing.T) {
+		paint := &Paint{
+			Pattern: NewSolidPattern(Blue),
+		}
+		color, ok := solidColorFromPaint(paint)
+		if !ok {
+			t.Fatal("expected ok=true for solid pattern")
+		}
+		if color != Blue {
+			t.Errorf("color = %v, want Blue", color)
+		}
+	})
+
+	t.Run("custom brush", func(t *testing.T) {
+		paint := NewPaint()
+		paint.SetBrush(NewCustomBrush(func(_, _ float64) RGBA { return Green }))
+		_, ok := solidColorFromPaint(paint)
+		if ok {
+			t.Error("expected ok=false for custom brush")
+		}
+	})
+
+	t.Run("custom pattern", func(t *testing.T) {
+		paint := &Paint{
+			Pattern: &testPattern{colorFn: func(_, _ float64) RGBA { return Green }},
+		}
+		_, ok := solidColorFromPaint(paint)
+		if ok {
+			t.Error("expected ok=false for custom pattern")
+		}
+	})
+}
+
+// colorDistance returns the squared Euclidean distance between two colors (RGB only).
+func colorDistance(a, b RGBA) float64 {
+	dr := a.R - b.R
+	dg := a.G - b.G
+	db := a.B - b.B
+	return dr*dr + dg*dg + db*db
+}


### PR DESCRIPTION
## Summary

Fixes #75 — Custom `Pattern` implementations always render black.

**Two root causes fixed:**

1. **Renderer bug**: `getColorFromPaint()` only handled `*SolidPattern` — returned Black for all custom patterns, gradients, checkerboards
2. **Sync bug**: `SetFillPattern()` set `paint.Pattern` but didn't update `paint.Brush` — broke `Paint.ColorAt()` precedence

**Solution: per-pixel paint sampling for non-solid paints**

- Solid paints → existing fast path (single color to rasterizer, no regression)
- Non-solid paints → new `painterPixmapAdapter` samples `paint.ColorAt(x,y)` per-pixel

### Changes

| File | Change |
|------|--------|
| `context_image.go` | `SetFillPattern`/`SetStrokePattern` now sync Brush |
| `painter.go` | NEW: `Painter` interface, `SolidPainter`, `FuncPainter`, `PainterFromPaint` |
| `software.go` | `painterPixmapAdapter`, `solidColorFromPaint`, updated all fill methods |
| `painter_test.go` | NEW: Painter unit tests (7 tests) |
| `pattern_render_test.go` | NEW: Integration tests — custom pattern, gradient, checkerboard (12 tests) |
| `CHANGELOG.md` | Added entry to Unreleased |

### Test plan

- [x] `TestCustomPatternFill` — reproduces the exact bug (custom pattern → non-black pixels)
- [x] `TestCustomBrushFill` — gradient fill produces color variation
- [x] `TestCheckerboardFill` — checkerboard produces alternating colors
- [x] `TestSolidFillStillWorks` — solid colors still use fast path
- [x] `TestSetFillPatternUpdatesBrush` / `TestSetStrokePatternUpdatesBrush` — sync fix
- [x] `TestGradientFillVariation` — vertical gradient variation
- [x] `TestSolidColorFromPaint` — solid/non-solid branching
- [x] `go test ./...` — all existing tests pass, 0 regressions
- [x] `golangci-lint run` — 0 issues
