### PR TITLE
feat: HiDPI device scale + DPI-aware rasterization (v0.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.34.0] - 2026-03-11
+
+### Added
+
+- **HiDPI/Retina device scale** — Cairo-pattern `SetDeviceScale()` for
+  DPI-transparent drawing. User code draws in logical coordinates (points/DIP),
+  the Context automatically scales to physical pixel resolution internally.
+  ([#171](https://github.com/gogpu/gg/issues/171),
+  [#175](https://github.com/gogpu/gg/issues/175))
+  - `NewContextWithScale(w, h, scale)` — create HiDPI-aware context
+  - `WithDeviceScale(scale)` — functional option for `NewContext`
+  - `SetDeviceScale(scale)` — set device scale on existing context
+  - `DeviceScale()` — query current device scale
+  - `PixelWidth()/PixelHeight()` — physical pixel dimensions
+  - `Width()/Height()` — logical dimensions (unchanged)
+- **DPI-aware rasterization tolerances** — curve flattening tolerance and stroke
+  expansion tolerance now scale with device DPI (femtovg pattern:
+  `tolerance = baseTolerance / deviceScale`). Produces sharper curves on
+  Retina/HiDPI displays.
+- **ggcanvas HiDPI auto-detection** — `ggcanvas.New()` auto-detects HiDPI scale
+  via `gpucontext.WindowProvider` interface (no manual scale parameter needed).
+  `ggcanvas.NewWithScale()` and `MustNewWithScale()` for explicit control.
+  `DeviceScale()` and `SetDeviceScale()` methods on Canvas.
 
 ## [0.33.6] - 2026-03-10
 

--- a/context.go
+++ b/context.go
@@ -16,11 +16,18 @@ import (
 // Context is the main drawing context.
 // It maintains a pixmap, current path, paint state, and transformation stack.
 // Context implements io.Closer for proper resource cleanup.
+//
+// When deviceScale > 1.0 (HiDPI/Retina), the Context maintains a larger physical
+// pixmap while exposing logical dimensions to user code. Drawing operations use
+// logical coordinates; the Context applies a base scale transform transparently.
 type Context struct {
-	width    int
-	height   int
+	width    int // logical width (user-facing)
+	height   int // logical height (user-facing)
 	pixmap   *Pixmap
 	renderer Renderer
+
+	// HiDPI support
+	deviceScale float64 // physical pixels per logical pixel (default 1.0)
 
 	// Current state
 	path      *Path
@@ -30,6 +37,7 @@ type Context struct {
 
 	// Transform and state stack
 	matrix         Matrix
+	baseMatrix     Matrix // device scale transform (Identity when scale=1.0)
 	stack          []Matrix
 	clipStackDepth []int // Tracks clip stack depth for each Push/Pop
 
@@ -57,7 +65,7 @@ type Context struct {
 // Ensure Context implements io.Closer
 var _ io.Closer = (*Context)(nil)
 
-// NewContext creates a new drawing context with the given dimensions.
+// NewContext creates a new drawing context with the given logical dimensions.
 // Optional ContextOption arguments can be used for dependency injection:
 //
 //	// Default software rendering (uses analytic anti-aliasing)
@@ -65,6 +73,13 @@ var _ io.Closer = (*Context)(nil)
 //
 //	// Custom GPU renderer (dependency injection)
 //	dc := gg.NewContext(800, 600, gg.WithRenderer(gpuRenderer))
+//
+//	// HiDPI/Retina rendering (logical 800x600, physical 1600x1200)
+//	dc := gg.NewContext(800, 600, gg.WithDeviceScale(2.0))
+//
+// When WithDeviceScale is used, the internal pixmap is allocated at physical
+// resolution (width*scale x height*scale) while Width/Height return the
+// logical dimensions. All drawing operations use logical coordinates.
 func NewContext(width, height int, opts ...ContextOption) *Context {
 	// Apply options
 	options := defaultOptions()
@@ -72,26 +87,48 @@ func NewContext(width, height int, opts ...ContextOption) *Context {
 		opt(&options)
 	}
 
-	// Use provided pixmap or create new one
-	pixmap := options.pixmap
-	if pixmap == nil {
-		pixmap = NewPixmap(width, height)
+	scale := options.deviceScale
+	if scale <= 0 {
+		scale = 1.0
 	}
 
-	// Use provided renderer or create software renderer
+	// Physical dimensions for the pixmap
+	pw := int(float64(width) * scale)
+	ph := int(float64(height) * scale)
+
+	// Use provided pixmap or create one at physical resolution
+	pixmap := options.pixmap
+	if pixmap == nil {
+		pixmap = NewPixmap(pw, ph)
+	}
+
+	// Use provided renderer or create software renderer at physical resolution
 	renderer := options.renderer
 	if renderer == nil {
-		renderer = NewSoftwareRenderer(width, height)
+		sr := NewSoftwareRenderer(pw, ph)
+		if scale > 1.0 {
+			sr.SetDeviceScale(float32(scale))
+		}
+		renderer = sr
+	}
+
+	// Base matrix: when scale != 1.0, apply a permanent scale transform
+	// so user coordinates are automatically mapped to physical pixels.
+	baseMatrix := Identity()
+	if scale != 1.0 {
+		baseMatrix = Scale(scale, scale)
 	}
 
 	return &Context{
 		width:          width,
 		height:         height,
+		deviceScale:    scale,
 		pixmap:         pixmap,
 		renderer:       renderer,
 		path:           NewPath(),
 		paint:          NewPaint(),
-		matrix:         Identity(),
+		matrix:         baseMatrix,
+		baseMatrix:     baseMatrix,
 		stack:          make([]Matrix, 0, 8),
 		clipStackDepth: make([]int, 0, 8),
 		pipelineMode:   options.pipelineMode,
@@ -100,6 +137,7 @@ func NewContext(width, height int, opts ...ContextOption) *Context {
 
 // NewContextForImage creates a context for drawing on an existing image.
 // Optional ContextOption arguments can be used for dependency injection.
+// The image dimensions are treated as physical pixel dimensions (deviceScale=1.0).
 func NewContextForImage(img image.Image, opts ...ContextOption) *Context {
 	bounds := img.Bounds()
 	width := bounds.Dx()
@@ -121,15 +159,35 @@ func NewContextForImage(img image.Image, opts ...ContextOption) *Context {
 	return &Context{
 		width:          width,
 		height:         height,
+		deviceScale:    1.0,
 		pixmap:         pixmap,
 		renderer:       renderer,
 		path:           NewPath(),
 		paint:          NewPaint(),
 		matrix:         Identity(),
+		baseMatrix:     Identity(),
 		stack:          make([]Matrix, 0, 8),
 		clipStackDepth: make([]int, 0, 8),
 		pipelineMode:   options.pipelineMode,
 	}
+}
+
+// NewContextWithScale creates a new drawing context with the given logical
+// dimensions and device scale factor. This is a convenience wrapper for:
+//
+//	gg.NewContext(w, h, gg.WithDeviceScale(scale))
+//
+// The internal pixmap is allocated at physical resolution (w*scale x h*scale).
+// All drawing operations use logical coordinates (w x h).
+//
+// Example (macOS Retina 2x):
+//
+//	dc := gg.NewContextWithScale(800, 600, 2.0)
+//	dc.Width()      // 800 (logical)
+//	dc.PixelWidth() // 1600 (physical)
+//	dc.DrawCircle(400, 300, 100) // logical coordinates
+func NewContextWithScale(width, height int, scale float64) *Context {
+	return NewContext(width, height, WithDeviceScale(scale))
 }
 
 // Close releases resources associated with the Context.
@@ -198,14 +256,86 @@ func (c *Context) RasterizerMode() RasterizerMode {
 	return c.rasterizerMode
 }
 
-// Width returns the width of the context.
+// Width returns the logical width of the context.
+// This is the coordinate space used by drawing operations.
+// For the physical pixel dimensions, use PixelWidth.
 func (c *Context) Width() int {
 	return c.width
 }
 
-// Height returns the height of the context.
+// Height returns the logical height of the context.
+// This is the coordinate space used by drawing operations.
+// For the physical pixel dimensions, use PixelHeight.
 func (c *Context) Height() int {
 	return c.height
+}
+
+// PixelWidth returns the physical pixel width of the internal pixmap.
+// This equals Width() * DeviceScale(), rounded to int.
+// On non-HiDPI displays (scale=1.0), this equals Width().
+func (c *Context) PixelWidth() int {
+	return int(float64(c.width) * c.deviceScale)
+}
+
+// PixelHeight returns the physical pixel height of the internal pixmap.
+// This equals Height() * DeviceScale(), rounded to int.
+// On non-HiDPI displays (scale=1.0), this equals Height().
+func (c *Context) PixelHeight() int {
+	return int(float64(c.height) * c.deviceScale)
+}
+
+// DeviceScale returns the device scale factor (physical pixels per logical pixel).
+// Default is 1.0. On Retina/HiDPI displays, typical values are 2.0 or 3.0.
+func (c *Context) DeviceScale() float64 {
+	return c.deviceScale
+}
+
+// SetDeviceScale changes the device scale factor on an existing context.
+// This reallocates the internal pixmap at the new physical resolution
+// and adjusts the base transform. The logical dimensions (Width, Height)
+// remain unchanged.
+//
+// Use this when the window moves to a display with a different scale factor.
+// Scale must be > 0; values <= 0 are ignored.
+func (c *Context) SetDeviceScale(scale float64) {
+	if scale <= 0 || scale == c.deviceScale {
+		return
+	}
+
+	oldScale := c.deviceScale
+	c.deviceScale = scale
+
+	// Physical dimensions
+	pw := int(float64(c.width) * scale)
+	ph := int(float64(c.height) * scale)
+
+	// Reallocate pixmap at new physical resolution
+	c.pixmap = NewPixmap(pw, ph)
+
+	// Update renderer dimensions and device scale
+	if sr, ok := c.renderer.(*SoftwareRenderer); ok {
+		sr.Resize(pw, ph)
+		sr.SetDeviceScale(float32(scale))
+	}
+
+	// Update base matrix
+	c.baseMatrix = Identity()
+	if scale != 1.0 {
+		c.baseMatrix = Scale(scale, scale)
+	}
+
+	// Update current matrix: remove old base scale, apply new one.
+	// If the user had additional transforms, preserve them.
+	if oldScale != 1.0 {
+		invOld := Scale(1.0/oldScale, 1.0/oldScale)
+		c.matrix = c.baseMatrix.Multiply(invOld.Multiply(c.matrix))
+	} else {
+		c.matrix = c.baseMatrix.Multiply(c.matrix)
+	}
+
+	// Reset clip stack (clip regions are in pixel coordinates)
+	c.clipStack = nil
+	c.ClearPath()
 }
 
 // Image returns the context's image.
@@ -509,9 +639,12 @@ func (c *Context) Pop() {
 	}
 }
 
-// Identity resets the transformation matrix to identity.
+// Identity resets the transformation matrix to the base matrix.
+// When device scale is 1.0, this is the identity matrix.
+// When device scale is > 1.0, this preserves the base scale transform
+// so drawing operations continue to map logical to physical coordinates.
 func (c *Context) Identity() {
-	c.matrix = Identity()
+	c.matrix = c.baseMatrix
 }
 
 // Translate applies a translation to the transformation matrix.
@@ -569,6 +702,7 @@ func (c *Context) TransformPoint(x, y float64) (float64, float64) {
 }
 
 // InvertY inverts the Y axis (useful for coordinate system changes).
+// Uses logical height so the inversion works correctly at any device scale.
 func (c *Context) InvertY() {
 	c.Translate(0, float64(c.height))
 	c.Scale(1, -1)
@@ -717,9 +851,12 @@ func (c *Context) EncodeJPEG(w io.Writer, quality int) error {
 	return jpeg.Encode(w, c.Image(), &jpeg.Options{Quality: quality})
 }
 
-// Resize changes the context dimensions, reusing internal buffers where possible.
+// Resize changes the context logical dimensions, reusing internal buffers where possible.
 // If the dimensions haven't changed, this is a no-op.
 // Returns an error if width or height is <= 0.
+//
+// The width and height are logical dimensions. The internal pixmap is
+// allocated at physical resolution (width*deviceScale x height*deviceScale).
 //
 // After Resize:
 //   - The pixmap is reallocated only if dimensions changed
@@ -739,16 +876,20 @@ func (c *Context) Resize(width, height int) error {
 		return nil
 	}
 
-	// Update dimensions
+	// Update logical dimensions
 	c.width = width
 	c.height = height
 
-	// Reallocate pixmap
-	c.pixmap = NewPixmap(width, height)
+	// Physical dimensions
+	pw := int(float64(width) * c.deviceScale)
+	ph := int(float64(height) * c.deviceScale)
+
+	// Reallocate pixmap at physical resolution
+	c.pixmap = NewPixmap(pw, ph)
 
 	// Resize renderer if it supports resizing
 	if sr, ok := c.renderer.(*SoftwareRenderer); ok {
-		sr.Resize(width, height)
+		sr.Resize(pw, ph)
 	}
 
 	// Reset clip stack to full rectangle

--- a/context_device_scale_test.go
+++ b/context_device_scale_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package gg
+
+import "testing"
+
+func TestNewContextWithScale(t *testing.T) {
+	tests := []struct {
+		name       string
+		width      int
+		height     int
+		scale      float64
+		wantW      int
+		wantH      int
+		wantPixelW int
+		wantPixelH int
+		wantScale  float64
+	}{
+		{
+			name:  "no scale",
+			width: 800, height: 600,
+			scale: 1.0,
+			wantW: 800, wantH: 600,
+			wantPixelW: 800, wantPixelH: 600,
+			wantScale: 1.0,
+		},
+		{
+			name:  "retina 2x",
+			width: 800, height: 600,
+			scale: 2.0,
+			wantW: 800, wantH: 600,
+			wantPixelW: 1600, wantPixelH: 1200,
+			wantScale: 2.0,
+		},
+		{
+			name:  "mobile 3x",
+			width: 400, height: 800,
+			scale: 3.0,
+			wantW: 400, wantH: 800,
+			wantPixelW: 1200, wantPixelH: 2400,
+			wantScale: 3.0,
+		},
+		{
+			name:  "fractional 1.5x",
+			width: 1000, height: 500,
+			scale: 1.5,
+			wantW: 1000, wantH: 500,
+			wantPixelW: 1500, wantPixelH: 750,
+			wantScale: 1.5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dc := NewContextWithScale(tt.width, tt.height, tt.scale)
+			defer func() { _ = dc.Close() }()
+
+			if dc.Width() != tt.wantW {
+				t.Errorf("Width() = %d, want %d", dc.Width(), tt.wantW)
+			}
+			if dc.Height() != tt.wantH {
+				t.Errorf("Height() = %d, want %d", dc.Height(), tt.wantH)
+			}
+			if dc.PixelWidth() != tt.wantPixelW {
+				t.Errorf("PixelWidth() = %d, want %d", dc.PixelWidth(), tt.wantPixelW)
+			}
+			if dc.PixelHeight() != tt.wantPixelH {
+				t.Errorf("PixelHeight() = %d, want %d", dc.PixelHeight(), tt.wantPixelH)
+			}
+			if dc.DeviceScale() != tt.wantScale {
+				t.Errorf("DeviceScale() = %f, want %f", dc.DeviceScale(), tt.wantScale)
+			}
+		})
+	}
+}
+
+func TestWithDeviceScale(t *testing.T) {
+	dc := NewContext(800, 600, WithDeviceScale(2.0))
+	defer func() { _ = dc.Close() }()
+
+	if dc.Width() != 800 {
+		t.Errorf("Width() = %d, want 800", dc.Width())
+	}
+	if dc.Height() != 600 {
+		t.Errorf("Height() = %d, want 600", dc.Height())
+	}
+	if dc.PixelWidth() != 1600 {
+		t.Errorf("PixelWidth() = %d, want 1600", dc.PixelWidth())
+	}
+	if dc.PixelHeight() != 1200 {
+		t.Errorf("PixelHeight() = %d, want 1200", dc.PixelHeight())
+	}
+	if dc.DeviceScale() != 2.0 {
+		t.Errorf("DeviceScale() = %f, want 2.0", dc.DeviceScale())
+	}
+}
+
+func TestDefaultContextHasScale1(t *testing.T) {
+	dc := NewContext(100, 100)
+	defer func() { _ = dc.Close() }()
+
+	if dc.DeviceScale() != 1.0 {
+		t.Errorf("DeviceScale() = %f, want 1.0", dc.DeviceScale())
+	}
+	if dc.PixelWidth() != dc.Width() {
+		t.Errorf("PixelWidth() = %d != Width() = %d at scale 1.0", dc.PixelWidth(), dc.Width())
+	}
+	if dc.PixelHeight() != dc.Height() {
+		t.Errorf("PixelHeight() = %d != Height() = %d at scale 1.0", dc.PixelHeight(), dc.Height())
+	}
+}
+
+func TestSetDeviceScale(t *testing.T) {
+	dc := NewContext(800, 600)
+	defer func() { _ = dc.Close() }()
+
+	// Initially 1x
+	if dc.DeviceScale() != 1.0 {
+		t.Fatalf("initial DeviceScale() = %f, want 1.0", dc.DeviceScale())
+	}
+	if dc.PixelWidth() != 800 {
+		t.Fatalf("initial PixelWidth() = %d, want 800", dc.PixelWidth())
+	}
+
+	// Change to 2x
+	dc.SetDeviceScale(2.0)
+	if dc.DeviceScale() != 2.0 {
+		t.Errorf("DeviceScale() = %f, want 2.0", dc.DeviceScale())
+	}
+	if dc.Width() != 800 {
+		t.Errorf("Width() changed to %d, want 800", dc.Width())
+	}
+	if dc.PixelWidth() != 1600 {
+		t.Errorf("PixelWidth() = %d, want 1600", dc.PixelWidth())
+	}
+	if dc.PixelHeight() != 1200 {
+		t.Errorf("PixelHeight() = %d, want 1200", dc.PixelHeight())
+	}
+}
+
+func TestSetDeviceScaleIgnoresInvalid(t *testing.T) {
+	dc := NewContext(100, 100, WithDeviceScale(2.0))
+	defer func() { _ = dc.Close() }()
+
+	// Zero should be ignored
+	dc.SetDeviceScale(0)
+	if dc.DeviceScale() != 2.0 {
+		t.Errorf("DeviceScale() = %f after SetDeviceScale(0), want 2.0", dc.DeviceScale())
+	}
+
+	// Negative should be ignored
+	dc.SetDeviceScale(-1)
+	if dc.DeviceScale() != 2.0 {
+		t.Errorf("DeviceScale() = %f after SetDeviceScale(-1), want 2.0", dc.DeviceScale())
+	}
+
+	// Same value should be no-op
+	dc.SetDeviceScale(2.0)
+	if dc.DeviceScale() != 2.0 {
+		t.Errorf("DeviceScale() = %f after SetDeviceScale(2.0), want 2.0", dc.DeviceScale())
+	}
+}
+
+func TestResizeWithDeviceScale(t *testing.T) {
+	dc := NewContext(800, 600, WithDeviceScale(2.0))
+	defer func() { _ = dc.Close() }()
+
+	if err := dc.Resize(400, 300); err != nil {
+		t.Fatalf("Resize() error: %v", err)
+	}
+
+	if dc.Width() != 400 {
+		t.Errorf("Width() = %d, want 400", dc.Width())
+	}
+	if dc.Height() != 300 {
+		t.Errorf("Height() = %d, want 300", dc.Height())
+	}
+	// Physical should be 400*2=800, 300*2=600
+	if dc.PixelWidth() != 800 {
+		t.Errorf("PixelWidth() = %d, want 800", dc.PixelWidth())
+	}
+	if dc.PixelHeight() != 600 {
+		t.Errorf("PixelHeight() = %d, want 600", dc.PixelHeight())
+	}
+}
+
+func TestIdentityResetsToBaseMatrix(t *testing.T) {
+	dc := NewContext(800, 600, WithDeviceScale(2.0))
+	defer func() { _ = dc.Close() }()
+
+	// Apply user transform
+	dc.Translate(100, 100)
+	dc.Rotate(0.5)
+
+	// Reset to identity
+	dc.Identity()
+
+	// Should be back to base matrix (Scale(2, 2)), not pure identity.
+	// Verify by transforming a point: (1, 0) should map to (2, 0)
+	px, py := dc.TransformPoint(1, 0)
+	if px != 2.0 || py != 0.0 {
+		t.Errorf("TransformPoint(1, 0) = (%f, %f), want (2, 0) after Identity() with scale 2x", px, py)
+	}
+}
+
+func TestDrawingAtDeviceScale(t *testing.T) {
+	// Verify that drawing at 2x scale produces pixels in the right location.
+	// Draw a single pixel at logical (0, 0) and verify physical pixmap is written.
+	dc := NewContextWithScale(10, 10, 2.0)
+	defer func() { _ = dc.Close() }()
+
+	// Physical pixmap is 20x20. Drawing at logical (0,0)-(1,1) should
+	// affect physical pixels (0,0)-(2,2) due to the 2x scale transform.
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, 1, 1)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill() error: %v", err)
+	}
+
+	img := dc.Image()
+	bounds := img.Bounds()
+
+	// Physical image should be 20x20
+	if bounds.Dx() != 20 || bounds.Dy() != 20 {
+		t.Errorf("Image bounds = %dx%d, want 20x20", bounds.Dx(), bounds.Dy())
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -288,6 +288,64 @@ dc.DrawString(s, x, y)
 | `text/glyph_outline.go` | `OutlineExtractor`, `GlyphOutline`, `OutlineSegment` |
 | `text/face.go` | `Face.Glyphs()`, `Face.Source()`, `Face.Size()` |
 
+## HiDPI/Retina Device Scale
+
+gg uses the Cairo-pattern `device_scale` for DPI-transparent drawing. User code
+operates in logical coordinates (points/DIP), while the internal pixmap is
+allocated at physical pixel resolution. A permanent base scale transform maps
+logical to physical automatically.
+
+### API
+
+```go
+// Create HiDPI-aware context (800x600 logical, 1600x1200 physical on Retina 2x)
+dc := gg.NewContextWithScale(800, 600, 2.0)
+
+// Or via functional option
+dc := gg.NewContext(800, 600, gg.WithDeviceScale(2.0))
+
+// Or set dynamically
+dc.SetDeviceScale(2.0)
+
+dc.Width()       // 800 (logical)
+dc.Height()      // 600 (logical)
+dc.PixelWidth()  // 1600 (physical)
+dc.PixelHeight() // 1200 (physical)
+dc.DeviceScale() // 2.0
+
+// Drawing uses logical coordinates — no DPI awareness needed in user code
+dc.DrawCircle(400, 300, 100) // centered in logical space
+dc.Fill()                     // rasterized at physical resolution
+```
+
+### Implementation
+
+- `NewContextWithScale(w, h, scale)` allocates pixmap at `w*scale × h*scale`
+- A permanent `Scale(scale, scale)` base matrix is applied to the transform stack
+- `Identity()` resets to the base matrix (not the identity matrix)
+- All drawing operations flow through the transform stack and are automatically scaled
+- `SoftwareRenderer` receives device scale for DPI-aware tolerances
+
+### DPI-Aware Rasterization (femtovg pattern)
+
+On HiDPI displays, rasterization tolerances are adjusted for sharper output:
+
+| Parameter | Formula | Effect on Retina 2x |
+|-----------|---------|---------------------|
+| Curve flatten tolerance | `baseTol / deviceScale` | 0.05 instead of 0.1 — finer subdivision |
+| Stroke expansion tolerance | `baseTol / deviceScale` | Tighter stroke edges |
+
+### gogpu Integration (ggcanvas)
+
+```go
+// ggcanvas automatically uses platform scale factor
+canvas := ggcanvas.MustNewWithScale(provider, logicalW, logicalH, scaleFactor)
+```
+
+`ggcanvas.NewWithScale()` creates the GPU texture at physical pixel dimensions
+while the gg Context operates in logical coordinates. The scale factor typically
+comes from `gogpu.App.ScaleFactor()`.
+
 ## Package Structure
 
 ```

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -62,17 +62,46 @@ type Canvas struct {
 
 // New creates a Canvas for integrated mode.
 // The provider should come from gogpu.App.GPUContextProvider().
+// The width and height are logical dimensions.
 //
-// The Canvas is created with default gg.Context settings.
+// If the provider also implements gpucontext.WindowProvider, the device
+// scale is auto-detected for HiDPI/Retina support. Otherwise defaults to 1.0.
 // Use Context() to access and configure the drawing context.
 //
 // Returns error if dimensions are invalid or provider is nil.
 func New(provider gpucontext.DeviceProvider, width, height int) (*Canvas, error) {
+	scale := 1.0
+	if wp, ok := provider.(gpucontext.WindowProvider); ok {
+		if s := wp.ScaleFactor(); s > 0 {
+			scale = s
+		}
+	}
+	return NewWithScale(provider, width, height, scale)
+}
+
+// NewWithScale creates a Canvas with HiDPI device scale support.
+// The width and height are logical dimensions. The internal pixmap is
+// allocated at physical resolution (width*scale x height*scale).
+//
+// The provider should come from gogpu.App.GPUContextProvider().
+// Scale factor should come from the platform (e.g., gogpu.Context.ScaleFactor()).
+// Typical values: 1.0 (standard), 2.0 (macOS Retina), 3.0 (mobile HiDPI).
+//
+// Example:
+//
+//	scale := dc.ScaleFactor()  // from gogpu.Context
+//	canvas, err := ggcanvas.NewWithScale(provider, 800, 600, scale)
+//
+// Returns error if dimensions are invalid, provider is nil, or scale <= 0.
+func NewWithScale(provider gpucontext.DeviceProvider, width, height int, scale float64) (*Canvas, error) {
 	if provider == nil {
 		return nil, ErrNilProvider
 	}
 	if width <= 0 || height <= 0 {
 		return nil, fmt.Errorf("%w: width=%d, height=%d", ErrInvalidDimensions, width, height)
+	}
+	if scale <= 0 {
+		scale = 1.0
 	}
 
 	// Share GPU device with accelerator if registered.
@@ -80,8 +109,13 @@ func New(provider gpucontext.DeviceProvider, width, height int) (*Canvas, error)
 	// provider may not implement HalProvider. GPU will initialize its own device.
 	_ = gg.SetAcceleratorDeviceProvider(provider)
 
+	var opts []gg.ContextOption
+	if scale != 1.0 {
+		opts = append(opts, gg.WithDeviceScale(scale))
+	}
+
 	c := &Canvas{
-		ctx:      gg.NewContext(width, height),
+		ctx:      gg.NewContext(width, height, opts...),
 		provider: provider,
 		width:    width,
 		height:   height,
@@ -109,6 +143,15 @@ func MustNew(provider gpucontext.DeviceProvider, width, height int) *Canvas {
 	return c
 }
 
+// MustNewWithScale is like NewWithScale but panics on error.
+func MustNewWithScale(provider gpucontext.DeviceProvider, width, height int, scale float64) *Canvas {
+	c, err := NewWithScale(provider, width, height, scale)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
 // Context returns the gg drawing context.
 // All gg drawing methods are available through this context.
 //
@@ -123,19 +166,43 @@ func (c *Canvas) Context() *gg.Context {
 	return c.ctx
 }
 
-// Width returns the canvas width in pixels.
+// Width returns the canvas logical width.
 func (c *Canvas) Width() int {
 	return c.width
 }
 
-// Height returns the canvas height in pixels.
+// Height returns the canvas logical height.
 func (c *Canvas) Height() int {
 	return c.height
 }
 
-// Size returns width and height as a convenience.
+// Size returns logical width and height as a convenience.
 func (c *Canvas) Size() (width, height int) {
 	return c.width, c.height
+}
+
+// DeviceScale returns the current device scale factor.
+// Returns 1.0 if the canvas was created without HiDPI support.
+func (c *Canvas) DeviceScale() float64 {
+	if c.ctx == nil {
+		return 1.0
+	}
+	return c.ctx.DeviceScale()
+}
+
+// SetDeviceScale changes the device scale factor on the canvas.
+// This delegates to the gg.Context and marks the canvas for re-upload.
+// Scale must be > 0; values <= 0 are ignored.
+func (c *Canvas) SetDeviceScale(scale float64) {
+	if c.closed || c.ctx == nil || scale <= 0 {
+		return
+	}
+	if scale == c.ctx.DeviceScale() {
+		return
+	}
+	c.ctx.SetDeviceScale(scale)
+	c.sizeChanged = true
+	c.dirty = true
 }
 
 // MarkDirty flags the canvas for GPU upload on next Flush().
@@ -366,6 +433,7 @@ func destroyTexture(tex any) {
 // createTexture creates a pending texture placeholder from pixel data.
 // This is called lazily on first Flush().
 // The actual GPU texture is created during RenderTo when a renderer is available.
+// Uses physical pixel dimensions (PixelWidth/PixelHeight) for the texture.
 func (c *Canvas) createTexture(data []byte) *pendingTexture {
 	// We store the creation request and let RenderTo handle it
 	// when it has access to the actual renderer.
@@ -377,9 +445,10 @@ func (c *Canvas) createTexture(data []byte) *pendingTexture {
 	// 3. Store data and create texture on-demand in RenderTo
 	//
 	// We choose option 3: store a placeholder and create in RenderTo.
+	// Use physical pixel dimensions since the pixmap is at physical resolution.
 	return &pendingTexture{
-		width:  c.width,
-		height: c.height,
+		width:  c.ctx.PixelWidth(),
+		height: c.ctx.PixelHeight(),
 		data:   data,
 	}
 }

--- a/internal/raster/edge_builder.go
+++ b/internal/raster/edge_builder.go
@@ -118,6 +118,11 @@ type EdgeBuilder struct {
 	// flattenCurves when true converts all curves to line segments
 	flattenCurves bool
 
+	// flattenTolerance overrides the default curve flattening tolerance (0.1 px).
+	// When > 0, this value is used instead of the hardcoded constant.
+	// On HiDPI displays, set to baseTol/deviceScale for finer subdivision.
+	flattenTolerance float32
+
 	// clipRect when non-nil clips all edges to this rectangle.
 	// Prevents FDot6→FDot16 overflow for coordinates exceeding safe range.
 	// Sentinel vertical lines are emitted at X boundaries to preserve winding.
@@ -563,6 +568,38 @@ func (eb *EdgeBuilder) FlattenCurves() bool {
 	return eb.flattenCurves
 }
 
+// SetFlattenTolerance sets the curve flattening tolerance in pixels.
+// When > 0, this overrides the default 0.1 px tolerance used for
+// converting curves to line segments. Smaller values produce more
+// segments (smoother curves).
+//
+// On HiDPI displays, set to baseTol/deviceScale for finer subdivision:
+//
+//	eb.SetFlattenTolerance(0.1 / deviceScale) // e.g., 0.05 for 2x Retina
+//
+// Set to 0 to use the default tolerance.
+func (eb *EdgeBuilder) SetFlattenTolerance(tol float32) {
+	if tol < 0 {
+		tol = 0
+	}
+	eb.flattenTolerance = tol
+}
+
+// FlattenTolerance returns the current curve flattening tolerance.
+// Returns 0 if using the default (0.1 px).
+func (eb *EdgeBuilder) FlattenTolerance() float32 {
+	return eb.flattenTolerance
+}
+
+// effectiveFlattenTolerance returns the tolerance to use for flattening.
+// Returns the custom tolerance if set, otherwise the default 0.1 px.
+func (eb *EdgeBuilder) effectiveFlattenTolerance() float32 {
+	if eb.flattenTolerance > 0 {
+		return eb.flattenTolerance
+	}
+	return 0.1 // default: tight tolerance for smooth curves
+}
+
 // SetClipRect sets the clipping rectangle for edge building.
 // When set, all edges are clipped to this rect before fixed-point conversion,
 // preventing FDot6→FDot16 integer overflow (RAST-010). Out-of-bounds line
@@ -639,10 +676,10 @@ func (eb *EdgeBuilder) addQuad(x0, y0, cx, cy, x1, y1 float32) {
 // Uses adaptive subdivision based on flatness tolerance.
 func (eb *EdgeBuilder) flattenQuadToLines(x0, y0, cx, cy, x1, y1 float32) {
 	// Flatness tolerance: max deviation from straight line.
-	// 0.1 px produces smooth curves even at small radii (r=9 → ~32 segments).
-	// Tighter than Skia's default (~0.25) to avoid visible polygon faceting
-	// in UI elements like radio buttons and checkboxes.
-	const tolerance = 0.1
+	// Default 0.1 px produces smooth curves even at small radii.
+	// On HiDPI, effectiveFlattenTolerance() returns baseTol/deviceScale
+	// for finer subdivision at physical pixel resolution.
+	tolerance := eb.effectiveFlattenTolerance()
 
 	eb.flattenQuadRecursive(x0, y0, cx, cy, x1, y1, tolerance, 0)
 }
@@ -749,10 +786,10 @@ func (eb *EdgeBuilder) addCubic(x0, y0, c1x, c1y, c2x, c2y, x1, y1 float32) {
 // Uses adaptive subdivision based on flatness tolerance.
 func (eb *EdgeBuilder) flattenCubicToLines(x0, y0, c1x, c1y, c2x, c2y, x1, y1 float32) {
 	// Flatness tolerance: max deviation from straight line.
-	// 0.1 px produces smooth curves even at small radii (r=9 → ~32 segments).
-	// Tighter than Skia's default (~0.25) to avoid visible polygon faceting
-	// in UI elements like radio buttons and checkboxes.
-	const tolerance = 0.1
+	// Default 0.1 px produces smooth curves even at small radii.
+	// On HiDPI, effectiveFlattenTolerance() returns baseTol/deviceScale
+	// for finer subdivision at physical pixel resolution.
+	tolerance := eb.effectiveFlattenTolerance()
 
 	eb.flattenCubicRecursive(x0, y0, c1x, c1y, c2x, c2y, x1, y1, tolerance, 0)
 }

--- a/options.go
+++ b/options.go
@@ -17,6 +17,7 @@ type contextOptions struct {
 	renderer     Renderer
 	pixmap       *Pixmap
 	pipelineMode PipelineMode
+	deviceScale  float64
 }
 
 // defaultOptions returns the default context options.
@@ -25,6 +26,7 @@ func defaultOptions() contextOptions {
 		renderer:     nil,              // Will be set to SoftwareRenderer if nil
 		pixmap:       nil,              // Will be created if nil
 		pipelineMode: PipelineModeAuto, // Auto-select pipeline
+		deviceScale:  1.0,              // No HiDPI scaling by default
 	}
 }
 
@@ -68,5 +70,27 @@ func WithPixmap(pm *Pixmap) ContextOption {
 func WithPipelineMode(mode PipelineMode) ContextOption {
 	return func(o *contextOptions) {
 		o.pipelineMode = mode
+	}
+}
+
+// WithDeviceScale sets the HiDPI device scale factor for the Context.
+// The scale factor determines the ratio between logical coordinates (used by
+// drawing code) and physical pixels (in the internal pixmap).
+//
+// For example, on a macOS Retina display with 2x scaling:
+//
+//	// Logical size: 800x600, Physical pixmap: 1600x1200
+//	dc := gg.NewContext(800, 600, gg.WithDeviceScale(2.0))
+//	dc.Width()      // 800 (logical)
+//	dc.PixelWidth() // 1600 (physical)
+//
+// The Context automatically applies a base scale transform so all drawing
+// operations work in logical coordinates while rendering at physical resolution.
+// Default is 1.0 (no scaling).
+func WithDeviceScale(scale float64) ContextOption {
+	return func(o *contextOptions) {
+		if scale > 0 {
+			o.deviceScale = scale
+		}
 	}
 }

--- a/software.go
+++ b/software.go
@@ -17,8 +17,12 @@ type SoftwareRenderer struct {
 	edgeBuilder    *raster.EdgeBuilder
 	analyticFiller *raster.AnalyticFiller
 
-	// Dimensions
+	// Dimensions (physical pixels)
 	width, height int
+
+	// HiDPI device scale factor (1.0 = no scaling).
+	// Used to adjust curve flattening tolerance for sharper rendering on Retina.
+	deviceScale float32
 
 	// rasterizerMode is set by Context before calling Fill/Stroke
 	// to support forced algorithm selection (RasterizerSparseStrips, etc.).
@@ -34,17 +38,35 @@ func NewSoftwareRenderer(width, height int) *SoftwareRenderer {
 		analyticFiller: raster.NewAnalyticFiller(width, height),
 		width:          width,
 		height:         height,
+		deviceScale:    1.0,
 	}
 }
 
-// Resize updates the renderer dimensions.
+// Resize updates the renderer dimensions (physical pixels).
 // This should be called when the context is resized.
 func (r *SoftwareRenderer) Resize(width, height int) {
 	r.width = width
 	r.height = height
 	eb := raster.NewEdgeBuilder(2) // 4x AA (Skia default), max coord 8191px
+	if r.deviceScale > 1.0 {
+		eb.SetFlattenTolerance(0.1 / r.deviceScale)
+	}
 	r.edgeBuilder = eb
 	r.analyticFiller = raster.NewAnalyticFiller(width, height)
+}
+
+// SetDeviceScale sets the HiDPI device scale factor for the renderer.
+// When scale > 1.0, curve flattening tolerance is reduced for finer
+// subdivision on HiDPI displays (femtovg pattern: tol = baseTol / scale).
+// This produces smoother curves at physical pixel resolution.
+func (r *SoftwareRenderer) SetDeviceScale(scale float32) {
+	if scale <= 0 {
+		scale = 1.0
+	}
+	r.deviceScale = scale
+	if scale > 1.0 {
+		r.edgeBuilder.SetFlattenTolerance(0.1 / scale)
+	}
 }
 
 // convertGGPathToCorePath converts a gg.Path to raster.PathLike.
@@ -597,10 +619,13 @@ func (r *SoftwareRenderer) Stroke(pixmap *Pixmap, p *Path, paint *Paint) error {
 	}
 
 	// Create stroke expander with tight tolerance for smooth curves.
-	// 0.025 px produces ~128 segments per circle — eliminates visible
-	// polygon faceting on small UI circles (radio buttons, checkboxes).
+	// 0.1 px base tolerance; on HiDPI, divide by deviceScale for finer curves.
 	expander := stroke.NewStrokeExpander(strokeStyle)
-	expander.SetTolerance(0.1)
+	strokeTol := float64(0.1)
+	if r.deviceScale > 1.0 {
+		strokeTol = 0.1 / float64(r.deviceScale)
+	}
+	expander.SetTolerance(strokeTol)
 
 	// Expand stroke to fill path
 	expandedElements := expander.Expand(strokeElements)


### PR DESCRIPTION
## Summary

Enterprise HiDPI/Retina support for the 2D graphics library.

- **Cairo-pattern device scale**: `SetDeviceScale()` applies permanent base transform — user draws in logical coords, pixmap allocated at physical resolution
- **New API**: `WithDeviceScale()`, `DeviceScale()`, `PixelWidth()`/`PixelHeight()`, `SetDeviceScale()`
- **DPI-aware rasterization**: curve flatten tolerance and stroke expansion scale with device DPI (femtovg pattern)
- **ggcanvas auto-detection**: `New()` auto-detects HiDPI scale from `gpucontext.WindowProvider` — no manual scale needed
- **ggcanvas explicit control**: `NewWithScale()`, `MustNewWithScale()`, `DeviceScale()`, `SetDeviceScale()`

Related: [#171](https://github.com/gogpu/gg/issues/171), [#175](https://github.com/gogpu/gg/issues/175)

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run` — 0 issues
- [x] `go fmt` clean
- [x] 8 new unit tests for device scale (`context_device_scale_test.go`)
- [x] Visual verification: basic, shapes, gogpu_integration, UI hello
- [ ] CI green
