### PR TITLE
chore(examples): update gogpu_integration to gg v0.26.1

### DIFF
--- a/examples/gogpu_integration/README.md
+++ b/examples/gogpu_integration/README.md
@@ -31,4 +31,4 @@ Resize the window to see automatic canvas reallocation.
 |------------|-----------------|
 | Go | 1.25+ |
 | gogpu | v0.15.7+ |
-| gg | v0.26.0+ |
+| gg | v0.26.1+ |

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.26.0
+	github.com/gogpu/gg v0.26.1
 	github.com/gogpu/gogpu v0.15.7
 )
 

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.2.1 h1:i4kzvI4oq+ETsMRNbdIIz0eakoUes0yCIlUQgusulb
 github.com/go-webgpu/webgpu v0.2.1/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
 github.com/gogpu/gg v0.26.0 h1:Xz1XLLYthO/sPvWhkX++uxMenIpB2AKn/2NzEVnupf4=
 github.com/gogpu/gg v0.26.0/go.mod h1:AKc7d4TXbYewUchFg+rp4YTr6xce8KD4P5K2mcVttoM=
+github.com/gogpu/gg v0.26.1 h1:e09ItVRqxAaszRdRxvMU3gh+a/5mLMxYYRrUuCHbvtw=
+github.com/gogpu/gg v0.26.1/go.mod h1:PCjIVMCn4icItjmWFktbfjeZLxrtecyBPyZONcqMaOU=
 github.com/gogpu/gogpu v0.15.6 h1:1keKtq3bJJJQ8jkhOCQujRxwXCgDse/6pHs4e2m+RmM=
 github.com/gogpu/gogpu v0.15.6/go.mod h1:QOIhKrY9nLNYcrPJux48Y2NR09FlQMeIgISv8W2/geI=
 github.com/gogpu/gogpu v0.15.7 h1:QuFXhEXGFCnibdUycxoacsFlSj3tnpzs7Zd7FNLcUjA=

--- a/examples/gogpu_integration/main.go
+++ b/examples/gogpu_integration/main.go
@@ -9,7 +9,7 @@
 //
 // Requirements:
 //   - gogpu v0.15.7+
-//   - gg v0.26.0+
+//   - gg v0.26.1+
 package main
 
 import (


### PR DESCRIPTION
Update example go.mod to gg v0.26.1, README and main.go minimum version references.