### PR TITLE
chore: update examples to gg v0.28.6

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.28.5
+	github.com/gogpu/gg v0.28.6
 	github.com/gogpu/gogpu v0.19.4
 	github.com/gogpu/gpucontext v0.9.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.3.0 h1:cAZb/FoZzflGCxBJV7Ub8GYkVGgJ1ul3IBDqqRb9RQQ=
 github.com/go-webgpu/webgpu v0.3.0/go.mod h1:2cooaik+rR8u7u8g0WBZvFga+nfhMpddRdTOkq/goA8=
-github.com/gogpu/gg v0.28.5 h1:5FiiPfwV4VM2OQNgKKatQbWPFW7Ku8jhSYC7Hsgj5Q8=
-github.com/gogpu/gg v0.28.5/go.mod h1:CqGayi9gYvq6KjkDH8B5UU8apKlC9xe9CyCqCNTKltg=
+github.com/gogpu/gg v0.28.6 h1:z34mpgddHCN6X6LozLZ9DnMtqithBBwzOq4OKjSvfYI=
+github.com/gogpu/gg v0.28.6/go.mod h1:Yh7zRd/SNKC+CxLS1SImbZOnn+WC/TUTTNK2Rs4ejxQ=
 github.com/gogpu/gogpu v0.19.4 h1:BhMfIMqbUBF2oFYRdxhrdFtrB86SZ7oIKh9dzxtjE40=
 github.com/gogpu/gogpu v0.19.4/go.mod h1:7VJqv0/6H3bf81h5z2MBRh+JgFc7VXmOkqyAvoxlpkM=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25
 
-require github.com/gogpu/gg v0.28.5
+require github.com/gogpu/gg v0.28.6
 
 require (
 	github.com/go-text/typesetting v0.3.3 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4
 github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.28.5 h1:5FiiPfwV4VM2OQNgKKatQbWPFW7Ku8jhSYC7Hsgj5Q8=
-github.com/gogpu/gg v0.28.5/go.mod h1:CqGayi9gYvq6KjkDH8B5UU8apKlC9xe9CyCqCNTKltg=
+github.com/gogpu/gg v0.28.6 h1:z34mpgddHCN6X6LozLZ9DnMtqithBBwzOq4OKjSvfYI=
+github.com/gogpu/gg v0.28.6/go.mod h1:Yh7zRd/SNKC+CxLS1SImbZOnn+WC/TUTTNK2Rs4ejxQ=
 golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
 golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=


### PR DESCRIPTION
## Summary

- Update sdf example: gg v0.28.5 → v0.28.6
- Update gogpu_integration example: gg v0.28.5 → v0.28.6

## Test plan

- [x] `go build ./...` — passes
- [x] `golangci-lint run` — 0 issues