### PR TITLE
feat: image clipping + anti-aliased clip masks (v0.33.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-03-03
+
+### Added
+
+- **DrawImage respects clip stack** — `DrawImageEx` refactored to route through the
+  `Fill()` pipeline (image-as-shader pattern). Images now correctly clip to any path
+  set via `Clip()`, `ClipRect()`, or nested `Push`/`Pop` clips. This follows the
+  enterprise pattern used by Skia, Cairo, tiny-skia, and Vello.
+  ([#155](https://github.com/gogpu/gg/issues/155))
+- **`DrawImageRounded(img, x, y, radius)`** — convenience method for drawing images
+  with rounded corners
+- **`DrawImageCircular(img, cx, cy, radius)`** — convenience method for drawing
+  circular avatar-style images
+- **`ImagePattern.SetAnchor(x, y)`** — position image patterns at arbitrary canvas
+  coordinates instead of tiling from origin (0,0)
+- **`ImagePattern.SetScale(sx, sy)`** — scale image patterns
+- **`ImagePattern.SetOpacity(opacity)`** — opacity multiplier for image patterns
+- **`ImagePattern.SetClamp(bool)`** — clamp mode: out-of-bounds returns transparent
+  instead of tiling
+- **Fill() and Stroke() respect clip stack** — all software rendering paths (analytic
+  filler + coverage filler) now apply clip masks via `Paint.ClipCoverage`
+
 ## [0.32.5] - 2026-03-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of tiling
 - **Fill() and Stroke() respect clip stack** — all software rendering paths (analytic
   filler + coverage filler) now apply clip masks via `Paint.ClipCoverage`
+- **Anti-aliased clip masks** — path-based clips now use 4x Y-supersampling with
+  fractional X-edge coverage for smooth clip edges (previously binary 0/255 only)
 
 ## [0.32.5] - 2026-03-02
 

--- a/context.go
+++ b/context.go
@@ -902,6 +902,11 @@ func (c *Context) doFill() error {
 		sr.rasterizerMode = cpuMode
 		defer func() { sr.rasterizerMode = RasterizerAuto }()
 	}
+
+	// Set clip coverage function on paint so the renderer can apply clipping.
+	c.applyClipToPaint()
+	defer func() { c.paint.ClipCoverage = nil }()
+
 	return c.renderer.Fill(c.pixmap, c.path, c.paint)
 }
 
@@ -934,7 +939,25 @@ func (c *Context) doStroke() error {
 		sr.rasterizerMode = cpuMode
 		defer func() { sr.rasterizerMode = RasterizerAuto }()
 	}
+
+	// Set clip coverage function on paint so the renderer can apply clipping.
+	c.applyClipToPaint()
+	defer func() { c.paint.ClipCoverage = nil }()
+
 	return c.renderer.Stroke(c.pixmap, c.path, c.paint)
+}
+
+// applyClipToPaint sets the ClipCoverage function on the paint when a clip
+// stack is active and has entries. This allows the renderer to apply per-pixel
+// clip masks during compositing.
+func (c *Context) applyClipToPaint() {
+	if c.clipStack == nil || c.clipStack.Depth() == 0 {
+		return
+	}
+	cs := c.clipStack
+	c.paint.ClipCoverage = func(x, y float64) byte {
+		return cs.Coverage(x, y)
+	}
 }
 
 // setForceSDF enables/disables forced SDF on the registered accelerator.

--- a/context_image.go
+++ b/context_image.go
@@ -127,6 +127,9 @@ func (c *Context) DrawImage(img *ImageBuf, x, y float64) {
 
 // DrawImageEx draws an image with advanced options.
 // The current transformation matrix is applied to the position and size.
+// The image is drawn through the Fill() pipeline, which means it respects
+// the current clip region. This follows the enterprise pattern used by
+// Skia, Cairo, tiny-skia, and Vello: image drawing = fillRect + image shader.
 //
 // Example:
 //
@@ -150,79 +153,62 @@ func (c *Context) DrawImageEx(img *ImageBuf, opts DrawImageOptions) {
 
 	// Get source dimensions
 	srcWidth, srcHeight := img.Bounds()
-	var srcRect intImage.Rect
+	srcX, srcY := 0, 0
+	srcW, srcH := srcWidth, srcHeight
 	if opts.SrcRect != nil {
-		srcRect = intImage.Rect{
-			X:      opts.SrcRect.Min.X,
-			Y:      opts.SrcRect.Min.Y,
-			Width:  opts.SrcRect.Dx(),
-			Height: opts.SrcRect.Dy(),
-		}
-	} else {
-		srcRect = intImage.Rect{
-			X:      0,
-			Y:      0,
-			Width:  srcWidth,
-			Height: srcHeight,
-		}
+		srcX = opts.SrcRect.Min.X
+		srcY = opts.SrcRect.Min.Y
+		srcW = opts.SrcRect.Dx()
+		srcH = opts.SrcRect.Dy()
 	}
 
-	// Determine destination size
+	// Determine destination size in user coordinates (before transform).
 	dstWidth := opts.DstWidth
 	dstHeight := opts.DstHeight
 	if dstWidth == 0 {
-		dstWidth = float64(srcRect.Width)
+		dstWidth = float64(srcW)
 	}
 	if dstHeight == 0 {
-		dstHeight = float64(srcRect.Height)
+		dstHeight = float64(srcH)
 	}
 
-	// Transform destination rectangle corners
+	// Compute scale factors for the image pattern.
+	// The pattern maps source pixels to destination pixels.
+	scaleX := dstWidth / float64(srcW)
+	scaleY := dstHeight / float64(srcH)
+
+	// Transform destination rectangle to device coordinates for the anchor.
 	topLeft := c.matrix.TransformPoint(Pt(opts.X, opts.Y))
-	bottomRight := c.matrix.TransformPoint(Pt(opts.X+dstWidth, opts.Y+dstHeight))
 
-	// Calculate transformed destination rectangle
-	dstX := int(topLeft.X)
-	dstY := int(topLeft.Y)
-	dstW := int(bottomRight.X - topLeft.X)
-	dstH := int(bottomRight.Y - topLeft.Y)
-
-	// Create destination rectangle
-	dstRect := intImage.Rect{
-		X:      dstX,
-		Y:      dstY,
-		Width:  dstW,
-		Height: dstH,
+	// Create image pattern anchored at the destination position.
+	pattern := &ImagePattern{
+		image:   img,
+		x:       srcX,
+		y:       srcY,
+		w:       srcW,
+		h:       srcH,
+		anchorX: topLeft.X,
+		anchorY: topLeft.Y,
+		opacity: opts.Opacity,
+		clamp:   true, // Don't tile — clamp to image bounds
+		scaleX:  scaleX,
+		scaleY:  scaleY,
 	}
 
-	// Convert Pixmap to ImageBuf for drawing
-	// This is a zero-copy operation - ImageBuf wraps the pixmap's data
-	dstImg := c.pixmapToImageBuf(c.pixmap)
+	// Save current state (paint, path, transform).
+	c.Push()
 
-	// Compute a scaling transform that maps dst rect coordinates to src rect
-	// coordinates. Without this, DrawImage uses identity (1:1 pixel mapping)
-	// which clips the source when dst is larger than src.
-	var transform *intImage.Affine
-	if dstW > 0 && dstH > 0 && srcRect.Width > 0 && srcRect.Height > 0 {
-		scaleX := float64(dstW) / float64(srcRect.Width)
-		scaleY := float64(dstH) / float64(srcRect.Height)
-		t := intImage.Scale(scaleX, scaleY)
-		transform = &t
-	}
+	// Set image pattern as fill source.
+	c.SetFillPattern(pattern)
 
-	// Prepare draw parameters
-	params := intImage.DrawParams{
-		SrcRect:   &srcRect,
-		DstRect:   dstRect,
-		Transform: transform,
-		Interp:    opts.Interpolation,
-		Opacity:   opts.Opacity,
-		BlendMode: opts.BlendMode,
-	}
+	// Draw rectangle at destination using the current transform.
+	// DrawRectangle applies the transform, which is what we want.
+	c.DrawRectangle(opts.X, opts.Y, dstWidth, dstHeight)
 
-	// Draw the image directly into the pixmap via the ImageBuf wrapper
-	intImage.DrawImage(dstImg, img, params)
-	// No need to copy back - ImageBuf shares the pixmap's underlying data
+	// Fill the rectangle — the Fill() pipeline handles clipping automatically.
+	_ = c.Fill()
+
+	c.Pop()
 }
 
 // CreateImagePattern creates an image pattern from a rectangular region of an image.
@@ -260,19 +246,71 @@ func (c *Context) SetStrokePattern(pattern Pattern) {
 }
 
 // ImagePattern represents an image-based pattern.
+// When anchorX/anchorY are set, the pattern is positioned at that canvas
+// location instead of tiling from (0,0). Coordinates outside the image region
+// return transparent black (clamp mode) when clamp is true.
 type ImagePattern struct {
-	image *ImageBuf
-	x, y  int
-	w, h  int
+	image   *ImageBuf
+	x, y    int     // source region offset within the image
+	w, h    int     // source region size (0 = full image dimension)
+	anchorX float64 // canvas anchor X
+	anchorY float64 // canvas anchor Y
+	opacity float64 // opacity multiplier (0=transparent, 1=opaque; 0 means default=1)
+	clamp   bool    // when true, out-of-bounds returns transparent instead of tiling
+	scaleX  float64 // horizontal scale factor (0 means 1.0)
+	scaleY  float64 // vertical scale factor (0 means 1.0)
+}
+
+// SetAnchor sets the canvas position where the pattern is anchored.
+// This offsets all coordinate lookups so the image appears at (x, y)
+// on the canvas rather than tiled from the origin.
+func (p *ImagePattern) SetAnchor(x, y float64) {
+	p.anchorX = x
+	p.anchorY = y
+}
+
+// SetOpacity sets the opacity multiplier for the pattern (0.0 to 1.0).
+func (p *ImagePattern) SetOpacity(opacity float64) {
+	p.opacity = opacity
+}
+
+// SetClamp enables clamp mode. When true, coordinates outside the image region
+// return transparent black instead of tiling/wrapping.
+func (p *ImagePattern) SetClamp(clamp bool) {
+	p.clamp = clamp
+}
+
+// SetScale sets the scale factors for the pattern. The source image is scaled
+// by these factors before being sampled. For example, SetScale(2, 2) makes
+// each source pixel cover 2x2 destination pixels.
+func (p *ImagePattern) SetScale(sx, sy float64) {
+	p.scaleX = sx
+	p.scaleY = sy
 }
 
 // ColorAt implements the Pattern interface.
-// It samples the image at the given coordinates using wrapping/tiling behavior.
+// It samples the image at the given coordinates. If an anchor is set,
+// coordinates are offset by the anchor position. In clamp mode, out-of-bounds
+// coordinates return transparent black; otherwise the pattern tiles.
 func (p *ImagePattern) ColorAt(x, y float64) RGBA {
+	// Subtract anchor to get local coordinates relative to the image origin.
+	lx := x - p.anchorX
+	ly := y - p.anchorY
+
+	// Apply inverse scale (map destination coords to source coords).
+	sx := p.scaleX
+	sy := p.scaleY
+	if sx != 0 {
+		lx /= sx
+	}
+	if sy != 0 {
+		ly /= sy
+	}
+
 	// Get image bounds
 	imgW, imgH := p.image.Bounds()
 
-	// If pattern region is specified, use it
+	// Determine pattern region.
 	patternW := p.w
 	patternH := p.h
 	if patternW == 0 {
@@ -282,9 +320,31 @@ func (p *ImagePattern) ColorAt(x, y float64) RGBA {
 		patternH = imgH
 	}
 
-	// Wrap coordinates to pattern region (tiling)
-	px := int(x) % patternW
-	py := int(y) % patternH
+	if p.clamp {
+		// Clamp mode: out-of-bounds returns transparent.
+		ix := int(lx)
+		iy := int(ly)
+		if ix < 0 || ix >= patternW || iy < 0 || iy >= patternH {
+			return RGBA{}
+		}
+		ix += p.x
+		iy += p.y
+		r, g, b, a := p.image.GetRGBA(ix, iy)
+		col := RGBA{
+			R: float64(r) / 255.0,
+			G: float64(g) / 255.0,
+			B: float64(b) / 255.0,
+			A: float64(a) / 255.0,
+		}
+		if p.opacity > 0 && p.opacity < 1.0 {
+			col.A *= p.opacity
+		}
+		return col
+	}
+
+	// Wrap coordinates to pattern region (tiling).
+	px := int(lx) % patternW
+	py := int(ly) % patternH
 	if px < 0 {
 		px += patternW
 	}
@@ -292,18 +352,65 @@ func (p *ImagePattern) ColorAt(x, y float64) RGBA {
 		py += patternH
 	}
 
-	// Add pattern offset
+	// Add source region offset.
 	px += p.x
 	py += p.y
 
-	// Sample the image
+	// Sample the image.
 	r, g, b, a := p.image.GetRGBA(px, py)
-	return RGBA{
+	col := RGBA{
 		R: float64(r) / 255.0,
 		G: float64(g) / 255.0,
 		B: float64(b) / 255.0,
 		A: float64(a) / 255.0,
 	}
+	if p.opacity > 0 && p.opacity < 1.0 {
+		col.A *= p.opacity
+	}
+	return col
+}
+
+// DrawImageRounded draws an image at (x, y) clipped to a rounded rectangle.
+// The image is drawn at its natural size, clipped by a rounded rectangle with
+// the given corner radius. This is a convenience method equivalent to:
+//
+//	dc.Push()
+//	dc.DrawRoundedRectangle(x, y, w, h, radius)
+//	dc.Clip()
+//	dc.DrawImage(img, x, y)
+//	dc.Pop()
+func (c *Context) DrawImageRounded(img *ImageBuf, x, y, radius float64) {
+	w, h := img.Bounds()
+	fw := float64(w)
+	fh := float64(h)
+
+	c.Push()
+	c.DrawRoundedRectangle(x, y, fw, fh, radius)
+	c.Clip()
+	c.DrawImage(img, x, y)
+	c.Pop()
+}
+
+// DrawImageCircular draws an image at the specified center, clipped to a circle.
+// The image is drawn centered at (cx, cy) and clipped by a circle with the given
+// radius. The image is scaled to fit within the circle's bounding box.
+func (c *Context) DrawImageCircular(img *ImageBuf, cx, cy, radius float64) {
+	c.Push()
+	c.DrawCircle(cx, cy, radius)
+	c.Clip()
+
+	// Draw image centered, scaled to fit the circle diameter.
+	diameter := radius * 2
+	c.DrawImageEx(img, DrawImageOptions{
+		X:         cx - radius,
+		Y:         cy - radius,
+		DstWidth:  diameter,
+		DstHeight: diameter,
+		Opacity:   1.0,
+		BlendMode: BlendNormal,
+	})
+
+	c.Pop()
 }
 
 // pixmapToImageBuf converts a Pixmap to an ImageBuf.

--- a/context_image_test.go
+++ b/context_image_test.go
@@ -444,3 +444,399 @@ func TestBlendModes(t *testing.T) {
 		})
 	}
 }
+
+// TestDrawImageClipped_RoundedRect verifies that DrawImage respects a
+// rounded rectangle clip region.
+func TestDrawImageClipped_RoundedRect(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Clear()
+
+	// Create a red 100x100 image.
+	img := makeTestImage(t, 100, 100, 255, 0, 0, 255)
+
+	dc.Push()
+
+	// Set a rounded rectangle clip in the center.
+	dc.DrawRoundedRectangle(50, 50, 100, 100, 15)
+	dc.Clip()
+
+	// Draw image at (50, 50) — exactly covering the clip region.
+	dc.DrawImage(img, 50, 50)
+
+	dc.Pop()
+
+	// Pixel inside the clip (center of the rounded rect) should be red.
+	inside := dc.pixmap.GetPixel(100, 100)
+	if inside.R < 0.8 {
+		t.Errorf("Expected red inside clip, got R=%.2f G=%.2f B=%.2f", inside.R, inside.G, inside.B)
+	}
+
+	// Pixel at the corner (50, 50) should be clipped away by the rounded corner.
+	// The corner radius is 15px, so (50, 50) is in the clipped corner area.
+	corner := dc.pixmap.GetPixel(51, 51)
+	if corner.R > 0.5 {
+		t.Errorf("Expected clipped corner at (51, 51), got R=%.2f (should be low due to rounded clip)", corner.R)
+	}
+
+	// Pixel outside the clip entirely should be transparent/background.
+	outside := dc.pixmap.GetPixel(10, 10)
+	if outside.R > 0.1 {
+		t.Errorf("Expected no image outside clip, got R=%.2f", outside.R)
+	}
+}
+
+// TestDrawImageClipped_Circle verifies that DrawImage respects a circular
+// clip region.
+func TestDrawImageClipped_Circle(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Clear()
+
+	// Create a green 200x200 image.
+	img := makeTestImage(t, 200, 200, 0, 255, 0, 255)
+
+	dc.Push()
+
+	// Clip to a circle centered at (100, 100) with radius 50.
+	dc.DrawCircle(100, 100, 50)
+	dc.Clip()
+
+	// Draw image at origin — covers entire canvas.
+	dc.DrawImage(img, 0, 0)
+
+	dc.Pop()
+
+	// Pixel at the center of the circle should be green.
+	center := dc.pixmap.GetPixel(100, 100)
+	if center.G < 0.8 {
+		t.Errorf("Expected green at circle center, got G=%.2f", center.G)
+	}
+
+	// Pixel well outside the circle should be background (not green).
+	outside := dc.pixmap.GetPixel(5, 5)
+	if outside.G > 0.1 {
+		t.Errorf("Expected no green outside circle clip, got G=%.2f", outside.G)
+	}
+}
+
+// TestDrawImageClipped_NestedClips verifies that DrawImage works with
+// nested Push/Pop and multiple clip regions.
+func TestDrawImageClipped_NestedClips(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Clear()
+
+	// Create a blue 200x200 image.
+	img := makeTestImage(t, 200, 200, 0, 0, 255, 255)
+
+	dc.Push()
+
+	// First clip: large rectangle covering most of the canvas.
+	dc.ClipRect(20, 20, 160, 160)
+
+	dc.Push()
+
+	// Second clip: circle in the center (intersects with the rectangle).
+	dc.DrawCircle(100, 100, 50)
+	dc.Clip()
+
+	// Draw image — should only appear in the intersection of rect and circle.
+	dc.DrawImage(img, 0, 0)
+
+	dc.Pop() // Restore to just the rectangle clip.
+	dc.Pop() // Restore to no clip.
+
+	// Pixel at center (inside both clips) should be blue.
+	center := dc.pixmap.GetPixel(100, 100)
+	if center.B < 0.8 {
+		t.Errorf("Expected blue at center (inside both clips), got B=%.2f", center.B)
+	}
+
+	// Pixel inside the rectangle but outside the circle should NOT be blue.
+	rectOnly := dc.pixmap.GetPixel(25, 25)
+	if rectOnly.B > 0.1 {
+		t.Errorf("Expected no blue at (25,25) — inside rect but outside circle, got B=%.2f", rectOnly.B)
+	}
+
+	// Pixel completely outside both clips should be background.
+	outside := dc.pixmap.GetPixel(5, 5)
+	if outside.B > 0.1 {
+		t.Errorf("Expected no blue at (5,5), got B=%.2f", outside.B)
+	}
+}
+
+// TestDrawImageClipped_NoClip is a regression test ensuring that DrawImage
+// without any clip produces the same result as before the refactoring.
+func TestDrawImageClipped_NoClip(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Clear()
+
+	// Create red image.
+	img := makeTestImage(t, 50, 50, 255, 0, 0, 255)
+
+	// Draw without any clip.
+	dc.DrawImage(img, 10, 10)
+
+	// Verify pixel at (10, 10) is red.
+	result := dc.pixmap.GetPixel(10, 10)
+	if result.R < 0.9 || result.G > 0.1 || result.B > 0.1 {
+		t.Errorf("Expected red at (10, 10), got R=%.2f G=%.2f B=%.2f", result.R, result.G, result.B)
+	}
+
+	// Verify pixel just inside at (59, 59) is red (10+50-1=59).
+	inside := dc.pixmap.GetPixel(59, 59)
+	if inside.R < 0.9 {
+		t.Errorf("Expected red at (59, 59), got R=%.2f", inside.R)
+	}
+
+	// Verify pixel just outside at (60, 60) is NOT red.
+	outsideR := dc.pixmap.GetPixel(60, 10)
+	if outsideR.R > 0.1 {
+		t.Errorf("Expected no red at (60, 10), got R=%.2f", outsideR.R)
+	}
+}
+
+// TestImagePattern_Anchor verifies that an image pattern with a non-zero
+// anchor renders at the correct position.
+func TestImagePattern_Anchor(t *testing.T) {
+	// Create 10x10 red image.
+	img := makeTestImage(t, 10, 10, 255, 0, 0, 255)
+
+	pattern := &ImagePattern{
+		image:   img,
+		w:       10,
+		h:       10,
+		anchorX: 50,
+		anchorY: 50,
+		clamp:   true,
+	}
+
+	// At the anchor position, should return red.
+	col := pattern.ColorAt(50, 50)
+	if col.R < 0.9 || col.A < 0.9 {
+		t.Errorf("Expected red at anchor (50, 50), got R=%.2f A=%.2f", col.R, col.A)
+	}
+
+	// Outside the image region, should return transparent (clamp mode).
+	col = pattern.ColorAt(0, 0)
+	if col.A > 0.01 {
+		t.Errorf("Expected transparent outside anchor region, got A=%.2f", col.A)
+	}
+
+	// Just past the image region, should also be transparent.
+	col = pattern.ColorAt(60, 60)
+	if col.A > 0.01 {
+		t.Errorf("Expected transparent past anchor region at (60, 60), got A=%.2f", col.A)
+	}
+}
+
+// TestImagePattern_Scale verifies that scaling works on the image pattern.
+func TestImagePattern_Scale(t *testing.T) {
+	// Create 10x10 red image.
+	img := makeTestImage(t, 10, 10, 255, 0, 0, 255)
+
+	pattern := &ImagePattern{
+		image:  img,
+		w:      10,
+		h:      10,
+		scaleX: 2.0, // Each pixel covers 2 destination pixels.
+		scaleY: 2.0,
+		clamp:  true,
+	}
+
+	// At (0, 0), maps to source (0, 0) — should be red.
+	col := pattern.ColorAt(0, 0)
+	if col.R < 0.9 {
+		t.Errorf("Expected red at (0, 0) with 2x scale, got R=%.2f", col.R)
+	}
+
+	// At (19, 19), maps to source (9, 9) — still inside, should be red.
+	col = pattern.ColorAt(19, 19)
+	if col.R < 0.9 {
+		t.Errorf("Expected red at (19, 19) with 2x scale, got R=%.2f", col.R)
+	}
+
+	// At (20, 0), maps to source (10, 0) — outside, should be transparent.
+	col = pattern.ColorAt(20, 0)
+	if col.A > 0.01 {
+		t.Errorf("Expected transparent at (20, 0) with 2x scale, got A=%.2f", col.A)
+	}
+}
+
+// TestImagePattern_Opacity verifies that pattern opacity is applied.
+func TestImagePattern_Opacity(t *testing.T) {
+	img := makeTestImage(t, 10, 10, 255, 0, 0, 255)
+
+	pattern := &ImagePattern{
+		image:   img,
+		w:       10,
+		h:       10,
+		opacity: 0.5,
+	}
+
+	col := pattern.ColorAt(0, 0)
+	if col.R < 0.9 {
+		t.Errorf("Expected red channel unchanged, got R=%.2f", col.R)
+	}
+	// Alpha should be halved.
+	if col.A < 0.45 || col.A > 0.55 {
+		t.Errorf("Expected alpha ~0.5, got A=%.2f", col.A)
+	}
+}
+
+// TestDrawImageClipped_WithTransform verifies that DrawImage respects
+// clipping even when a transform is applied.
+func TestDrawImageClipped_WithTransform(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Clear()
+
+	// Create red image.
+	img := makeTestImage(t, 100, 100, 255, 0, 0, 255)
+
+	dc.Push()
+
+	// Clip to center rectangle.
+	dc.ClipRect(50, 50, 100, 100)
+
+	// Apply translation so image starts at (0, 0) but is shifted to (50, 50).
+	dc.Translate(50, 50)
+
+	// Draw image at origin in transformed space.
+	dc.DrawImage(img, 0, 0)
+
+	dc.Pop()
+
+	// Center of the clip should have red pixels.
+	center := dc.pixmap.GetPixel(100, 100)
+	if center.R < 0.8 {
+		t.Errorf("Expected red at center with transform+clip, got R=%.2f", center.R)
+	}
+
+	// Outside the clip should be background.
+	outside := dc.pixmap.GetPixel(10, 10)
+	if outside.R > 0.1 {
+		t.Errorf("Expected no red outside clip with transform, got R=%.2f", outside.R)
+	}
+}
+
+// TestDrawImageRounded verifies the convenience method.
+func TestDrawImageRounded(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Clear()
+
+	img := makeTestImage(t, 80, 80, 255, 0, 0, 255)
+
+	dc.DrawImageRounded(img, 60, 60, 10)
+
+	// Center of the image should be red.
+	center := dc.pixmap.GetPixel(100, 100)
+	if center.R < 0.8 {
+		t.Errorf("Expected red at center of rounded image, got R=%.2f", center.R)
+	}
+
+	// Corner should be clipped (radius=10, so the pixel at (60, 60) is in the rounded corner).
+	corner := dc.pixmap.GetPixel(61, 61)
+	if corner.R > 0.5 {
+		t.Errorf("Expected clipped corner at (61, 61), got R=%.2f", corner.R)
+	}
+}
+
+// TestDrawImageCircular verifies the convenience method.
+func TestDrawImageCircular(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Clear()
+
+	img := makeTestImage(t, 100, 100, 0, 0, 255, 255)
+
+	dc.DrawImageCircular(img, 100, 100, 40)
+
+	// Center should be blue (inside the circle).
+	center := dc.pixmap.GetPixel(100, 100)
+	if center.B < 0.8 {
+		t.Errorf("Expected blue at center of circular image, got B=%.2f", center.B)
+	}
+
+	// Pixel at the edge of the bounding box but outside the circle.
+	// At 45 degrees from center at distance 40 = (100+28, 100+28) roughly.
+	// At the actual corner (60, 60) which is outside the circle.
+	corner := dc.pixmap.GetPixel(62, 62)
+	if corner.B > 0.3 {
+		t.Errorf("Expected no blue at corner outside circle, got B=%.2f", corner.B)
+	}
+}
+
+// TestFillClippedSolid verifies that regular solid-color Fill() also
+// respects the clip stack after this refactoring.
+func TestFillClippedSolid(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Clear()
+
+	dc.Push()
+
+	// Clip to a circle.
+	dc.DrawCircle(100, 100, 50)
+	dc.Clip()
+
+	// Fill the entire canvas with red.
+	dc.SetRGB(1, 0, 0)
+	dc.DrawRectangle(0, 0, 200, 200)
+	dc.Fill()
+
+	dc.Pop()
+
+	// Center of the circle should be red.
+	center := dc.pixmap.GetPixel(100, 100)
+	if center.R < 0.8 {
+		t.Errorf("Expected red at circle center, got R=%.2f", center.R)
+	}
+
+	// Outside the circle should be background (black from Clear).
+	outside := dc.pixmap.GetPixel(5, 5)
+	if outside.R > 0.1 {
+		t.Errorf("Expected no red outside circle clip, got R=%.2f", outside.R)
+	}
+}
+
+// TestStrokeClipped verifies that Stroke() respects the clip stack.
+func TestStrokeClipped(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Clear()
+
+	dc.Push()
+
+	// Clip to a small rectangle in the center.
+	dc.ClipRect(80, 80, 40, 40)
+
+	// Stroke a horizontal line across the entire canvas.
+	dc.SetRGB(1, 0, 0)
+	dc.SetLineWidth(4)
+	dc.DrawLine(0, 100, 200, 100)
+	dc.Stroke()
+
+	dc.Pop()
+
+	// Inside the clip, the line should be visible.
+	inside := dc.pixmap.GetPixel(100, 100)
+	if inside.R < 0.5 {
+		t.Errorf("Expected red stroke inside clip, got R=%.2f", inside.R)
+	}
+
+	// Outside the clip, the line should NOT be visible.
+	outside := dc.pixmap.GetPixel(10, 100)
+	if outside.R > 0.1 {
+		t.Errorf("Expected no stroke outside clip, got R=%.2f", outside.R)
+	}
+}
+
+// makeTestImage creates a solid-color test image with the given RGBA values.
+func makeTestImage(t *testing.T, width, height int, r, g, b, a uint8) *ImageBuf { //nolint:unparam // a=255 is intentional in tests; keeping param for completeness
+	t.Helper()
+	img, err := NewImageBuf(width, height, FormatRGBA8)
+	if err != nil {
+		t.Fatalf("Failed to create image: %v", err)
+	}
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			_ = img.SetRGBA(x, y, r, g, b, a)
+		}
+	}
+	return img
+}

--- a/internal/clip/mask.go
+++ b/internal/clip/mask.go
@@ -180,10 +180,14 @@ func (mc *MaskClipper) rasterizePath(elements []PathElement, antiAlias bool) {
 	}
 
 	// Scanline rasterization
-	// Note: antiAlias parameter is reserved for future enhancement
-	_ = antiAlias
-	for y := 0; y < mc.mask.Height(); y++ {
-		mc.rasterizeScanline(edges, y)
+	if antiAlias {
+		for y := 0; y < mc.mask.Height(); y++ {
+			mc.rasterizeScanlineAA(edges, y)
+		}
+	} else {
+		for y := 0; y < mc.mask.Height(); y++ {
+			mc.rasterizeScanline(edges, y)
+		}
 	}
 }
 
@@ -209,6 +213,102 @@ func (mc *MaskClipper) makeEdge(p0, p1 Point) edge {
 		return edge{x0: x0, y0: y0, x1: x1, y1: y1, dir: -1}
 	}
 	return edge{x0: x0, y0: y0, x1: x1, y1: y1, dir: 1}
+}
+
+// rasterizeScanlineAA fills a single scanline with anti-aliasing using 4x
+// Y-supersampling and fractional X-edge coverage. Each pixel is sampled at 4
+// sub-scanlines (y+0.125, y+0.375, y+0.625, y+0.875) and the coverage is
+// averaged. Edge pixels get fractional coverage based on the exact intersection.
+func (mc *MaskClipper) rasterizeScanlineAA(edges []edge, y int) {
+	width := mc.mask.Width()
+	// Accumulate coverage from 4 sub-scanlines (each contributes 0-255/4).
+	coverage := make([]uint16, width)
+
+	subOffsets := [4]float64{0.125, 0.375, 0.625, 0.875}
+	for _, off := range subOffsets {
+		scanY := float64(y) + off
+
+		// Find edge intersections at this sub-scanline.
+		var intersections []float64
+		for _, e := range edges {
+			if e.y0 <= scanY && scanY < e.y1 {
+				t := (scanY - e.y0) / (e.y1 - e.y0)
+				x := e.x0 + t*(e.x1-e.x0)
+				intersections = append(intersections, x)
+			}
+		}
+		if len(intersections) == 0 {
+			continue
+		}
+		sortFloats(intersections)
+
+		// Fill spans with fractional edge coverage.
+		for i := 0; i+1 < len(intersections); i += 2 {
+			x1 := intersections[i]
+			x2 := intersections[i+1]
+
+			px1 := int(x1)
+			px2 := int(x2)
+			if px1 < 0 {
+				px1 = 0
+			}
+			if px2 >= width {
+				px2 = width - 1
+			}
+
+			if px1 == px2 {
+				// Single pixel span — coverage = span width.
+				frac := x2 - x1
+				if frac > 1.0 {
+					frac = 1.0
+				}
+				coverage[px1] += uint16(frac * 64) // 64 = 255/4 ≈ per-subsample max
+				continue
+			}
+
+			// Left edge pixel: fractional coverage.
+			if px1 >= 0 && px1 < width {
+				leftFrac := 1.0 - (x1 - float64(px1))
+				if leftFrac > 1.0 {
+					leftFrac = 1.0
+				}
+				if leftFrac < 0 {
+					leftFrac = 0
+				}
+				coverage[px1] += uint16(leftFrac * 64)
+			}
+
+			// Interior pixels: full coverage for this subsample.
+			for x := px1 + 1; x < px2; x++ {
+				if x >= 0 && x < width {
+					coverage[x] += 64 // 255/4
+				}
+			}
+
+			// Right edge pixel: fractional coverage.
+			if px2 >= 0 && px2 < width && px2 > px1 {
+				rightFrac := x2 - float64(px2)
+				if rightFrac > 1.0 {
+					rightFrac = 1.0
+				}
+				if rightFrac < 0 {
+					rightFrac = 0
+				}
+				coverage[px2] += uint16(rightFrac * 64)
+			}
+		}
+	}
+
+	// Write accumulated coverage to mask.
+	for x := 0; x < width; x++ {
+		if coverage[x] > 0 {
+			c := coverage[x]
+			if c > 255 {
+				c = 255
+			}
+			_ = mc.mask.SetRGBA(x, y, byte(c), byte(c), byte(c), byte(c))
+		}
+	}
 }
 
 // rasterizeScanline fills a single scanline using the non-zero winding rule.

--- a/paint.go
+++ b/paint.go
@@ -82,6 +82,12 @@ type Paint struct {
 	// Used internally by the renderer to determine effective stroke width.
 	// Set automatically by Context.Stroke() before rendering.
 	TransformScale float64
+
+	// ClipCoverage is a function that returns the clip coverage (0-255)
+	// at a given pixel coordinate. When non-nil, the renderer multiplies
+	// pixel alpha by this coverage to apply the clip mask.
+	// Set automatically by Context before rendering when a clip is active.
+	ClipCoverage func(x, y float64) byte
 }
 
 // NewPaint creates a new Paint with default values.

--- a/software.go
+++ b/software.go
@@ -195,17 +195,58 @@ func (r *SoftwareRenderer) fillWithCoverageFiller(
 	if paint.FillRule == FillRuleEvenOdd {
 		fillRule = FillRuleEvenOdd
 	}
+	clipFn := paint.ClipCoverage
 	if color, ok := solidColorFromPaint(paint); ok {
-		filler.FillCoverage(p, r.width, r.height, fillRule,
-			func(x, y int, coverage uint8) {
-				r.blendCoverageSolid(pixmap, x, y, coverage, color)
-			})
+		r.fillCoverageSolidPath(pixmap, p, filler, fillRule, color, clipFn)
 	} else {
-		filler.FillCoverage(p, r.width, r.height, fillRule,
-			func(x, y int, coverage uint8) {
-				r.blendCoveragePaint(pixmap, x, y, coverage, paint)
-			})
+		r.fillCoveragePaintPath(pixmap, p, filler, fillRule, paint, clipFn)
 	}
+}
+
+// fillCoverageSolidPath fills using the CoverageFiller with a solid color,
+// applying optional clip coverage.
+func (r *SoftwareRenderer) fillCoverageSolidPath(
+	pixmap *Pixmap, p *Path, filler CoverageFiller,
+	fillRule FillRule, color RGBA, clipFn func(x, y float64) byte,
+) {
+	filler.FillCoverage(p, r.width, r.height, fillRule,
+		func(x, y int, coverage uint8) {
+			coverage = applyClipCoverage(clipFn, x, y, coverage)
+			if coverage == 0 {
+				return
+			}
+			r.blendCoverageSolid(pixmap, x, y, coverage, color)
+		})
+}
+
+// fillCoveragePaintPath fills using the CoverageFiller with a paint pattern,
+// applying optional clip coverage.
+func (r *SoftwareRenderer) fillCoveragePaintPath(
+	pixmap *Pixmap, p *Path, filler CoverageFiller,
+	fillRule FillRule, paint *Paint, clipFn func(x, y float64) byte,
+) {
+	filler.FillCoverage(p, r.width, r.height, fillRule,
+		func(x, y int, coverage uint8) {
+			coverage = applyClipCoverage(clipFn, x, y, coverage)
+			if coverage == 0 {
+				return
+			}
+			r.blendCoveragePaint(pixmap, x, y, coverage, paint)
+		})
+}
+
+// applyClipCoverage multiplies pixel coverage by the clip mask coverage.
+// Returns 0 if the pixel is fully clipped. When clipFn is nil, returns the
+// original coverage unchanged.
+func applyClipCoverage(clipFn func(x, y float64) byte, px, py int, coverage uint8) uint8 {
+	if clipFn == nil {
+		return coverage
+	}
+	cc := clipFn(float64(px)+0.5, float64(py)+0.5)
+	if cc == 0 {
+		return 0
+	}
+	return uint8(uint16(coverage) * uint16(cc) / 255)
 }
 
 // Fill implements Renderer.Fill using analytic anti-aliasing.
@@ -271,13 +312,15 @@ func (r *SoftwareRenderer) Fill(pixmap *Pixmap, p *Path, paint *Paint) error {
 
 	if color, ok := solidColorFromPaint(paint); ok {
 		// Fast path: solid color
+		clipFn := paint.ClipCoverage
 		r.analyticFiller.Fill(r.edgeBuilder, coreFillRule, func(y int, runs *raster.AlphaRuns) {
-			r.blendAlphaRunsFromCoreRuns(pixmap, y, runs, color)
+			r.blendAlphaRunsFromCoreRuns(pixmap, y, runs, color, clipFn)
 		})
 	} else {
 		// Pattern/gradient path: per-pixel color sampling
+		clipFn := paint.ClipCoverage
 		r.analyticFiller.Fill(r.edgeBuilder, coreFillRule, func(y int, runs *raster.AlphaRuns) {
-			r.blendAlphaRunsFromCoreRunsPaint(pixmap, y, runs, paint)
+			r.blendAlphaRunsFromCoreRunsPaint(pixmap, y, runs, paint, clipFn)
 		})
 	}
 
@@ -385,10 +428,13 @@ func solidColorFromPaint(paint *Paint) (RGBA, bool) {
 
 // blendAlphaRunsFromCoreRuns blends alpha values from raster.AlphaRuns to the pixmap.
 // Uses source-over compositing for proper alpha blending.
-func (r *SoftwareRenderer) blendAlphaRunsFromCoreRuns(pixmap *Pixmap, y int, runs *raster.AlphaRuns, color RGBA) {
+// When clipFn is non-nil, each pixel's alpha is multiplied by the clip coverage.
+func (r *SoftwareRenderer) blendAlphaRunsFromCoreRuns(pixmap *Pixmap, y int, runs *raster.AlphaRuns, color RGBA, clipFn func(x, y float64) byte) {
 	if y < 0 || y >= pixmap.Height() {
 		return
 	}
+
+	fy := float64(y) + 0.5
 
 	for x, alpha := range runs.Iter() {
 		if alpha == 0 {
@@ -396,6 +442,18 @@ func (r *SoftwareRenderer) blendAlphaRunsFromCoreRuns(pixmap *Pixmap, y int, run
 		}
 		if x < 0 || x >= pixmap.Width() {
 			continue
+		}
+
+		// Apply clip coverage if active.
+		if clipFn != nil {
+			cc := clipFn(float64(x)+0.5, fy)
+			if cc == 0 {
+				continue
+			}
+			alpha = uint8(uint16(alpha) * uint16(cc) / 255)
+			if alpha == 0 {
+				continue
+			}
 		}
 
 		// Full coverage - just set the pixel
@@ -425,7 +483,8 @@ func (r *SoftwareRenderer) blendAlphaRunsFromCoreRuns(pixmap *Pixmap, y int, run
 
 // blendAlphaRunsFromCoreRunsPaint is like blendAlphaRunsFromCoreRuns but samples
 // the paint color at each pixel instead of using a single constant color.
-func (r *SoftwareRenderer) blendAlphaRunsFromCoreRunsPaint(pixmap *Pixmap, y int, runs *raster.AlphaRuns, paint *Paint) {
+// When clipFn is non-nil, each pixel's alpha is multiplied by the clip coverage.
+func (r *SoftwareRenderer) blendAlphaRunsFromCoreRunsPaint(pixmap *Pixmap, y int, runs *raster.AlphaRuns, paint *Paint, clipFn func(x, y float64) byte) {
 	if y < 0 || y >= pixmap.Height() {
 		return
 	}
@@ -440,8 +499,22 @@ func (r *SoftwareRenderer) blendAlphaRunsFromCoreRunsPaint(pixmap *Pixmap, y int
 			continue
 		}
 
+		fx := float64(x) + 0.5
+
+		// Apply clip coverage if active.
+		if clipFn != nil {
+			cc := clipFn(fx, fy)
+			if cc == 0 {
+				continue
+			}
+			alpha = uint8(uint16(alpha) * uint16(cc) / 255)
+			if alpha == 0 {
+				continue
+			}
+		}
+
 		// Sample color from paint at pixel center
-		color := paint.ColorAt(float64(x)+0.5, fy)
+		color := paint.ColorAt(fx, fy)
 
 		if alpha == 255 && color.A == 1.0 {
 			pixmap.SetPixel(x, y, color)


### PR DESCRIPTION
## Summary

- **DrawImage respects clip stack** — `DrawImageEx` refactored to route through `Fill()` pipeline (image-as-shader pattern, same as Skia/Cairo/tiny-skia/Vello). Images now correctly clip to any path set via `Clip()`. ([#155](https://github.com/gogpu/gg/issues/155))
- **Anti-aliased clip masks** — path-based clips use 4x Y-supersampling + fractional X-edge coverage for smooth clip edges
- **DrawImageRounded / DrawImageCircular** — convenience methods for rounded corners and circular avatar clips
- **ImagePattern enhancements** — anchor, scale, opacity, clamp mode for precise image positioning
- **Fill() / Stroke() clip integration** — all software rendering paths apply clip masks via `Paint.ClipCoverage`

## Test plan

- [x] 12 new unit tests (clip, pattern, convenience methods)
- [x] All existing tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run`)
- [x] Visual verification: 5 clip scenarios (rounded rect, circle, star, nested clips)
