### PR TITLE
chore: update examples to gg v0.29.3

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.29.2
+	github.com/gogpu/gg v0.29.3
 	github.com/gogpu/gogpu v0.20.3
 	github.com/gogpu/gpucontext v0.9.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.3.1 h1:GxaJ3Cz2FGzHZ3adAYvuRFTdCMcwrENLbuilyIxSH0o=
 github.com/go-webgpu/webgpu v0.3.1/go.mod h1:lPa1+DhNDB3jb97/KI2ivW+ewK1V9x4k58fObvWBhR4=
-github.com/gogpu/gg v0.29.2 h1:2+j9tNN9duZCcLQb9EBq7CdeIFVKDWCIE2503rN9eBg=
-github.com/gogpu/gg v0.29.2/go.mod h1:mc7AMO5Aoz/lubmOlnf7EJO8uRA5H/hjZMW3Y9zVUKo=
+github.com/gogpu/gg v0.29.3 h1:i25wjxl6SnUOKkKs5K/69ulmIcLCPOx+rabaxWOCa6s=
+github.com/gogpu/gg v0.29.3/go.mod h1:saGMVwuWcqce1D7lnkeDYHEaZ8/7dVTXsh1X3qFqrfw=
 github.com/gogpu/gogpu v0.20.3 h1:7RRQEeDrkXKkqaBIMROBa65HHbTuh4vZ3wigDJ8FE44=
 github.com/gogpu/gogpu v0.20.3/go.mod h1:c11IvfQz18xu22VY6S5n89jNT27ocNfY0duCBmorE4w=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25
 
-require github.com/gogpu/gg v0.29.2
+require github.com/gogpu/gg v0.29.3
 
 require (
 	github.com/go-text/typesetting v0.3.3 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4
 github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.29.2 h1:2+j9tNN9duZCcLQb9EBq7CdeIFVKDWCIE2503rN9eBg=
-github.com/gogpu/gg v0.29.2/go.mod h1:mc7AMO5Aoz/lubmOlnf7EJO8uRA5H/hjZMW3Y9zVUKo=
+github.com/gogpu/gg v0.29.3 h1:i25wjxl6SnUOKkKs5K/69ulmIcLCPOx+rabaxWOCa6s=
+github.com/gogpu/gg v0.29.3/go.mod h1:saGMVwuWcqce1D7lnkeDYHEaZ8/7dVTXsh1X3qFqrfw=
 golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
 golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=


### PR DESCRIPTION
- sdf: gg v0.29.2 → v0.29.3
- gogpu_integration: gg v0.29.2 → v0.29.3