### PR TITLE
chore: update examples to gg v0.28.3

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.28.2
+	github.com/gogpu/gg v0.28.3
 	github.com/gogpu/gogpu v0.19.0
 	github.com/gogpu/gpucontext v0.9.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM
 github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.3.0 h1:cAZb/FoZzflGCxBJV7Ub8GYkVGgJ1ul3IBDqqRb9RQQ=
 github.com/go-webgpu/webgpu v0.3.0/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
-github.com/gogpu/gg v0.28.2 h1:D7F3Z3uiBt9ro6bw1vlA0uRMpJSM/5JDaTWBgamrO18=
-github.com/gogpu/gg v0.28.2/go.mod h1:yGWPguAwY5fFQr2OpC31l8mGxyCB8bbaW9kpVFUhQfw=
+github.com/gogpu/gg v0.28.3 h1:sqai71bqWzDUs0VwnUjmVJ8WuEE51Y4bGLK/VpUdimE=
+github.com/gogpu/gg v0.28.3/go.mod h1:mbKps2Hz1pB/uw9qSmndjP5TihI0KZVvyv67p6gZ9sU=
 github.com/gogpu/gogpu v0.19.0 h1:7d7PIWnB+y7YPD8igs1OGYNflUqH8G6eaaft5SjLWoo=
 github.com/gogpu/gogpu v0.19.0/go.mod h1:cr/WQF20MytLdoSC2SBzqkrLS5tWn/HcUJ5ZRinKujc=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25
 
-require github.com/gogpu/gg v0.28.2
+require github.com/gogpu/gg v0.28.3
 
 require (
 	github.com/go-text/typesetting v0.3.3 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4
 github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.28.2 h1:D7F3Z3uiBt9ro6bw1vlA0uRMpJSM/5JDaTWBgamrO18=
-github.com/gogpu/gg v0.28.2/go.mod h1:yGWPguAwY5fFQr2OpC31l8mGxyCB8bbaW9kpVFUhQfw=
+github.com/gogpu/gg v0.28.3 h1:sqai71bqWzDUs0VwnUjmVJ8WuEE51Y4bGLK/VpUdimE=
+github.com/gogpu/gg v0.28.3/go.mod h1:mbKps2Hz1pB/uw9qSmndjP5TihI0KZVvyv67p6gZ9sU=
 golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
 golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=


### PR DESCRIPTION
Update example dependencies to latest released versions:
- sdf: gg v0.28.2 → v0.28.3
- gogpu_integration: gg v0.28.2 → v0.28.3