### PR TITLE
fix: flush GPU accelerator before text drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] - 2026-02-10
+
+### Fixed
+
+- **Text rendering over GPU shapes** — `DrawString` and `DrawStringAnchored` now flush pending GPU accelerator batch before drawing text, preventing GPU-rendered shapes (e.g., rounded rect backgrounds) from overwriting previously drawn text
+
 ## [0.27.0] - 2026-02-10
 
 ### Added

--- a/text.go
+++ b/text.go
@@ -31,6 +31,8 @@ func (c *Context) DrawString(s string, x, y float64) {
 	if c.face == nil {
 		return
 	}
+	// Flush pending GPU shapes so they don't overwrite text.
+	c.flushGPUAccelerator()
 	text.Draw(c.pixmap, s, c.face, x, y, c.currentColor())
 }
 
@@ -54,7 +56,8 @@ func (c *Context) DrawStringAnchored(s string, x, y, ax, ay float64) {
 	x -= w * ax
 	y += h * ay // Note: y is baseline, so we adjust upward for top alignment
 
-	// Draw the text
+	// Flush pending GPU shapes so they don't overwrite text.
+	c.flushGPUAccelerator()
 	text.Draw(c.pixmap, s, c.face, x, y, c.currentColor())
 }
 


### PR DESCRIPTION
## Summary

- Flush pending GPU accelerator batch before drawing text in `DrawString` and `DrawStringAnchored`
- Prevents GPU-rendered shapes (e.g., rounded rect backgrounds) from overwriting previously drawn text pixels

## Root cause

`DrawString`/`DrawStringAnchored` draw text directly to the pixmap via `text.Draw()`, bypassing `Fill()`/`Stroke()`. The SDF accelerator batches shapes and flushes them later — after text was already drawn — overwriting text pixels.

## Test plan

- [x] Verified fix with `ui/examples/hello` — all text renders correctly over GPU-drawn backgrounds
- [ ] CI green
