### PR TITLE
fix(examples): use relative output paths

### DIFF
--- a/examples/clipping/main.go
+++ b/examples/clipping/main.go
@@ -41,11 +41,11 @@ func main() {
 	example6ResetClip(dc)
 
 	// Save the result
-	err := dc.SavePNG("examples/clipping/output.png")
+	err := dc.SavePNG("output.png")
 	if err != nil {
 		log.Fatalf("Failed to save PNG: %v", err)
 	}
-	log.Println("Saved: examples/clipping/output.png")
+	log.Println("Saved: output.png")
 }
 
 // example1CircularClip demonstrates basic circular clipping.

--- a/examples/images/main.go
+++ b/examples/images/main.go
@@ -28,12 +28,12 @@ func main() {
 	drawExamples(dc, testImg)
 
 	// Save the result
-	if err := dc.SavePNG("examples/images/output.png"); err != nil {
+	if err := dc.SavePNG("output.png"); err != nil {
 		log.Fatalf("Failed to save image: %v", err)
 	}
 
 	fmt.Println("Image drawing example completed successfully!")
-	fmt.Println("Output saved to: examples/images/output.png")
+	fmt.Println("Output saved to: output.png")
 }
 
 // createTestImage creates a simple colorful test pattern.


### PR DESCRIPTION
## Summary

- Fix hardcoded output paths in `clipping` and `images` examples
- Both used `examples/*/output.png` which only worked from repo root
- Now use `output.png` — `go run .` works from example directory

## Test plan

- [x] `cd examples/images && go run .` — pass
- [x] `cd examples/clipping && go run .` — pass
- [x] All 13 gg examples verified locally
