### PR TITLE
chore: update wgpu v0.19.7, naga v0.14.6 (v0.33.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.3] - 2026-03-07
+
+### Changed
+
+- **Update wgpu v0.19.6 → v0.19.7** — Queue.WriteTexture public API
+  ([wgpu#95](https://github.com/gogpu/wgpu/pull/95) by [@Carmen-Shannon](https://github.com/Carmen-Shannon))
+- **Update naga v0.14.5 → v0.14.6** — MSL pass-through globals fix
+  ([naga#40](https://github.com/gogpu/naga/pull/40))
+
 ## [0.33.2] - 2026-03-05
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-text/typesetting v0.3.3
 	github.com/gogpu/gpucontext v0.9.0
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/naga v0.14.5
-	github.com/gogpu/wgpu v0.19.6
+	github.com/gogpu/naga v0.14.6
+	github.com/gogpu/wgpu v0.19.7
 	golang.org/x/image v0.36.0
 	golang.org/x/text v0.34.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Lo
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.14.5 h1:eT3yJjXGShNtL//+W7ir2KB40k77OWvLah62ww2HZ4c=
-github.com/gogpu/naga v0.14.5/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.19.6 h1:aSjMUb3tcSkIuljdTDl+06oE4cXbFBHYhEyzyT9ImVo=
-github.com/gogpu/wgpu v0.19.6/go.mod h1:XFwTzUxOLpAP7vqtRpFIQhHS2/ziKrdvaNDYXHW1whc=
+github.com/gogpu/naga v0.14.6 h1:zXtYxeEt1P70UDVuoa1EgMzKvted9ZsHkVcFV13qkSs=
+github.com/gogpu/naga v0.14.6/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.19.7 h1:Oymo9GOfJ5q7PiO4p1PGFgt+t+eR4V5S2ur5xJlQ5D4=
+github.com/gogpu/wgpu v0.19.7/go.mod h1:li6h9TJ/ppfg/arwAieVNrBPOFCynfzfhNfOqCXCGi8=
 golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
 golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=


### PR DESCRIPTION
## Summary

- Update wgpu v0.19.6 → v0.19.7 (Queue.WriteTexture public API by @Carmen-Shannon)
- Update naga v0.14.5 → v0.14.6 (MSL pass-through globals fix)