### PR TITLE
chore(examples): update gogpu_integration to gg v0.24.1, gogpu v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Examples:** update `gogpu_integration` dependencies to gg v0.24.1, gogpu v0.15.5
+
 ### Planned for v1.0.0
 - API Review and cleanup
 - Comprehensive documentation

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.24.0
+	github.com/gogpu/gg v0.24.1
 	github.com/gogpu/gogpu v0.15.5
 )
 

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.2.1 h1:i4kzvI4oq+ETsMRNbdIIz0eakoUes0yCIlUQgusulb
 github.com/go-webgpu/webgpu v0.2.1/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
 github.com/gogpu/gg v0.24.0 h1:+0HHq78ygRQBHupQj7HKqhwPJKxrqbBw/Gyds77wSVI=
 github.com/gogpu/gg v0.24.0/go.mod h1:/Fl8q73HWE/ayy46lmhVOuvFjOdCikf+X4vPdWtNnNw=
+github.com/gogpu/gg v0.24.1 h1:75ciNmmpCW7coJ3dtU1PC7eqB/n4Chk6WtmZEbldeZQ=
+github.com/gogpu/gg v0.24.1/go.mod h1:/Fl8q73HWE/ayy46lmhVOuvFjOdCikf+X4vPdWtNnNw=
 github.com/gogpu/gogpu v0.15.4 h1:cSXJQEbEYJdFICrckk5E//ZO/j53F7k0GG3iSjJIomw=
 github.com/gogpu/gogpu v0.15.4/go.mod h1:uEKDGl+T+LO+Moqg36F33BB33cSqLTgGYSiAFOxWJro=
 github.com/gogpu/gogpu v0.15.5 h1:xa7RQdMhbZN/kkVTY990RIZbUqoOu8+RVyaW8FR4Lmc=


### PR DESCRIPTION
Update example dependencies to latest releases with premultiplied alpha fix.