### PR TITLE
chore: update examples to gg v0.29.5

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.29.3
+	github.com/gogpu/gg v0.29.5
 	github.com/gogpu/gogpu v0.20.4
 	github.com/gogpu/gpucontext v0.9.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.3.1 h1:GxaJ3Cz2FGzHZ3adAYvuRFTdCMcwrENLbuilyIxSH0o=
 github.com/go-webgpu/webgpu v0.3.1/go.mod h1:lPa1+DhNDB3jb97/KI2ivW+ewK1V9x4k58fObvWBhR4=
-github.com/gogpu/gg v0.29.3 h1:i25wjxl6SnUOKkKs5K/69ulmIcLCPOx+rabaxWOCa6s=
-github.com/gogpu/gg v0.29.3/go.mod h1:saGMVwuWcqce1D7lnkeDYHEaZ8/7dVTXsh1X3qFqrfw=
+github.com/gogpu/gg v0.29.5 h1:0H7IdvT0FsssT8NCSh+1uL1O4wC34zD49f+A/81CFso=
+github.com/gogpu/gg v0.29.5/go.mod h1:Ht8UplINvrkaK2WDXL/gHJrCUp9wqVdpwsl8n1aA3d8=
 github.com/gogpu/gogpu v0.20.4 h1:tZKFXOqPMfcWaMPnF93CjYSAv93UEw+4pH1CIqm6x3o=
 github.com/gogpu/gogpu v0.20.4/go.mod h1:v1m5pAiJa2vHahPvvLI2H0u3mr2iis7jqmE8iA0g0+8=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=


### PR DESCRIPTION
Update gogpu_integration example to gg v0.29.5