### PR TITLE
chore: update examples dependencies (gg v0.35.1)

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.34.0
+	github.com/gogpu/gg v0.35.1
 	github.com/gogpu/gogpu v0.23.0
 	github.com/gogpu/gpucontext v0.9.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU
 github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.2 h1:phQCeD5zY8jTgNjkrs090JYUMpqNPO7a9DMXvnHcQ2A=
 github.com/go-webgpu/webgpu v0.4.2/go.mod h1:+gz9PjcckFCZ/Gv1vJXXEDrf7fqo7VHH6uV0nJrSuRk=
-github.com/gogpu/gg v0.34.0 h1:jRgiG6h3aBBy6Lfw7C5oJxv5Fzp9kdFYqfzfFwbbT6A=
-github.com/gogpu/gg v0.34.0/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
+github.com/gogpu/gg v0.35.1 h1:WE9JC9YekYIkR5DScFcOR3UAFKZnmkwYlgg/n4Kbnck=
+github.com/gogpu/gg v0.35.1/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
 github.com/gogpu/gogpu v0.23.0 h1:2gIovi+tRoeGm4gtfL0WUsQe077QLH3NRiUH6Odda/U=
 github.com/gogpu/gogpu v0.23.0/go.mod h1:cRElQjIvz0rGcUvYdn1dHhCs7voVQgKLevs64swNyW4=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25
 
-require github.com/gogpu/gg v0.34.0
+require github.com/gogpu/gg v0.35.1
 
 require (
 	github.com/go-text/typesetting v0.3.3 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4
 github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.34.0 h1:jRgiG6h3aBBy6Lfw7C5oJxv5Fzp9kdFYqfzfFwbbT6A=
-github.com/gogpu/gg v0.34.0/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
+github.com/gogpu/gg v0.35.1 h1:WE9JC9YekYIkR5DScFcOR3UAFKZnmkwYlgg/n4Kbnck=
+github.com/gogpu/gg v0.35.1/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
 golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
 golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=


### PR DESCRIPTION
Update both examples to gg v0.35.1:
- `examples/gogpu_integration`: v0.34.0 → v0.35.1
- `examples/sdf`: v0.34.0 → v0.35.1