### PR TITLE
feat(text): add GoTextShaper with HarfBuzz-level shaping (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **GoTextShaper: HarfBuzz-level text shaping** ([#78](https://github.com/gogpu/gg/issues/78))
+  - `GoTextShaper` wraps go-text/typesetting's HarfBuzz engine
+  - Supports ligatures, kerning, contextual alternates, complex scripts
+  - Opt-in via `text.SetShaper(text.NewGoTextShaper())`
+  - Thread-safe: `sync.Pool` for HarfBuzz shapers, cached `font.Font` (read-only)
+  - Fixed concurrency bug: `font.Face` and `HarfbuzzShaper` are not goroutine-safe
+  - Uses `font.Font` cache (thread-safe) + per-call `font.NewFace()` (lightweight)
+  - Uses deprecated `ClusterIndex` replaced with `TextIndex()`
+  - 20+ tests including concurrency, kerning, ligatures, cache management
+  - 3 benchmarks (short, standard, long text)
+
 - **WebP image format support** ([#77](https://github.com/gogpu/gg/issues/77))
   - `LoadWebP()`, `DecodeWebP()` for explicit WebP decoding
   - `LoadImage()` and `LoadImageFromBytes()` auto-detect WebP via registered decoder

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 |----------|--------------|
 | **Rendering** | Immediate and retained mode, GPU acceleration, CPU fallback |
 | **Shapes** | Rectangles, circles, ellipses, arcs, bezier curves, polygons, stars |
-| **Text** | TrueType fonts, MSDF rendering, emoji support, bidirectional text |
+| **Text** | TrueType fonts, MSDF rendering, emoji support, bidirectional text, HarfBuzz shaping |
 | **Compositing** | 29 blend modes (Porter-Duff, Advanced, HSL), layer isolation |
 | **Images** | 7 pixel formats, PNG/JPEG/WebP I/O, mipmaps, affine transforms |
 | **Vector Export** | Recording system with PDF and SVG backends |
@@ -224,7 +224,7 @@ renderer.Render(target, scene)
 
 ### Text Rendering
 
-Full Unicode support with font fallback:
+Full Unicode support with font fallback and optional HarfBuzz-level shaping:
 
 ```go
 // Font composition
@@ -240,6 +240,11 @@ multiFace, _ := text.NewMultiFace(
 
 dc.SetFont(multiFace)
 dc.DrawString("Hello World! Nice day!", 50, 100)
+
+// Optional: enable HarfBuzz shaping for ligatures, kerning, complex scripts
+shaper := text.NewGoTextShaper()
+text.SetShaper(shaper)
+defer text.SetShaper(nil)
 
 // Text layout with wrapping
 opts := text.LayoutOptions{

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,7 +191,9 @@ gg/
 │   └── raster/         # Built-in raster backend
 │
 ├── text/               # Text rendering
-│   ├── shaper.go       # Pluggable text shaping
+│   ├── shaper.go       # Pluggable shaper interface + global registry
+│   ├── shaper_builtin.go # Default shaper (x/image, basic LTR)
+│   ├── shaper_gotext.go  # HarfBuzz shaper (go-text/typesetting)
 │   ├── layout.go       # Multi-line layout engine
 │   ├── glyph_cache.go  # LRU glyph cache (16-shard)
 │   ├── glyph_run.go    # GlyphRunBuilder for batching

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gogpu/gg
 go 1.25
 
 require (
+	github.com/go-text/typesetting v0.3.3
 	github.com/go-webgpu/webgpu v0.2.1
 	github.com/gogpu/gpucontext v0.7.0
 	github.com/gogpu/gputypes v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
+github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4eaQc=
+github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
+github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
+github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
 github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM=
 github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.2.1 h1:i4kzvI4oq+ETsMRNbdIIz0eakoUes0yCIlUQgusulbI=
 github.com/go-webgpu/webgpu v0.2.1/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
-github.com/gogpu/gpucontext v0.6.0 h1:ZQdKGl7oLvtM9sPg6O/SJQaZs9D2jddAXNQWU0HcLnA=
-github.com/gogpu/gpucontext v0.6.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gpucontext v0.7.0 h1:6ev64ycEsrkHVeBzdaaiUW+K9eBH9WyL83WsXPPeCoA=
 github.com/gogpu/gpucontext v0.7.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=

--- a/text/README.md
+++ b/text/README.md
@@ -28,7 +28,8 @@ Bidi/Script  Cache    Lines    ┌────┴────┐
 ### Pluggable Shaper (v0.10.0)
 - **Shaper interface** — Converts text to positioned glyphs
 - **BuiltinShaper** — Default using golang.org/x/image
-- **Custom shapers** — Plug in go-text/typesetting or HarfBuzz
+- **GoTextShaper** — HarfBuzz-level shaping via go-text/typesetting (opt-in)
+- **Custom shapers** — Plug in any implementation via SetShaper()
 
 ### Bidi/Script Segmentation (v0.10.0)
 - **25+ Unicode scripts** — Latin, Arabic, Hebrew, Han, Cyrillic, Thai, etc.
@@ -148,10 +149,24 @@ for _, r := range results {
 width := text.MeasureText("Hello World", face, 16)
 ```
 
+### GoTextShaper (HarfBuzz-level shaping)
+
+```go
+// Enable HarfBuzz-level shaping for ligatures, kerning, and complex scripts
+shaper := text.NewGoTextShaper()
+text.SetShaper(shaper)
+defer text.SetShaper(nil) // Reset to BuiltinShaper
+
+// Shape text — now uses go-text/typesetting HarfBuzz engine
+glyphs := text.Shape("Hello", face, 24)
+```
+
+GoTextShaper is safe for concurrent use and caches parsed font data internally.
+
 ### Custom Shaper
 
 ```go
-// Implement custom shaper (e.g., go-text/typesetting)
+// Implement custom shaper
 type MyShaper struct {
     // ...
 }
@@ -212,6 +227,7 @@ type Line struct {
 
 - `golang.org/x/image/font/opentype` — TTF/OTF parsing
 - `golang.org/x/text/unicode/bidi` — Unicode Bidirectional Algorithm
+- `github.com/go-text/typesetting` — HarfBuzz shaping engine (used by GoTextShaper)
 
 ## Subpackages
 

--- a/text/shaper_gotext.go
+++ b/text/shaper_gotext.go
@@ -1,0 +1,242 @@
+package text
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/go-text/typesetting/di"
+	"github.com/go-text/typesetting/font"
+	"github.com/go-text/typesetting/language"
+	"github.com/go-text/typesetting/shaping"
+	"golang.org/x/image/math/fixed"
+)
+
+// GoTextShaper provides HarfBuzz-level text shaping using go-text/typesetting.
+// It supports advanced OpenType features including:
+//   - Ligature substitution (fi, fl, ffi, etc.)
+//   - Kerning pairs (AV, To, etc.)
+//   - Contextual alternates
+//   - Right-to-left text (Arabic, Hebrew)
+//   - Complex scripts (Devanagari, Thai, etc.)
+//
+// GoTextShaper is an opt-in replacement for BuiltinShaper. To use it:
+//
+//	shaper := text.NewGoTextShaper()
+//	text.SetShaper(shaper)
+//	defer text.SetShaper(nil) // Reset to default BuiltinShaper
+//
+// GoTextShaper is safe for concurrent use. It caches parsed font.Font objects
+// (which are thread-safe) and creates lightweight font.Face instances per
+// Shape() call (font.Face is NOT safe for concurrent use). The HarfbuzzShaper
+// instances are pooled via sync.Pool since they also are not concurrent-safe.
+type GoTextShaper struct {
+	// shaperPool pools HarfbuzzShaper instances for concurrent use.
+	// HarfbuzzShaper has internal mutable state (buffer) and is NOT safe
+	// for concurrent use, but reusing across sequential calls is efficient.
+	shaperPool sync.Pool
+
+	// mu protects the font cache.
+	mu sync.RWMutex
+
+	// fontCache maps FontSource pointers to parsed go-text Font objects.
+	// font.Font is read-only and safe for concurrent use, unlike font.Face.
+	// This avoids re-parsing the font data on every Shape() call.
+	fontCache map[*FontSource]*font.Font
+}
+
+// NewGoTextShaper creates a new GoTextShaper backed by go-text/typesetting's
+// HarfBuzz implementation.
+func NewGoTextShaper() *GoTextShaper {
+	return &GoTextShaper{
+		shaperPool: sync.Pool{
+			New: func() any {
+				return &shaping.HarfbuzzShaper{}
+			},
+		},
+		fontCache: make(map[*FontSource]*font.Font),
+	}
+}
+
+// Shape implements the Shaper interface.
+// It converts text into positioned glyphs using HarfBuzz shaping via go-text/typesetting.
+// This produces higher-quality output than BuiltinShaper for text that benefits
+// from kerning, ligatures, or complex script shaping.
+func (s *GoTextShaper) Shape(text string, face Face, size float64) []ShapedGlyph {
+	if text == "" || face == nil {
+		return nil
+	}
+
+	source := face.Source()
+	if source == nil {
+		return nil
+	}
+
+	// Get or create the cached go-text Font for this source.
+	goTextFont, err := s.getOrCreateFont(source)
+	if err != nil {
+		// Fall back: return nil on font parsing error.
+		// In production, users should validate their fonts upfront.
+		return nil
+	}
+
+	// Create a lightweight font.Face for this shaping call.
+	// font.Face is NOT safe for concurrent use, so each Shape() call
+	// gets its own instance. font.NewFace is cheap — it wraps the
+	// thread-safe *Font and initializes glyph caches.
+	goTextFace := font.NewFace(goTextFont)
+
+	runes := []rune(text)
+
+	// Convert our Direction to go-text's di.Direction.
+	dir := mapDirection(face.Direction())
+
+	// Detect script from the first non-space rune.
+	script := detectScript(runes)
+
+	// Build shaping input.
+	input := shaping.Input{
+		Text:      runes,
+		RunStart:  0,
+		RunEnd:    len(runes),
+		Direction: dir,
+		Face:      goTextFace,
+		Size:      floatToFixed(size),
+		Script:    script,
+		Language:  language.NewLanguage("en"),
+	}
+
+	// Get a HarfbuzzShaper from the pool (not concurrent-safe, so each
+	// goroutine needs its own instance).
+	hbShaper := s.shaperPool.Get().(*shaping.HarfbuzzShaper)
+	output := hbShaper.Shape(input)
+	s.shaperPool.Put(hbShaper)
+
+	// Convert go-text glyphs to our ShapedGlyph format.
+	return convertGlyphs(output.Glyphs, dir)
+}
+
+// getOrCreateFont returns a cached go-text font.Font for the given source,
+// or parses the font data and caches the Font (not Face).
+// font.Font is read-only and safe for concurrent use.
+func (s *GoTextShaper) getOrCreateFont(source *FontSource) (*font.Font, error) {
+	// Fast path: check cache with read lock.
+	s.mu.RLock()
+	if f, ok := s.fontCache[source]; ok {
+		s.mu.RUnlock()
+		return f, nil
+	}
+	s.mu.RUnlock()
+
+	// Slow path: parse font and update cache with write lock.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if f, ok := s.fontCache[source]; ok {
+		return f, nil
+	}
+
+	// Parse font data using go-text/typesetting.
+	// ParseTTF returns a *Face which embeds the thread-safe *Font.
+	reader := bytes.NewReader(source.data)
+	goTextFace, err := font.ParseTTF(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the Font (thread-safe), not the Face.
+	s.fontCache[source] = goTextFace.Font
+	return goTextFace.Font, nil
+}
+
+// ClearCache removes all cached parsed fonts.
+// Call this if you no longer need previously loaded fonts and want to free memory.
+func (s *GoTextShaper) ClearCache() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.fontCache = make(map[*FontSource]*font.Font)
+}
+
+// RemoveSource removes the cached parsed font for a specific FontSource.
+// This is useful when a FontSource is closed.
+func (s *GoTextShaper) RemoveSource(source *FontSource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.fontCache, source)
+}
+
+// mapDirection converts our text.Direction to go-text's di.Direction.
+func mapDirection(d Direction) di.Direction {
+	switch d {
+	case DirectionRTL:
+		return di.DirectionRTL
+	case DirectionTTB:
+		return di.DirectionTTB
+	case DirectionBTT:
+		return di.DirectionBTT
+	default:
+		return di.DirectionLTR
+	}
+}
+
+// detectScript inspects the runes and returns the script of the first
+// non-space character. This is a simple heuristic; for mixed-script text,
+// users should split runs by script before shaping.
+func detectScript(runes []rune) language.Script {
+	for _, r := range runes {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			continue
+		}
+		return language.LookupScript(r)
+	}
+	return language.Latin
+}
+
+// floatToFixed converts a float64 font size to fixed.Int26_6.
+// The fixed-point representation uses 6 fractional bits, so we multiply by 64.
+func floatToFixed(size float64) fixed.Int26_6 {
+	return fixed.Int26_6(size * 64)
+}
+
+// fixedToFloat converts a fixed.Int26_6 value to float64.
+func fixedToFloat(v fixed.Int26_6) float64 {
+	return float64(v) / 64.0
+}
+
+// convertGlyphs converts go-text/typesetting output glyphs to our ShapedGlyph slice.
+func convertGlyphs(glyphs []shaping.Glyph, dir di.Direction) []ShapedGlyph {
+	if len(glyphs) == 0 {
+		return nil
+	}
+
+	result := make([]ShapedGlyph, len(glyphs))
+
+	var x, y float64
+
+	for i, g := range glyphs {
+		// XOffset and YOffset represent fine-grained positioning adjustments
+		// applied on top of the current pen position.
+		xOff := fixedToFloat(g.XOffset)
+		yOff := fixedToFloat(g.YOffset)
+
+		result[i] = ShapedGlyph{
+			GID:     GlyphID(uint16(g.GlyphID)), //nolint:gosec // GlyphID is uint16 by design; overflow is handled by font subsetting
+			Cluster: g.TextIndex(),
+			X:       x + xOff,
+			Y:       y + yOff,
+		}
+
+		// Advance the pen position.
+		if dir.IsVertical() {
+			adv := fixedToFloat(g.Advance)
+			result[i].YAdvance = adv
+			y += adv
+		} else {
+			adv := fixedToFloat(g.Advance)
+			result[i].XAdvance = adv
+			x += adv
+		}
+	}
+
+	return result
+}

--- a/text/shaper_gotext_test.go
+++ b/text/shaper_gotext_test.go
@@ -1,0 +1,650 @@
+package text
+
+import (
+	"sync"
+	"testing"
+
+	"golang.org/x/image/font/gofont/goregular"
+)
+
+// goTextTestFace creates a test Face at size 16 for GoTextShaper tests.
+// Uses Go Regular font which has Latin, Cyrillic, and Greek glyphs,
+// including kerning tables.
+func goTextTestFace(t *testing.T) (Face, *FontSource) {
+	t.Helper()
+
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to create font source: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = source.Close()
+	})
+
+	face := source.Face(16.0)
+	return face, source
+}
+
+// TestGoTextShaper_BasicLatin tests shaping basic Latin text.
+// Verifies that glyphs are produced with non-zero advances and correct count.
+func TestGoTextShaper_BasicLatin(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	result := shaper.Shape("Hello", face, 16.0)
+	if len(result) != 5 {
+		t.Fatalf("Shape(\"Hello\"): got %d glyphs, want 5", len(result))
+	}
+
+	// Verify all glyphs have non-zero advances and increasing X positions.
+	var prevX float64
+	for i, g := range result {
+		if g.XAdvance <= 0 {
+			t.Errorf("glyph %d: XAdvance=%f, want > 0", i, g.XAdvance)
+		}
+		if i > 0 && g.X <= prevX {
+			t.Errorf("glyph %d: X=%f should be > previous X=%f", i, g.X, prevX)
+		}
+		prevX = g.X
+	}
+}
+
+// TestGoTextShaper_VariousText tests shaping various Latin strings.
+func TestGoTextShaper_VariousText(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	tests := []struct {
+		name    string
+		text    string
+		wantLen int
+	}{
+		{"single char", "A", 1},
+		{"word", "Hello", 5},
+		{"with space", "Hello World", 11},
+		{"numbers", "12345", 5},
+		{"punctuation", "Hello, World!", 13},
+		{"lowercase", "abcdefg", 7},
+		{"uppercase", "ABCDEFG", 7},
+		{"mixed", "Test123", 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shaper.Shape(tt.text, face, 16.0)
+			if len(result) != tt.wantLen {
+				t.Errorf("Shape(%q): got %d glyphs, want %d", tt.text, len(result), tt.wantLen)
+			}
+
+			// Verify all glyphs have positive advances.
+			for i, g := range result {
+				if g.XAdvance <= 0 {
+					t.Errorf("glyph %d in %q: XAdvance=%f, want > 0", i, tt.text, g.XAdvance)
+				}
+			}
+		})
+	}
+}
+
+// TestGoTextShaper_Kerning tests that GoTextShaper applies kerning.
+// The pair "AV" is a classic kerning pair where the V tucks under the A,
+// making the combined width less than the sum of individual widths.
+func TestGoTextShaper_Kerning(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	// Shape "A" and "V" separately to get individual advances.
+	glyphsA := shaper.Shape("A", face, 16.0)
+	glyphsV := shaper.Shape("V", face, 16.0)
+	if len(glyphsA) != 1 || len(glyphsV) != 1 {
+		t.Fatalf("expected 1 glyph each for A and V, got %d and %d",
+			len(glyphsA), len(glyphsV))
+	}
+
+	individualWidth := glyphsA[0].XAdvance + glyphsV[0].XAdvance
+
+	// Shape "AV" together -- kerning should tighten the pair.
+	glyphsAV := shaper.Shape("AV", face, 16.0)
+	if len(glyphsAV) != 2 {
+		t.Fatalf("Shape(\"AV\"): got %d glyphs, want 2", len(glyphsAV))
+	}
+
+	combinedWidth := glyphsAV[1].X + glyphsAV[1].XAdvance
+
+	// If the font has kerning for AV, combined should be less than individual.
+	// Go Regular has kerning tables, so this should hold.
+	// However, not all fonts guarantee AV kerning, so we log rather than fail hard.
+	if combinedWidth < individualWidth {
+		t.Logf("Kerning detected: AV combined=%.2f < individual=%.2f (diff=%.2f)",
+			combinedWidth, individualWidth, individualWidth-combinedWidth)
+	} else {
+		t.Logf("No kerning detected for AV pair in this font: combined=%.2f, individual=%.2f",
+			combinedWidth, individualWidth)
+	}
+
+	// At minimum, combined width should not exceed individual width + epsilon.
+	// This is a sanity check that the shaper is not producing wrong results.
+	if combinedWidth > individualWidth*1.1 {
+		t.Errorf("AV combined width %.2f is suspiciously larger than individual %.2f",
+			combinedWidth, individualWidth)
+	}
+}
+
+// TestGoTextShaper_Ligatures tests ligature substitution.
+// The "ffi" sequence in "office" may be substituted by a single ligature glyph
+// in fonts that support it. Go Regular may or may not have ligatures,
+// so we test the shaping does not break and report findings.
+func TestGoTextShaper_Ligatures(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	text := "office"
+	runes := []rune(text)
+	result := shaper.Shape(text, face, 16.0)
+
+	if len(result) == 0 {
+		t.Fatal("Shape(\"office\") returned no glyphs")
+	}
+
+	if len(result) < len(runes) {
+		t.Logf("Ligatures detected: %d glyphs for %d runes", len(result), len(runes))
+	} else if len(result) == len(runes) {
+		t.Logf("No ligatures: %d glyphs for %d runes (font may not have fi/ffi ligatures)", len(result), len(runes))
+	}
+
+	// Verify total advance is reasonable (positive and finite).
+	totalAdvance := result[len(result)-1].X + result[len(result)-1].XAdvance
+	if totalAdvance <= 0 {
+		t.Errorf("total advance = %f, want > 0", totalAdvance)
+	}
+}
+
+// TestGoTextShaper_EmptyText tests that empty text returns nil.
+func TestGoTextShaper_EmptyText(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	result := shaper.Shape("", face, 16.0)
+	if result != nil {
+		t.Errorf("Shape(\"\") = %v, want nil", result)
+	}
+}
+
+// TestGoTextShaper_NilFace tests that nil face returns nil.
+func TestGoTextShaper_NilFace(t *testing.T) {
+	shaper := NewGoTextShaper()
+
+	result := shaper.Shape("Hello", nil, 16.0)
+	if result != nil {
+		t.Errorf("Shape with nil face = %v, want nil", result)
+	}
+}
+
+// TestGoTextShaper_SetShaper tests GoTextShaper integration with the global shaper system.
+func TestGoTextShaper_SetShaper(t *testing.T) {
+	// Save original shaper.
+	original := GetShaper()
+	t.Cleanup(func() {
+		SetShaper(original)
+	})
+
+	face, _ := goTextTestFace(t)
+	goTextShaper := NewGoTextShaper()
+
+	// Set GoTextShaper as global.
+	SetShaper(goTextShaper)
+
+	current := GetShaper()
+	if _, ok := current.(*GoTextShaper); !ok {
+		t.Errorf("GetShaper() should return *GoTextShaper, got %T", current)
+	}
+
+	// Shape via the global Shape function.
+	result := Shape("Hello", face, 16.0)
+	if len(result) != 5 {
+		t.Errorf("Shape(\"Hello\") via global: got %d glyphs, want 5", len(result))
+	}
+
+	// Reset to nil should restore BuiltinShaper.
+	SetShaper(nil)
+	if _, ok := GetShaper().(*BuiltinShaper); !ok {
+		t.Errorf("SetShaper(nil) should restore BuiltinShaper, got %T", GetShaper())
+	}
+}
+
+// TestGoTextShaper_VsBuiltinShaper compares GoTextShaper output with BuiltinShaper.
+// Both should produce similar (but not identical) results for simple Latin text.
+// GoTextShaper may produce tighter or different layout due to kerning.
+func TestGoTextShaper_VsBuiltinShaper(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	goTextShaper := NewGoTextShaper()
+	builtinShaper := &BuiltinShaper{}
+
+	text := "Hello World"
+
+	goTextResult := goTextShaper.Shape(text, face, 16.0)
+	builtinResult := builtinShaper.Shape(text, face, 16.0)
+
+	// Both should produce the same number of glyphs for simple Latin.
+	if len(goTextResult) != len(builtinResult) {
+		t.Errorf("glyph count mismatch: GoText=%d, Builtin=%d",
+			len(goTextResult), len(builtinResult))
+		return
+	}
+
+	// Compare total advance widths.
+	goTextTotal := goTextResult[len(goTextResult)-1].X + goTextResult[len(goTextResult)-1].XAdvance
+	builtinTotal := builtinResult[len(builtinResult)-1].X + builtinResult[len(builtinResult)-1].XAdvance
+
+	t.Logf("Total advance: GoText=%.2f, Builtin=%.2f, diff=%.2f",
+		goTextTotal, builtinTotal, goTextTotal-builtinTotal)
+
+	// Both should produce positive total advance.
+	if goTextTotal <= 0 {
+		t.Errorf("GoText total advance = %f, want > 0", goTextTotal)
+	}
+	if builtinTotal <= 0 {
+		t.Errorf("Builtin total advance = %f, want > 0", builtinTotal)
+	}
+
+	// Glyph IDs should match (same font, same characters, no ligatures for Latin).
+	for i := range goTextResult {
+		if goTextResult[i].GID != builtinResult[i].GID {
+			t.Logf("glyph %d GID mismatch: GoText=%d, Builtin=%d (expected for ligatures/substitution)",
+				i, goTextResult[i].GID, builtinResult[i].GID)
+		}
+	}
+}
+
+// TestGoTextShaper_DifferentSizes tests shaping at various font sizes.
+// Larger sizes should produce larger total advances.
+func TestGoTextShaper_DifferentSizes(t *testing.T) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to create font source: %v", err)
+	}
+	defer func() {
+		_ = source.Close()
+	}()
+
+	shaper := NewGoTextShaper()
+	sizes := []float64{8, 12, 16, 24, 32, 48}
+	var prevTotalAdvance float64
+
+	for _, size := range sizes {
+		face := source.Face(size)
+		result := shaper.Shape("Hello", face, size)
+		if len(result) != 5 {
+			t.Errorf("size %f: got %d glyphs, want 5", size, len(result))
+			continue
+		}
+
+		totalAdvance := result[len(result)-1].X + result[len(result)-1].XAdvance
+		if size > 8 && totalAdvance <= prevTotalAdvance {
+			t.Errorf("size %f: total advance %f should be > previous %f",
+				size, totalAdvance, prevTotalAdvance)
+		}
+		prevTotalAdvance = totalAdvance
+	}
+}
+
+// TestGoTextShaper_Concurrency tests thread safety of GoTextShaper.
+// Multiple goroutines shape text concurrently using the same shaper instance.
+func TestGoTextShaper_Concurrency(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	var wg sync.WaitGroup
+	errors := make(chan string, 200)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				result := shaper.Shape("Hello World", face, 16.0)
+				if len(result) != 11 {
+					errors <- "wrong glyph count"
+				}
+				for _, g := range result {
+					if g.XAdvance <= 0 {
+						errors <- "zero advance"
+					}
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+
+	var errMsgs []string
+	for msg := range errors {
+		errMsgs = append(errMsgs, msg)
+	}
+	if len(errMsgs) > 0 {
+		t.Errorf("concurrent shaping had %d errors; first: %s", len(errMsgs), errMsgs[0])
+	}
+}
+
+// TestGoTextShaper_FaceCache tests the internal font face cache.
+func TestGoTextShaper_FaceCache(t *testing.T) {
+	_, source := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	face := source.Face(16.0)
+
+	// First call should parse the font and cache it.
+	result1 := shaper.Shape("A", face, 16.0)
+	if len(result1) != 1 {
+		t.Fatalf("first Shape(\"A\"): got %d glyphs, want 1", len(result1))
+	}
+
+	// Second call should use the cached font face.
+	result2 := shaper.Shape("A", face, 16.0)
+	if len(result2) != 1 {
+		t.Fatalf("second Shape(\"A\"): got %d glyphs, want 1", len(result2))
+	}
+
+	// Results should be identical.
+	if result1[0].GID != result2[0].GID {
+		t.Errorf("GID mismatch between cached calls: %d vs %d",
+			result1[0].GID, result2[0].GID)
+	}
+	if result1[0].XAdvance != result2[0].XAdvance {
+		t.Errorf("XAdvance mismatch between cached calls: %f vs %f",
+			result1[0].XAdvance, result2[0].XAdvance)
+	}
+}
+
+// TestGoTextShaper_ClearCache tests that ClearCache removes cached font faces.
+func TestGoTextShaper_ClearCache(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	// Populate cache.
+	_ = shaper.Shape("A", face, 16.0)
+
+	shaper.mu.RLock()
+	cacheLen := len(shaper.fontCache)
+	shaper.mu.RUnlock()
+	if cacheLen != 1 {
+		t.Errorf("cache should have 1 entry, got %d", cacheLen)
+	}
+
+	// Clear cache.
+	shaper.ClearCache()
+
+	shaper.mu.RLock()
+	cacheLen = len(shaper.fontCache)
+	shaper.mu.RUnlock()
+	if cacheLen != 0 {
+		t.Errorf("cache should be empty after ClearCache, got %d entries", cacheLen)
+	}
+
+	// Shaping should still work (re-parses font).
+	result := shaper.Shape("A", face, 16.0)
+	if len(result) != 1 {
+		t.Errorf("Shape after ClearCache: got %d glyphs, want 1", len(result))
+	}
+}
+
+// TestGoTextShaper_RemoveSource tests that RemoveSource removes a specific entry.
+func TestGoTextShaper_RemoveSource(t *testing.T) {
+	_, source := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	face := source.Face(16.0)
+
+	// Populate cache.
+	_ = shaper.Shape("A", face, 16.0)
+
+	shaper.mu.RLock()
+	cacheLen := len(shaper.fontCache)
+	shaper.mu.RUnlock()
+	if cacheLen != 1 {
+		t.Errorf("cache should have 1 entry, got %d", cacheLen)
+	}
+
+	// Remove the source.
+	shaper.RemoveSource(source)
+
+	shaper.mu.RLock()
+	cacheLen = len(shaper.fontCache)
+	shaper.mu.RUnlock()
+	if cacheLen != 0 {
+		t.Errorf("cache should be empty after RemoveSource, got %d entries", cacheLen)
+	}
+}
+
+// TestGoTextShaper_GlyphPositioning tests that glyph X positions are
+// correctly accumulated from advances.
+func TestGoTextShaper_GlyphPositioning(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	result := shaper.Shape("ABC", face, 16.0)
+	if len(result) < 3 {
+		t.Fatalf("Shape(\"ABC\"): got %d glyphs, want >= 3", len(result))
+	}
+
+	// First glyph should start at X=0 (possibly with offset).
+	if result[0].X < 0 {
+		t.Errorf("first glyph X=%f, want >= 0", result[0].X)
+	}
+
+	// Y should be 0 for horizontal text (no vertical offset unless kerning applies Y).
+	for i, g := range result {
+		if g.YAdvance != 0 {
+			t.Errorf("glyph %d: YAdvance=%f, want 0 for horizontal text", i, g.YAdvance)
+		}
+	}
+}
+
+// TestGoTextShaper_WhitespaceHandling tests shaping text with whitespace.
+func TestGoTextShaper_WhitespaceHandling(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	tests := []struct {
+		name    string
+		text    string
+		wantLen int
+	}{
+		{"single space", " ", 1},
+		{"tab", "\t", 1},
+		{"multiple spaces", "   ", 3},
+		{"word and space", "A B", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shaper.Shape(tt.text, face, 16.0)
+			if len(result) != tt.wantLen {
+				t.Errorf("Shape(%q): got %d glyphs, want %d", tt.text, len(result), tt.wantLen)
+			}
+		})
+	}
+}
+
+// TestGoTextShaper_ClusterIndices tests that cluster indices are populated.
+func TestGoTextShaper_ClusterIndices(t *testing.T) {
+	face, _ := goTextTestFace(t)
+	shaper := NewGoTextShaper()
+
+	result := shaper.Shape("Hello", face, 16.0)
+	if len(result) != 5 {
+		t.Fatalf("Shape(\"Hello\"): got %d glyphs, want 5", len(result))
+	}
+
+	// For simple Latin text without ligatures, cluster indices should map to rune indices.
+	for i, g := range result {
+		if g.Cluster != i {
+			t.Logf("glyph %d: Cluster=%d (may differ if font applies substitution)", i, g.Cluster)
+		}
+	}
+}
+
+// TestGoTextShaper_DetectScript tests the detectScript helper function.
+func TestGoTextShaper_DetectScript(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+	}{
+		{"Latin", "Hello"},
+		{"spaces then Latin", "  Hello"},
+		{"all spaces", "   "},
+		{"empty", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runes := []rune(tt.text)
+			// Just ensure it does not panic.
+			_ = detectScript(runes)
+		})
+	}
+}
+
+// TestGoTextShaper_MapDirection tests the mapDirection helper.
+func TestGoTextShaper_MapDirection(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  Direction
+	}{
+		{"LTR", DirectionLTR},
+		{"RTL", DirectionRTL},
+		{"TTB", DirectionTTB},
+		{"BTT", DirectionBTT},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Verify mapDirection does not panic and returns a valid value.
+			result := mapDirection(tt.dir)
+			_ = result
+		})
+	}
+}
+
+// TestGoTextShaper_FixedPointConversion tests float-to-fixed and back.
+func TestGoTextShaper_FixedPointConversion(t *testing.T) {
+	tests := []struct {
+		name  string
+		value float64
+	}{
+		{"zero", 0},
+		{"positive", 16.0},
+		{"small", 0.5},
+		{"large", 72.0},
+		{"fractional", 12.75},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixed := floatToFixed(tt.value)
+			back := fixedToFloat(fixed)
+
+			// Allow small rounding error due to fixed-point precision.
+			diff := back - tt.value
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > 0.02 {
+				t.Errorf("floatToFixed(%.4f) -> fixedToFloat = %.4f, diff=%.4f > 0.02",
+					tt.value, back, diff)
+			}
+		})
+	}
+}
+
+// TestGoTextShaper_ConvertGlyphsEmpty tests convertGlyphs with empty input.
+func TestGoTextShaper_ConvertGlyphsEmpty(t *testing.T) {
+	result := convertGlyphs(nil, 0)
+	if result != nil {
+		t.Errorf("convertGlyphs(nil) = %v, want nil", result)
+	}
+}
+
+// TestNewGoTextShaper tests constructor.
+func TestNewGoTextShaper(t *testing.T) {
+	shaper := NewGoTextShaper()
+	if shaper == nil {
+		t.Fatal("NewGoTextShaper() returned nil")
+	}
+	if shaper.fontCache == nil {
+		t.Error("faceCache should be initialized")
+	}
+}
+
+// BenchmarkGoTextShape benchmarks GoTextShaper with a standard sentence.
+func BenchmarkGoTextShape(b *testing.B) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		b.Fatalf("failed to create font source: %v", err)
+	}
+	defer func() {
+		_ = source.Close()
+	}()
+
+	face := source.Face(16.0)
+	shaper := NewGoTextShaper()
+
+	// Warm the cache.
+	_ = shaper.Shape("warmup", face, 16.0)
+
+	text := "The quick brown fox jumps over the lazy dog"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = shaper.Shape(text, face, 16.0)
+	}
+}
+
+// BenchmarkGoTextShapeShort benchmarks shaping a short string.
+func BenchmarkGoTextShapeShort(b *testing.B) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		b.Fatalf("failed to create font source: %v", err)
+	}
+	defer func() {
+		_ = source.Close()
+	}()
+
+	face := source.Face(16.0)
+	shaper := NewGoTextShaper()
+
+	// Warm the cache.
+	_ = shaper.Shape("w", face, 16.0)
+
+	text := "Hello"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = shaper.Shape(text, face, 16.0)
+	}
+}
+
+// BenchmarkGoTextShapeLong benchmarks shaping a long string.
+func BenchmarkGoTextShapeLong(b *testing.B) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		b.Fatalf("failed to create font source: %v", err)
+	}
+	defer func() {
+		_ = source.Close()
+	}()
+
+	face := source.Face(16.0)
+	shaper := NewGoTextShaper()
+
+	// Warm the cache.
+	_ = shaper.Shape("w", face, 16.0)
+
+	text := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = shaper.Shape(text, face, 16.0)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `GoTextShaper` — opt-in HarfBuzz-level text shaping via `go-text/typesetting`
- Supports ligatures (fi, fl, ffi), kerning (AV, To), contextual alternates, RTL, complex scripts
- Thread-safe: `sync.Pool` for HarfBuzz shapers, cached `font.Font` (read-only), per-call `font.NewFace()`
- 18 tests (concurrency, kerning, ligatures, cache management) + 3 benchmarks
- Updated README, CHANGELOG, ARCHITECTURE docs

### Usage

```go
shaper := text.NewGoTextShaper()
text.SetShaper(shaper)
defer text.SetShaper(nil)
```

Closes #78
