### PR TITLE
fix: GPU pipeline diagnostic logging for HiDPI debugging (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.1] - 2026-03-11
+
+### Added
+
+- **GPU pipeline diagnostic logging** — comprehensive structured `slog` logging
+  across the entire GPU rendering dimensional handoff chain. All logs are
+  zero-cost when disabled (default `nopHandler`). Enable via `gg.SetLogger()`.
+  ([#171](https://github.com/gogpu/gg/issues/171))
+  - `NewContext` / `SetDeviceScale` — log logical/physical dimensions and scale
+  - `ggcanvas.NewWithScale` — log canvas creation with logical, scale, physical dims
+  - `ggcanvas.RenderDirect` — log surface dimensions per frame
+  - `SetDeviceProvider` — log shared GPU device type on success
+  - `SetSurfaceTarget` — log surface dimensions and mode/size changes
+  - `RenderFrame` — log effective viewport dimensions (target vs surface override)
+  - `EnsureTextures` — log MSAA/stencil texture creation dimensions
+  - `FlushGPU` — log target dimensions on entry
+  - `makeSDFRenderUniform` — log viewport uniform dimensions passed to shader
+  - `Flush` — log pending shape counts per tier and pipeline mode
+
+### Fixed
+
+- **`ggcanvas.NewWithScale` no longer silently discards `SetAcceleratorDeviceProvider`
+  errors** — now logs `Warn` on failure instead of `_ =` discard.
+
 ## [0.34.0] - 2026-03-11
 
 ### Added

--- a/context.go
+++ b/context.go
@@ -119,6 +119,14 @@ func NewContext(width, height int, opts ...ContextOption) *Context {
 		baseMatrix = Scale(scale, scale)
 	}
 
+	if scale != 1.0 {
+		Logger().Info("NewContext HiDPI",
+			"logical_w", width, "logical_h", height,
+			"scale", scale,
+			"physical_w", pw, "physical_h", ph,
+		)
+	}
+
 	return &Context{
 		width:          width,
 		height:         height,
@@ -308,6 +316,12 @@ func (c *Context) SetDeviceScale(scale float64) {
 	// Physical dimensions
 	pw := int(float64(c.width) * scale)
 	ph := int(float64(c.height) * scale)
+
+	Logger().Info("SetDeviceScale",
+		"old_scale", oldScale, "new_scale", scale,
+		"logical_w", c.width, "logical_h", c.height,
+		"physical_w", pw, "physical_h", ph,
+	)
 
 	// Reallocate pixmap at new physical resolution
 	c.pixmap = NewPixmap(pw, ph)
@@ -916,7 +930,12 @@ func (c *Context) FlushGPU() error {
 	if a == nil {
 		return nil
 	}
-	return a.Flush(c.gpuRenderTarget())
+	t := c.gpuRenderTarget()
+	Logger().Debug("FlushGPU",
+		"target_w", t.Width, "target_h", t.Height,
+		"stride", t.Stride,
+	)
+	return a.Flush(t)
 }
 
 // gpuRenderTarget returns the current context's pixel buffer as a GPU render target.

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -104,10 +104,20 @@ func NewWithScale(provider gpucontext.DeviceProvider, width, height int, scale f
 		scale = 1.0
 	}
 
+	physW := int(float64(width) * scale)
+	physH := int(float64(height) * scale)
+	gg.Logger().Info("ggcanvas.NewWithScale",
+		"logical_w", width, "logical_h", height,
+		"scale", scale,
+		"physical_w", physW, "physical_h", physH,
+	)
+
 	// Share GPU device with accelerator if registered.
 	// Error is non-fatal: accelerator may not support device sharing or
 	// provider may not implement HalProvider. GPU will initialize its own device.
-	_ = gg.SetAcceleratorDeviceProvider(provider)
+	if err := gg.SetAcceleratorDeviceProvider(provider); err != nil {
+		gg.Logger().Warn("SetAcceleratorDeviceProvider failed", "err", err)
+	}
 
 	var opts []gg.ContextOption
 	if scale != 1.0 {
@@ -349,6 +359,11 @@ func (c *Canvas) RenderDirect(surfaceView any, width, height uint32) error {
 	if !c.dirty {
 		return nil
 	}
+
+	gg.Logger().Debug("ggcanvas.RenderDirect",
+		"width", width, "height", height,
+		"hasSurfaceView", surfaceView != nil,
+	)
 
 	// Configure GPU accelerator for direct surface rendering.
 	// The surface target stays set between frames to avoid destroying

--- a/internal/gpu/gpu_textures.go
+++ b/internal/gpu/gpu_textures.go
@@ -128,6 +128,11 @@ func (ts *textureSet) ensureTextures(device hal.Device, w, h uint32, labelPrefix
 
 	ts.width = w
 	ts.height = h
+	slogger().Info("created offscreen textures",
+		"label", labelPrefix,
+		"width", w, "height", h,
+		"msaa_samples", sampleCount,
+	)
 	return nil
 }
 
@@ -206,6 +211,11 @@ func (ts *textureSet) ensureSurfaceTextures(device hal.Device, w, h uint32, labe
 	// No resolve texture -- surface view is the resolve target.
 	ts.width = w
 	ts.height = h
+	slogger().Info("created surface textures",
+		"label", labelPrefix,
+		"width", w, "height", h,
+		"msaa_samples", sampleCount,
+	)
 	return nil
 }
 

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -163,6 +163,13 @@ func (s *GPURenderSession) SetSurfaceTarget(view hal.TextureView, width, height 
 	s.surfaceView = view
 	s.surfaceWidth = width
 	s.surfaceHeight = height
+	if modeChanged || sizeChanged {
+		slogger().Debug("GPURenderSession.SetSurfaceTarget changed",
+			"surface", view != nil,
+			"width", width, "height", height,
+			"modeChanged", modeChanged, "sizeChanged", sizeChanged,
+		)
+	}
 }
 
 // RenderMode returns the current render mode based on whether a surface
@@ -222,6 +229,11 @@ func (s *GPURenderSession) RenderFrame(
 	if s.surfaceView != nil && s.surfaceWidth > 0 && s.surfaceHeight > 0 {
 		w, h = s.surfaceWidth, s.surfaceHeight
 	}
+	slogger().Debug("RenderFrame dimensions",
+		"target_w", target.Width, "target_h", target.Height,
+		"effective_w", w, "effective_h", h,
+		"surface", s.surfaceView != nil,
+	)
 	if err := s.EnsureTextures(w, h); err != nil {
 		return fmt.Errorf("ensure textures: %w", err)
 	}

--- a/internal/gpu/sdf_gpu.go
+++ b/internal/gpu/sdf_gpu.go
@@ -270,7 +270,9 @@ func (a *SDFAccelerator) SetDeviceProvider(provider any) error {
 	// Initialize internal VelloAccelerator with the shared device for compute routing.
 	a.initVelloAccelerator(device, queue)
 
-	slogger().Debug("switched to shared GPU device")
+	slogger().Info("switched to shared GPU device",
+		"adapter", fmt.Sprintf("%T", device),
+	)
 	return nil
 }
 
@@ -297,6 +299,7 @@ func (a *SDFAccelerator) SetSurfaceTarget(view any, width, height uint32) {
 		return
 	}
 	a.session.SetSurfaceTarget(halView, width, height)
+	slogger().Debug("SetSurfaceTarget configured", "width", width, "height", height)
 }
 
 // DrawText queues text for GPU MSDF rendering. The face parameter must be a
@@ -614,6 +617,14 @@ func (a *SDFAccelerator) Flush(target gg.GPURenderTarget) error {
 
 	// Determine effective mode for this flush.
 	effectiveMode := a.effectivePipelineMode()
+
+	slogger().Debug("Flush",
+		"sdf", len(a.pendingShapes),
+		"convex", len(a.pendingConvexCommands),
+		"stencil", len(a.pendingStencilPaths),
+		"text", len(a.pendingTextBatches),
+		"mode", effectiveMode,
+	)
 
 	// Reset scene stats for the next frame.
 	a.sceneStats = gg.SceneStats{}

--- a/internal/gpu/sdf_render.go
+++ b/internal/gpu/sdf_render.go
@@ -731,5 +731,6 @@ func makeSDFRenderUniform(w, h uint32) []byte {
 	binary.LittleEndian.PutUint32(buf[0:4], math.Float32bits(float32(w)))
 	binary.LittleEndian.PutUint32(buf[4:8], math.Float32bits(float32(h)))
 	// Padding bytes 8..15 remain zero.
+	slogger().Debug("SDF uniform viewport", "width", w, "height", h)
 	return buf
 }


### PR DESCRIPTION
## Summary

- Add comprehensive structured `slog` diagnostic logging across the entire GPU rendering dimensional handoff chain for remote HiDPI/Retina debugging (#171)
- Fix silent error discard in `ggcanvas.NewWithScale` — `SetAcceleratorDeviceProvider` errors now logged as `Warn`
- All logs are zero-cost when disabled (default `nopHandler`). Enable via `gg.SetLogger(slog.Default())`

## Logging points added

| Location | Level | What |
|----------|-------|------|
| `NewContext` / `SetDeviceScale` | Info | logical/physical dims, scale |
| `ggcanvas.NewWithScale` | Info | canvas creation dims + scale |
| `ggcanvas.RenderDirect` | Debug | surface dimensions per frame |
| `SetDeviceProvider` | Info | shared GPU device type |
| `SetSurfaceTarget` | Debug | surface dims, mode/size changes |
| `RenderFrame` | Debug | target vs effective viewport dims |
| `EnsureTextures` | Info | MSAA/stencil texture creation dims |
| `FlushGPU` | Debug | target dimensions on entry |
| `makeSDFRenderUniform` | Debug | viewport uniform dims to shader |
| `Flush` | Debug | pending shape counts + pipeline mode |

## Motivation

@sverrehu reported that the v0.34.0 HiDPI fix did not resolve Retina rendering issues (#171). The entire dimensional handoff chain (canvas creation → device provider → surface target → MSAA textures → shader uniforms) had zero logging points, making remote diagnosis impossible.

## Test plan

- [x] `go build ./...` — pass
- [x] `go test ./...` — pass
- [x] `golangci-lint run` — 0 issues
- [ ] CI green
