### PR TITLE
fix: correct DrawStringAnchored/DrawStringWrapped vertical anchor formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.4] - 2026-03-07
+
+### Fixed
+
+- **Fix `DrawStringAnchored` vertical anchor (`ay`) formula** — the formula
+  `y += h * ay` (inherited from fogleman/gg) did not match the documented
+  semantics `(0,0)=top-left, (0.5,0.5)=center, (1,1)=bottom-right`. Replaced
+  with the correct bounding-box anchor formula `y = y + ascent - ay * h` where
+  `h = ascent + descent` (visual bounding box, no lineGap). Research verified
+  against Cairo, Skia, and HTML Canvas baseline models.
+  ([#166](https://github.com/gogpu/gg/issues/166),
+  reported in [#159](https://github.com/gogpu/gg/issues/159) by
+  [@rcarlier](https://github.com/rcarlier))
+
+- **Fix `DrawStringWrapped` vertical anchor and height calculation** — same
+  formula fix applied. Block height now uses
+  `(n-1)*fh*lineSpacing + ascent + descent` (visual bounding box model).
+
+- **Fix `MeasureMultilineString` height calculation** — now returns visual
+  bounding box height consistent with `DrawStringWrapped`.
+
 ## [0.33.3] - 2026-03-07
 
 ### Changed

--- a/text.go
+++ b/text.go
@@ -101,9 +101,17 @@ func (c *Context) DrawStringAnchored(s string, x, y, ax, ay float64) {
 	}
 
 	// Measure the text and calculate offset based on anchor.
-	w, h := text.Measure(s, c.face)
+	// The anchor maps linearly within the text bounding box:
+	//   ay=0 → y is the top of the text (baseline = y + ascent)
+	//   ay=0.5 → y is the vertical center (baseline = y + ascent - h/2)
+	//   ay=1 → y is the bottom (baseline = y + ascent - h)
+	// Formula: baseline = y + ascent - ay * h
+	// where h = ascent + descent (visual bounding box, no lineGap).
+	w, _ := text.Measure(s, c.face)
+	metrics := c.face.Metrics()
+	h := metrics.Ascent + metrics.Descent
 	x -= w * ax
-	y += h * ay // Note: y is baseline, so we adjust upward for top alignment
+	y = y + metrics.Ascent - ay*h
 
 	// Try GPU text rendering first with user-space coordinates.
 	// The CTM is applied in the vertex shader.
@@ -180,18 +188,17 @@ func (c *Context) MeasureMultilineString(s string, lineSpacing float64) (width, 
 		return 0, 0
 	}
 	lines := splitLines(s)
-	fh := c.fontHeight()
+	metrics := c.face.Metrics()
+	fh := metrics.LineHeight()
 	for _, line := range lines {
 		lw, _ := text.Measure(line, c.face)
 		if lw > width {
 			width = lw
 		}
 	}
-	// Height formula: n lines with (n-1) inter-line gaps of fh*lineSpacing,
-	// plus one line height for the last line.
-	// h = fh * ((n-1)*lineSpacing + 1)
+	// Visual height: ascent above first baseline + (n-1) inter-line gaps + descent below last baseline.
 	n := float64(len(lines))
-	height = n*fh*lineSpacing - (lineSpacing-1)*fh
+	height = (n-1)*fh*lineSpacing + metrics.Ascent + metrics.Descent
 	return
 }
 
@@ -217,15 +224,22 @@ func (c *Context) DrawStringWrapped(s string, x, y, ax, ay, width, lineSpacing f
 		return
 	}
 
-	fh := c.fontHeight()
+	metrics := c.face.Metrics()
+	fh := metrics.LineHeight()
 
-	// Total height (same formula as MeasureMultilineString)
+	// Visual height of the text block:
+	// - (n-1) inter-line gaps of fh*lineSpacing
+	// - ascent above first baseline + descent below last baseline
 	n := float64(len(lines))
-	h := n*fh*lineSpacing - (lineSpacing-1)*fh
+	h := (n-1)*fh*lineSpacing + metrics.Ascent + metrics.Descent
 
-	// Adjust starting position by anchor
+	// Adjust starting position by anchor (bounding-box model):
+	//   ay=0 → y is the top of the block (first baseline = y + ascent)
+	//   ay=0.5 → y is the vertical center
+	//   ay=1 → y is the bottom of the block
+	// Formula: first_baseline = y + ascent - ay * h
 	x -= ax * width
-	y -= ay * h
+	y = y + metrics.Ascent - ay*h
 
 	// Adjust x base for alignment
 	switch align {

--- a/text_wrap_test.go
+++ b/text_wrap_test.go
@@ -471,13 +471,143 @@ func TestDrawStringWrapped_HeightConsistency(t *testing.T) {
 	_, mh := dc.MeasureMultilineString(s, lineSpacing)
 
 	// The measured height should be consistent with what DrawStringWrapped uses.
-	// With anchor (0, 0) and (0, 1), the difference in y should equal the height.
-	fh := dc.fontHeight()
+	// Visual height = ascent + (n-1)*fh*lineSpacing + descent
+	metrics := dc.face.Metrics()
+	fh := metrics.LineHeight()
 	lines := splitLines(s)
 	n := float64(len(lines))
-	h := n*fh*lineSpacing - (lineSpacing-1)*fh
+	h := (n-1)*fh*lineSpacing + metrics.Ascent + metrics.Descent
 
 	if mh != h {
 		t.Errorf("MeasureMultilineString height (%f) != computed height (%f)", mh, h)
+	}
+}
+
+// --------------------------------------------------------------------------
+// DrawStringAnchored anchor correctness (issue #166)
+// --------------------------------------------------------------------------
+
+func TestDrawStringAnchored_AnchorSemantics(t *testing.T) {
+	fontPath := findTestFont()
+	if fontPath == "" {
+		t.Skip("No system font available")
+	}
+
+	dc := NewContext(400, 400)
+	defer dc.Close()
+	dc.ClearWithColor(White)
+
+	source, err := text.NewFontSourceFromFile(fontPath)
+	if err != nil {
+		t.Fatalf("Failed to load font: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	dc.SetFont(source.Face(24.0))
+	dc.SetRGB(0, 0, 0)
+
+	s := "Test"
+	metrics := dc.face.Metrics()
+	h := metrics.Ascent + metrics.Descent
+
+	// ay=0 → y is the TOP of the text → baseline should be at y + ascent.
+	// Draw at y=50 with ay=0: text should span [50, 50+h].
+	// Check: ink exists near y=50 (top), no ink above y=50.
+	dc.ClearWithColor(White)
+	dc.DrawStringAnchored(s, 50, 50, 0, 0)
+
+	hasInkAbove := false
+	for y := 0; y < 48; y++ {
+		for x := 40; x < 200; x++ {
+			p := dc.pixmap.GetPixel(x, y)
+			if p.R < 0.95 {
+				hasInkAbove = true
+			}
+		}
+	}
+	if hasInkAbove {
+		t.Error("ay=0: ink found above y=50, text should start AT y=50 (top-left)")
+	}
+
+	hasInkInRange := false
+	for y := 50; y < 50+int(h)+2; y++ {
+		for x := 40; x < 200; x++ {
+			p := dc.pixmap.GetPixel(x, y)
+			if p.R < 0.95 {
+				hasInkInRange = true
+			}
+		}
+	}
+	if !hasInkInRange {
+		t.Error("ay=0: no ink found in expected text range [50, 50+h]")
+	}
+
+	// ay=0.5 → y is the VERTICAL CENTER → text should be centered at y=200.
+	// Ink should exist both above and below y=200.
+	dc.ClearWithColor(White)
+	dc.DrawStringAnchored(s, 50, 200, 0, 0.5)
+
+	hasInkAboveCenter := false
+	for y := 200 - int(h); y < 200; y++ {
+		if y < 0 {
+			continue
+		}
+		for x := 40; x < 200; x++ {
+			p := dc.pixmap.GetPixel(x, y)
+			if p.R < 0.95 {
+				hasInkAboveCenter = true
+			}
+		}
+	}
+	hasInkBelowCenter := false
+	for y := 200; y < 200+int(h); y++ {
+		if y >= 400 {
+			break
+		}
+		for x := 40; x < 200; x++ {
+			p := dc.pixmap.GetPixel(x, y)
+			if p.R < 0.95 {
+				hasInkBelowCenter = true
+			}
+		}
+	}
+	if !hasInkAboveCenter {
+		t.Error("ay=0.5: no ink above y=200, text should be centered at y=200")
+	}
+	if !hasInkBelowCenter {
+		t.Error("ay=0.5: no ink below y=200, text should be centered at y=200")
+	}
+
+	// ay=1 → y is the BOTTOM of the text → all ink should be ABOVE y=350.
+	dc.ClearWithColor(White)
+	dc.DrawStringAnchored(s, 50, 350, 0, 1)
+
+	hasInkBelow := false
+	for y := 352; y < 400; y++ {
+		for x := 40; x < 200; x++ {
+			p := dc.pixmap.GetPixel(x, y)
+			if p.R < 0.95 {
+				hasInkBelow = true
+			}
+		}
+	}
+	if hasInkBelow {
+		t.Error("ay=1: ink found below y=350, bottom of text should be AT y=350")
+	}
+
+	hasInkAboveBottom := false
+	for y := 350 - int(h) - 2; y < 350; y++ {
+		if y < 0 {
+			continue
+		}
+		for x := 40; x < 200; x++ {
+			p := dc.pixmap.GetPixel(x, y)
+			if p.R < 0.95 {
+				hasInkAboveBottom = true
+			}
+		}
+	}
+	if !hasInkAboveBottom {
+		t.Error("ay=1: no ink found above y=350, text should end AT y=350")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the vertical anchor (`ay`) formula in `DrawStringAnchored`, `DrawStringWrapped`, and `MeasureMultilineString`.

The formula `y += h * ay` (inherited from fogleman/gg) does not match the documented anchor semantics `(0,0)=top-left, (0.5,0.5)=center, (1,1)=bottom-right`. Replaced with the correct bounding-box anchor formula:

```
baseline = y + ascent - ay * h
```

where `h = ascent + descent` (visual bounding box, no lineGap).

### What changed

- **`DrawStringAnchored`** — correct vertical anchor using `y = y + ascent - ay * h`
- **`DrawStringWrapped`** — same formula fix + visual block height `(n-1)*fh*lineSpacing + ascent + descent`
- **`MeasureMultilineString`** — consistent visual height formula

### Research

Verified against Cairo, Skia, and HTML Canvas — none use anchor-based vertical text positioning, all use explicit baseline models. The correct formula is the only one where `(0,0)=top-left`, `(0.5,0.5)=center`, `(1,1)=bottom-right` are mathematically true. Full analysis: `TEXT-ANCHORING-RESEARCH.md`.

### Breaking change note

`DrawString(s, x, y)` is **NOT affected** — it does not delegate to `DrawStringAnchored`, so `y=baseline` convention is preserved (industry standard).

Fixes #166
Relates to #159

## Test plan

- [x] `TestDrawStringAnchored_AnchorSemantics` — verifies ay=0 (top), ay=0.5 (center), ay=1 (bottom) via pixel inspection
- [x] `TestDrawStringWrapped_HeightConsistency` — updated for new height formula
- [x] All existing text tests pass (`TestWordWrap`, `TestMeasureMultilineString`, `TestFontHeight`, etc.)
- [x] Visual verification with crosshair + bounding box overlay
