### PR TITLE
chore(examples): update gg dependency to v0.28.1

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.28.0
+	github.com/gogpu/gg v0.28.1
 	github.com/gogpu/gogpu v0.18.1
 	github.com/gogpu/gpucontext v0.9.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM
 github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.3.0 h1:cAZb/FoZzflGCxBJV7Ub8GYkVGgJ1ul3IBDqqRb9RQQ=
 github.com/go-webgpu/webgpu v0.3.0/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
-github.com/gogpu/gg v0.28.0 h1:rkETpCHoS4ZQhLeabeH4+wgLqebQR1K8518/wt4u76g=
-github.com/gogpu/gg v0.28.0/go.mod h1:xxwovyZnwS2OgfFpngSzANmEdEcLw3dhrY7BD3OFcdQ=
+github.com/gogpu/gg v0.28.1 h1:sEcbXXnnAAzOASgcWmTFpVfyZrYjC/pVSlh2D4fxMCY=
+github.com/gogpu/gg v0.28.1/go.mod h1:xxwovyZnwS2OgfFpngSzANmEdEcLw3dhrY7BD3OFcdQ=
 github.com/gogpu/gogpu v0.18.1 h1:Zq0lXyLzSpOgNSzk7/7LUPzioBRU3nd4nnKHDvSrKE0=
 github.com/gogpu/gogpu v0.18.1/go.mod h1:n7/QStq8dV/oIeginWztbJlytTezS/N5bda6FGIQguU=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=


### PR DESCRIPTION
Update gogpu_integration example to use gg v0.28.1 (just released).