### PR TITLE
chore: update examples to gg v0.29.2

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.29.0
+	github.com/gogpu/gg v0.29.2
 	github.com/gogpu/gogpu v0.20.2
 	github.com/gogpu/gpucontext v0.9.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.3.1 h1:GxaJ3Cz2FGzHZ3adAYvuRFTdCMcwrENLbuilyIxSH0o=
 github.com/go-webgpu/webgpu v0.3.1/go.mod h1:lPa1+DhNDB3jb97/KI2ivW+ewK1V9x4k58fObvWBhR4=
-github.com/gogpu/gg v0.29.0 h1:XrjJxeF5dH5NTK+Bshr5yhlaIhP1VDmKsz3dvbBBsAY=
-github.com/gogpu/gg v0.29.0/go.mod h1:RmLDMiVgaH+Yfui+fIL9x0lrzJHEesEodnnr+UntSOs=
+github.com/gogpu/gg v0.29.2 h1:2+j9tNN9duZCcLQb9EBq7CdeIFVKDWCIE2503rN9eBg=
+github.com/gogpu/gg v0.29.2/go.mod h1:mc7AMO5Aoz/lubmOlnf7EJO8uRA5H/hjZMW3Y9zVUKo=
 github.com/gogpu/gogpu v0.20.2 h1:OZmOxwr57kvf5HRoT2pNsVT6bdZkpMYZS1u1zB977wo=
 github.com/gogpu/gogpu v0.20.2/go.mod h1:hIHEAPNvzgvdCCQscxAJU8cF3aqMkyJTiv6PmNOe70Y=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25
 
-require github.com/gogpu/gg v0.29.1
+require github.com/gogpu/gg v0.29.2
 
 require (
 	github.com/go-text/typesetting v0.3.3 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4
 github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.29.1 h1:qs9N6it2qPNe67pDsZIIjBKTKaQ+Lshi5HRINdaMII0=
-github.com/gogpu/gg v0.29.1/go.mod h1:fidY0tvQKsNqA3b9HE8+K1kbjSXaLbGB6qVpuLwf5Z4=
+github.com/gogpu/gg v0.29.2 h1:2+j9tNN9duZCcLQb9EBq7CdeIFVKDWCIE2503rN9eBg=
+github.com/gogpu/gg v0.29.2/go.mod h1:mc7AMO5Aoz/lubmOlnf7EJO8uRA5H/hjZMW3Y9zVUKo=
 golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
 golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=


### PR DESCRIPTION
Update examples to use gg v0.29.2 (wgpu v0.16.11 Vulkan fix).