### PR TITLE
chore: update wgpu v0.19.7 → v0.20.0 (v0.33.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.6] - 2026-03-10
+
+### Changed
+
+- **Update wgpu v0.19.7 → v0.20.0** — enterprise-grade validation layer:
+  core validation (30+ WebGPU spec rules), 7 typed error types with `errors.As()`,
+  WebGPU deferred error pattern, HAL defense-in-depth.
+- **Update gputypes v0.2.0 → v0.3.0** — `TextureUsage.ContainsUnknownBits()`.
+
 ## [0.33.5] - 2026-03-08
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.25
 require (
 	github.com/go-text/typesetting v0.3.3
 	github.com/gogpu/gpucontext v0.9.0
-	github.com/gogpu/gputypes v0.2.0
+	github.com/gogpu/gputypes v0.3.0
 	github.com/gogpu/naga v0.14.6
-	github.com/gogpu/wgpu v0.19.7
+	github.com/gogpu/wgpu v0.20.0
 	golang.org/x/image v0.36.0
 	golang.org/x/text v0.34.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,12 @@ github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU
 github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
-github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
-github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=
+github.com/gogpu/gputypes v0.3.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.14.6 h1:zXtYxeEt1P70UDVuoa1EgMzKvted9ZsHkVcFV13qkSs=
 github.com/gogpu/naga v0.14.6/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.19.7 h1:Oymo9GOfJ5q7PiO4p1PGFgt+t+eR4V5S2ur5xJlQ5D4=
-github.com/gogpu/wgpu v0.19.7/go.mod h1:li6h9TJ/ppfg/arwAieVNrBPOFCynfzfhNfOqCXCGi8=
+github.com/gogpu/wgpu v0.20.0 h1:aqSbndAXNCuatehaAOUD6Bde0On/4Q6JDNDaaQUtCks=
+github.com/gogpu/wgpu v0.20.0/go.mod h1:Df/UU2lEx615/x0dEe1uaMv4chn0tEDi6d4wIreED3o=
 golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
 golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=


### PR DESCRIPTION
## Summary

- Update wgpu v0.19.7 → v0.20.0 — enterprise-grade validation layer
- Update gputypes v0.2.0 → v0.3.0 (transitive)

## Test plan

- [x] `GOWORK=off go build ./...` passes
- [x] `GOWORK=off golangci-lint run --timeout=5m` — 0 issues