### PR TITLE
feat: smart multi-engine rasterizer selection (v0.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.0] - 2026-02-28
+
+### Added
+
+- **Smart rasterizer selection** — Multi-factor auto-selection of rasterization
+  algorithm per-path. Adaptive threshold formula `max(32, 2048/sqrt(bboxArea))`
+  considers path complexity and bounding box area. BBox precheck: paths < 32px
+  always use scanline. Five algorithms: AnalyticFiller (scanline), SparseStrips
+  (4×4 tiles), TileCompute (16×16 tiles), SDFAccelerator (per-pixel SDF),
+  Vello PTCL (GPU compute).
+- **`CoverageFiller` interface** — Tile-based coverage rasterizer interface with
+  `RegisterCoverageFiller()` / `GetCoverageFiller()` registration pattern
+  (mirrors `GPUAccelerator`). `ForceableFiller` extension interface exposes
+  `SparseFiller()` / `ComputeFiller()` for forced algorithm selection.
+- **`AdaptiveFiller`** — Auto-selects between SparseStrips (4×4) and TileCompute
+  (16×16) based on estimated segment count (10K threshold) and canvas area (2MP).
+- **`RasterizerMode` API** — Per-context force override: `RasterizerAuto`,
+  `RasterizerAnalytic`, `RasterizerSparseStrips`, `RasterizerTileCompute`,
+  `RasterizerSDF`. Use `Context.SetRasterizerMode()` for debugging, benchmarking,
+  or known workloads.
+- **`ForceSDFAware` interface** — Optional GPU accelerator interface for forced
+  SDF rendering. `SetForceSDF(true)` bypasses the 16px minimum size check.
+- **`gg/raster/` package** — CPU-only tile rasterizer registration via blank
+  import `import _ "github.com/gogpu/gg/raster"`. Independent of GPU packages.
+- **SDF minimum size** — Shapes smaller than 16px skip SDF rendering (unless
+  `RasterizerSDF` mode is forced) to avoid overhead on tiny shapes.
+
 ## [0.31.1] - 2026-02-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 | **Compositing** | 29 blend modes (Porter-Duff, Advanced, HSL), layer isolation |
 | **Images** | 7 pixel formats, PNG/JPEG/WebP I/O, mipmaps, affine transforms |
 | **Vector Export** | Recording system with PDF and SVG backends |
+| **Rasterizer** | Smart per-path algorithm selection (scanline, 4×4 tiles, 16×16 tiles, SDF, compute) |
 | **Performance** | Tile-based parallel rendering, LRU caching |
 
 ---
@@ -181,9 +182,11 @@ dc := gg.NewContext(800, 600, gg.WithPixmap(pm))
 | Component | Location | Description |
 |-----------|----------|-------------|
 | **CPU Raster** | `internal/raster` | Core analytic AA rasterizer (Vello-based) |
+| **Tile Rasterizers** | `internal/gpu` | SparseStrips (4×4) + TileCompute (16×16) with adaptive selection |
 | **GPU Accelerator** | `internal/gpu` | Five-tier GPU pipeline (SDF, Convex, Stencil+Cover, MSDF Text, Compute) |
-| **GPU Registration** | `gpu/` | Public opt-in via `import _ "github.com/gogpu/gg/gpu"` |
-| **Software** | Root `gg` package | Default CPU renderer |
+| **GPU + Tiles** | `gpu/` | Opt-in via `import _ "github.com/gogpu/gg/gpu"` (GPU + tile rasterizers) |
+| **Tiles Only** | `raster/` | Opt-in via `import _ "github.com/gogpu/gg/raster"` (CPU-only tiles) |
+| **Software** | Root `gg` package | Default CPU renderer with smart algorithm selection |
 
 ---
 

--- a/accelerator.go
+++ b/accelerator.go
@@ -250,6 +250,14 @@ type PipelineModeAware interface {
 	SetPipelineMode(mode PipelineMode)
 }
 
+// ForceSDFAware is an optional interface for GPU accelerators that support
+// forced SDF rendering. When enabled, the accelerator bypasses the minimum
+// size check for SDF shapes, allowing RasterizerSDF mode to force SDF
+// rendering regardless of shape size.
+type ForceSDFAware interface {
+	SetForceSDF(force bool)
+}
+
 // SceneStatsTracker is an optional interface for accelerators that track
 // per-frame scene statistics for auto pipeline selection. The Context
 // does not call these methods directly — the accelerator uses them internally.

--- a/coverage_filler.go
+++ b/coverage_filler.go
@@ -1,0 +1,49 @@
+package gg
+
+import "sync"
+
+// CoverageFiller is a tile-based coverage rasterizer for complex paths.
+//
+// When registered via RegisterCoverageFiller, the SoftwareRenderer auto-selects
+// it for paths above a complexity threshold (coverageFillerThreshold elements).
+// For simpler paths, the AnalyticFiller (scanline) is used directly.
+//
+// The callback receives per-pixel coverage values (0-255) that the caller
+// composites onto the target pixmap using source-over blending.
+//
+// Implementations:
+//   - SparseStripsFiller (4x4 tiles, CPU/SIMD-optimized) — default
+//   - TileComputeFiller (16x16 tiles, GPU workgroup-ready) — alternative
+type CoverageFiller interface {
+	// FillCoverage rasterizes the path and calls callback for each pixel
+	// with non-zero coverage. The coverage value is 0-255 (anti-aliased alpha).
+	FillCoverage(path *Path, width, height int, fillRule FillRule,
+		callback func(x, y int, coverage uint8))
+}
+
+var (
+	coverageMu     sync.RWMutex
+	coverageFiller CoverageFiller
+)
+
+// RegisterCoverageFiller registers a tile-based coverage filler for complex paths.
+//
+// Only one filler can be registered. Subsequent calls replace the previous one.
+// Typical usage via blank import in the gpu package:
+//
+//	func init() {
+//	    gg.RegisterCoverageFiller(&gpuimpl.SparseStripsFiller{})
+//	}
+func RegisterCoverageFiller(f CoverageFiller) {
+	coverageMu.Lock()
+	coverageFiller = f
+	coverageMu.Unlock()
+}
+
+// GetCoverageFiller returns the registered CoverageFiller, or nil if none.
+func GetCoverageFiller() CoverageFiller {
+	coverageMu.RLock()
+	f := coverageFiller
+	coverageMu.RUnlock()
+	return f
+}

--- a/coverage_filler.go
+++ b/coverage_filler.go
@@ -47,3 +47,15 @@ func GetCoverageFiller() CoverageFiller {
 	coverageMu.RUnlock()
 	return f
 }
+
+// ForceableFiller is an optional interface for CoverageFillers that support
+// forced algorithm selection. When the user sets RasterizerSparseStrips or
+// RasterizerTileCompute mode, the renderer uses SparseFiller() or ComputeFiller()
+// instead of the adaptive auto-selection.
+type ForceableFiller interface {
+	CoverageFiller
+	// SparseFiller returns the SparseStrips (4x4 tiles) filler component.
+	SparseFiller() CoverageFiller
+	// ComputeFiller returns the TileCompute (16x16 tiles) filler component.
+	ComputeFiller() CoverageFiller
+}

--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -1,17 +1,22 @@
 //go:build !nogpu
 
-// Package gpu registers the GPU accelerator for hardware-accelerated rendering.
+// Package gpu registers the GPU accelerator and coverage filler for
+// hardware-accelerated rendering.
 //
-// Import this package to enable GPU-based rendering. The GPU accelerator uses
-// wgpu/hal compute shaders for parallel evaluation, providing hardware-accelerated
-// anti-aliased rendering for shapes like circles and rounded rectangles.
+// Import this package to enable both GPU-based shape rendering (SDF for circles,
+// rounded rectangles) and adaptive tile-based rasterization for complex paths.
+// The GPU accelerator uses wgpu/hal compute shaders for parallel evaluation.
 //
 // If GPU initialization fails (no Vulkan/Metal/DX12 available), the
 // registration is silently skipped and rendering falls back to CPU.
 //
+// For tile-based rasterization only (no GPU shapes), use:
+//
+//	import _ "github.com/gogpu/gg/raster"
+//
 // Usage:
 //
-//	import _ "github.com/gogpu/gg/gpu" // enable GPU acceleration
+//	import _ "github.com/gogpu/gg/gpu" // enable GPU acceleration + tile rasterization
 package gpu
 
 import (
@@ -26,9 +31,10 @@ func init() {
 		gg.Logger().Warn("GPU accelerator not available", "err", err)
 	}
 
-	// Coverage filler: SparseStrips (4x4 tiles, SIMD-optimized for CPU)
-	// Alternative: &gpuimpl.TileComputeFiller{} (16x16 tiles, GPU workgroup-optimized)
-	gg.RegisterCoverageFiller(&gpuimpl.SparseStripsFiller{})
+	// Coverage filler: AdaptiveFiller auto-selects between SparseStrips (4x4
+	// tiles, SIMD-optimized) and TileCompute (16x16 tiles) based on path
+	// complexity and canvas size.
+	gg.RegisterCoverageFiller(&gpuimpl.AdaptiveFiller{})
 }
 
 // SetDeviceProvider configures the GPU accelerator to use a shared GPU device

--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -20,10 +20,15 @@ import (
 )
 
 func init() {
+	// GPU accelerator (SDF shapes: circles, rounded rects)
 	accel := &gpuimpl.SDFAccelerator{}
 	if err := gg.RegisterAccelerator(accel); err != nil {
 		gg.Logger().Warn("GPU accelerator not available", "err", err)
 	}
+
+	// Coverage filler: SparseStrips (4x4 tiles, SIMD-optimized for CPU)
+	// Alternative: &gpuimpl.TileComputeFiller{} (16x16 tiles, GPU workgroup-optimized)
+	gg.RegisterCoverageFiller(&gpuimpl.SparseStripsFiller{})
 }
 
 // SetDeviceProvider configures the GPU accelerator to use a shared GPU device

--- a/internal/gpu/adaptive_filler.go
+++ b/internal/gpu/adaptive_filler.go
@@ -1,0 +1,64 @@
+//go:build !nogpu
+
+package gpu
+
+import "github.com/gogpu/gg"
+
+const (
+	// extremeSegmentThreshold is the estimated segment count above which
+	// TileCompute (16x16) is preferred over SparseStrips (4x4).
+	// At 10K+ segments, hashmap pressure for 4x4 tiles becomes significant
+	// because the number of active tiles grows quadratically with path complexity,
+	// while 16x16 tiles reduce tile count by 16x.
+	extremeSegmentThreshold = 10000
+
+	// largeBBoxThreshold is the bounding box area (px^2) above which
+	// TileCompute is considered. Approximately 1920x1080 = 2 megapixels.
+	// Below this, 4x4 tiles provide better cache locality and lower overhead.
+	largeBBoxThreshold = 2_000_000
+
+	// segmentMultiplier estimates flattened segments from path elements.
+	// Average: 1x for lines, ~4x for quadratics, ~8x for cubics.
+	// Typical mixed paths average ~3x after curve flattening.
+	segmentMultiplier = 3
+)
+
+// AdaptiveFiller selects between SparseStrips (4x4) and TileCompute (16x16)
+// based on path complexity and canvas size.
+//
+// For most paths, SparseStrips is faster due to smaller tile granularity and
+// SIMD-friendly 4x4 layout. TileCompute becomes advantageous for extremely
+// complex paths (10K+ segments) on large canvases, where 16x16 tiles reduce
+// the overhead of tile management and backdrop propagation.
+type AdaptiveFiller struct {
+	sparse  SparseStripsFiller
+	compute TileComputeFiller
+}
+
+// SparseFiller returns the SparseStrips (4x4 tiles) filler component.
+func (f *AdaptiveFiller) SparseFiller() gg.CoverageFiller {
+	return &f.sparse
+}
+
+// ComputeFiller returns the TileCompute (16x16 tiles) filler component.
+func (f *AdaptiveFiller) ComputeFiller() gg.CoverageFiller {
+	return &f.compute
+}
+
+// FillCoverage rasterizes the path using the appropriate tile-based filler.
+// It estimates segment count from path element count and selects TileCompute
+// only for very complex paths on large canvases.
+func (f *AdaptiveFiller) FillCoverage(
+	path *gg.Path, width, height int, fillRule gg.FillRule,
+	callback func(x, y int, coverage uint8),
+) {
+	elements := len(path.Elements())
+	estimatedSegments := elements * segmentMultiplier
+	canvasArea := width * height
+
+	if estimatedSegments > extremeSegmentThreshold && canvasArea > largeBBoxThreshold {
+		f.compute.FillCoverage(path, width, height, fillRule, callback)
+		return
+	}
+	f.sparse.FillCoverage(path, width, height, fillRule, callback)
+}

--- a/internal/gpu/sdf_gpu.go
+++ b/internal/gpu/sdf_gpu.go
@@ -87,9 +87,16 @@ var _ gg.SurfaceTargetAware = (*SDFAccelerator)(nil)
 var _ gg.GPUTextAccelerator = (*SDFAccelerator)(nil)
 var _ gg.PipelineModeAware = (*SDFAccelerator)(nil)
 var _ gg.ComputePipelineAware = (*SDFAccelerator)(nil)
+var _ gg.ForceSDFAware = (*SDFAccelerator)(nil)
 
 // Name returns the accelerator identifier.
 func (a *SDFAccelerator) Name() string { return "sdf-gpu" }
+
+// SetForceSDF propagates the force-SDF flag to the CPU fallback accelerator.
+// When enabled, the CPU fallback skips the minimum size check for SDF shapes.
+func (a *SDFAccelerator) SetForceSDF(force bool) {
+	a.cpuFallback.SetForceSDF(force)
+}
 
 // CanAccelerate reports whether this accelerator supports the given operation.
 func (a *SDFAccelerator) CanAccelerate(op gg.AcceleratedOp) bool {

--- a/internal/gpu/sparse_strips_filler.go
+++ b/internal/gpu/sparse_strips_filler.go
@@ -1,0 +1,97 @@
+//go:build !nogpu
+
+package gpu
+
+import (
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/scene"
+)
+
+// SparseStripsFiller implements gg.CoverageFiller using the SparseStrips
+// rasterizer (4x4 tiles). This is the default filler, optimized for CPU
+// with SIMD-friendly tile sizes.
+type SparseStripsFiller struct{}
+
+// FillCoverage rasterizes the path using SparseStrips and calls callback
+// for each pixel with non-zero coverage.
+func (f *SparseStripsFiller) FillCoverage(
+	path *gg.Path, width, height int, fillRule gg.FillRule,
+	callback func(x, y int, coverage uint8),
+) {
+	if path == nil || len(path.Elements()) == 0 {
+		return
+	}
+
+	// 1. Convert gg.Path → scene.Path
+	scenePath := convertGGToScenePath(path)
+	if scenePath.IsEmpty() {
+		return
+	}
+
+	// 2. Get SparseStripsRasterizer from pool
+	config := DefaultConfig(uint16(width), uint16(height)) //nolint:gosec // width/height bounded by viewport
+	config.FillRule = convertToSceneFillRule(fillRule)
+	ssr := globalSparseStripsPool.Get(config)
+	defer globalSparseStripsPool.Put(ssr)
+
+	// 3. Rasterize
+	ssr.RasterizePath(scenePath, scene.IdentityAffine(), FlattenTolerance)
+
+	// 4. Walk TileGrid → callback
+	grid := ssr.Grid()
+	grid.ForEach(func(tile *Tile) {
+		baseX := int(tile.PixelX())
+		baseY := int(tile.PixelY())
+		for py := 0; py < TileSize; py++ {
+			y := baseY + py
+			if y < 0 || y >= height {
+				continue
+			}
+			for px := 0; px < TileSize; px++ {
+				x := baseX + px
+				if x < 0 || x >= width {
+					continue
+				}
+				c := tile.GetCoverage(px, py)
+				if c > 0 {
+					callback(x, y, c)
+				}
+			}
+		}
+	})
+}
+
+// convertGGToScenePath converts a gg.Path (float64) to a scene.Path (float32).
+func convertGGToScenePath(p *gg.Path) *scene.Path {
+	sp := scene.NewPath()
+	for _, elem := range p.Elements() {
+		switch e := elem.(type) {
+		case gg.MoveTo:
+			sp.MoveTo(float32(e.Point.X), float32(e.Point.Y))
+		case gg.LineTo:
+			sp.LineTo(float32(e.Point.X), float32(e.Point.Y))
+		case gg.QuadTo:
+			sp.QuadTo(
+				float32(e.Control.X), float32(e.Control.Y),
+				float32(e.Point.X), float32(e.Point.Y),
+			)
+		case gg.CubicTo:
+			sp.CubicTo(
+				float32(e.Control1.X), float32(e.Control1.Y),
+				float32(e.Control2.X), float32(e.Control2.Y),
+				float32(e.Point.X), float32(e.Point.Y),
+			)
+		case gg.Close:
+			sp.Close()
+		}
+	}
+	return sp
+}
+
+// convertToSceneFillRule converts gg.FillRule to scene.FillStyle.
+func convertToSceneFillRule(rule gg.FillRule) scene.FillStyle {
+	if rule == gg.FillRuleEvenOdd {
+		return scene.FillEvenOdd
+	}
+	return scene.FillNonZero
+}

--- a/internal/gpu/tilecompute_filler.go
+++ b/internal/gpu/tilecompute_filler.go
@@ -1,0 +1,93 @@
+//go:build !nogpu
+
+package gpu
+
+import (
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/internal/gpu/tilecompute"
+	"github.com/gogpu/gg/scene"
+)
+
+// TileComputeFiller implements gg.CoverageFiller using the tilecompute
+// rasterizer (16x16 tiles). This is an alternative filler optimized for
+// GPU workgroup-sized tiles.
+type TileComputeFiller struct{}
+
+// FillCoverage rasterizes the path using tilecompute and calls callback
+// for each pixel with non-zero coverage.
+func (f *TileComputeFiller) FillCoverage(
+	path *gg.Path, width, height int, fillRule gg.FillRule,
+	callback func(x, y int, coverage uint8),
+) {
+	if path == nil || len(path.Elements()) == 0 {
+		return
+	}
+
+	// 1. Convert gg.Path → scene.Path → flatten → LineSoup
+	scenePath := convertGGToScenePath(path)
+	if scenePath.IsEmpty() {
+		return
+	}
+
+	flatCtx := NewFlattenContext()
+	flatCtx.FlattenPathTo(scenePath, scene.IdentityAffine(), FlattenTolerance)
+	segs := flatCtx.Segments()
+	if segs.Len() == 0 {
+		return
+	}
+
+	lines := segmentsToLineSoup(segs)
+	if len(lines) == 0 {
+		return
+	}
+
+	// 2. Convert fill rule
+	tcFillRule := tilecompute.FillRuleNonZero
+	if fillRule == gg.FillRuleEvenOdd {
+		tcFillRule = tilecompute.FillRuleEvenOdd
+	}
+
+	// 3. Rasterize with tilecompute (16x16 tiles)
+	rast := tilecompute.NewRasterizer(width, height)
+	alphas := rast.Rasterize(lines, tcFillRule)
+
+	// 4. Convert float32 alphas → uint8 → callback
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			a := alphas[y*width+x]
+			if a > 0 {
+				c := uint8(a*255 + 0.5) //nolint:gosec // Intentional float-to-uint8 with rounding
+				if c > 0 {
+					callback(x, y, c)
+				}
+			}
+		}
+	}
+}
+
+// segmentsToLineSoup converts SparseStrips SegmentList to tilecompute LineSoup.
+// LineSegments store monotonic segments (Y0 <= Y1) with a Winding field.
+// LineSoup expects original (unsorted) direction — we restore it using Winding.
+func segmentsToLineSoup(segs *SegmentList) []tilecompute.LineSoup {
+	lines := make([]tilecompute.LineSoup, 0, segs.Len())
+
+	for _, seg := range segs.Segments() {
+		var p0, p1 [2]float32
+		if seg.Winding < 0 {
+			// Original direction was upward — swap back to restore direction
+			p0 = [2]float32{seg.X1, seg.Y1}
+			p1 = [2]float32{seg.X0, seg.Y0}
+		} else {
+			// Original direction was downward — keep as is
+			p0 = [2]float32{seg.X0, seg.Y0}
+			p1 = [2]float32{seg.X1, seg.Y1}
+		}
+		lines = append(lines, tilecompute.LineSoup{
+			PathIx: 0,
+			P0:     p0,
+			P1:     p1,
+		})
+	}
+
+	return lines
+}

--- a/raster/raster.go
+++ b/raster/raster.go
@@ -1,0 +1,25 @@
+//go:build !nogpu
+
+// Package raster registers the CPU tile-based coverage filler for complex paths.
+//
+// Import this package to enable adaptive tile rasterization (4x4 or 16x16 tiles)
+// for paths above the complexity threshold, without requiring GPU acceleration.
+// The filler auto-selects SparseStrips (4x4 tiles) for typical paths and
+// TileCompute (16x16 tiles) for extremely complex paths on large canvases.
+//
+// If GPU acceleration is also needed, use import _ "github.com/gogpu/gg/gpu"
+// instead, which registers both the GPU accelerator and the coverage filler.
+//
+// Usage:
+//
+//	import _ "github.com/gogpu/gg/raster" // enable CPU tile rasterization
+package raster
+
+import (
+	"github.com/gogpu/gg"
+	gpuimpl "github.com/gogpu/gg/internal/gpu"
+)
+
+func init() {
+	gg.RegisterCoverageFiller(&gpuimpl.AdaptiveFiller{})
+}

--- a/rasterizer_mode.go
+++ b/rasterizer_mode.go
@@ -1,0 +1,66 @@
+package gg
+
+// RasterizerMode controls which rasterization algorithm is used for path rendering.
+//
+// The default is RasterizerAuto, which uses intelligent multi-factor auto-selection
+// based on path complexity, bounding box area, and shape type. Force modes bypass
+// auto-selection and always use a specific algorithm.
+//
+// The mode is per-Context, not global. Different contexts can use different strategies.
+//
+// Use cases for force modes:
+//   - Debugging: force AnalyticFiller to isolate tile rasterizer bugs
+//   - Benchmarking: compare algorithms on the same workload
+//   - Known workload: user knows their data better than heuristics
+//   - Quality control: force SDF for maximum circle/rrect quality
+//   - Regression testing: ensure each algorithm produces correct output
+type RasterizerMode int
+
+const (
+	// RasterizerAuto uses intelligent multi-factor auto-selection (default).
+	// It considers path complexity, bounding box area, shape type, and registered
+	// fillers to choose the optimal algorithm per-path.
+	RasterizerAuto RasterizerMode = iota
+
+	// RasterizerAnalytic forces the AnalyticFiller (scanline) for all paths.
+	// This bypasses CoverageFiller entirely, even for complex paths.
+	// Best for: debugging, simple UIs, guaranteed minimal overhead.
+	RasterizerAnalytic
+
+	// RasterizerSparseStrips forces SparseStrips (4x4 tiles) for all paths.
+	// Bypasses the adaptive threshold and always uses SparseStrips regardless
+	// of path complexity.
+	// Requires a CoverageFiller with ForceableFiller support to be registered.
+	// Best for: CPU-optimized rendering, SIMD-friendly workloads.
+	RasterizerSparseStrips
+
+	// RasterizerTileCompute forces TileCompute (16x16 tiles) for all paths.
+	// Bypasses the adaptive threshold and always uses TileCompute regardless
+	// of path complexity.
+	// Requires a CoverageFiller with ForceableFiller support to be registered.
+	// Best for: GPU workgroup-ready workloads, extreme complexity.
+	RasterizerTileCompute
+
+	// RasterizerSDF forces SDF rendering for detected shapes, bypassing the
+	// minimum size check. Non-SDF shapes fall back to auto-selection.
+	// Best for: maximum visual quality on geometric shapes (circles, rrects).
+	RasterizerSDF
+)
+
+// String returns the rasterizer mode name.
+func (m RasterizerMode) String() string {
+	switch m {
+	case RasterizerAuto:
+		return "Auto"
+	case RasterizerAnalytic:
+		return "Analytic"
+	case RasterizerSparseStrips:
+		return "SparseStrips"
+	case RasterizerTileCompute:
+		return "TileCompute"
+	case RasterizerSDF:
+		return "SDF"
+	default:
+		return "Unknown"
+	}
+}


### PR DESCRIPTION
## Summary

Smart multi-engine rasterizer selection with 5 algorithms and per-path auto-selection.

### New Features
- **CoverageFiller interface** — tile-based coverage rasterizer with registration pattern (mirrors GPUAccelerator)
- **SparseStripsFiller** (4×4 tiles) + **TileComputeFiller** (16×16 tiles) — connected to rendering pipeline
- **AdaptiveFiller** — auto-selects between 4×4 and 16×16 based on segment count (10K) and canvas area (2MP)
- **Adaptive threshold** — `max(32, 2048/sqrt(bboxArea))` per-path selection between scanline and tile rasterizers
- **SDF minimum size** — shapes < 16px skip SDF (avoid overhead on tiny shapes)
- **RasterizerMode API** — per-context force override: Auto/Analytic/SparseStrips/TileCompute/SDF
- **ForceableFiller** + **ForceSDFAware** interfaces for forced algorithm selection
- **`gg/raster/` package** — CPU-only tile rasterizer registration (no GPU dependencies)

### Documentation
- CHANGELOG.md v0.32.0 entry
- ARCHITECTURE.md — smart rasterizer selection section with flow diagrams
- README.md — rasterizer feature row, updated rendering structure table

### Selection Flow
```
Context.Fill()
  → Shape detection → SDF Accelerator (circles, rrects)
  → Adaptive threshold → Scanline (below) or AdaptiveFiller (above)
       → < 10K segments → SparseStrips (4×4)
       → > 10K segments → TileCompute (16×16)
  → GPU Compute → Vello PTCL (full scene)
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — all 32 packages pass
- [x] `golangci-lint run` — 0 issues (with GOWORK=off)
- [x] `GOOS=linux GOARCH=amd64 go build ./...` — cross-compile passes
- [x] `examples/gogpu_integration` runs correctly with Vulkan backend
