### PR TITLE
chore: update examples dependencies (gogpu v0.23.1)

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/gogpu/gg v0.35.1
-	github.com/gogpu/gogpu v0.23.0
+	github.com/gogpu/gogpu v0.23.1
 	github.com/gogpu/gpucontext v0.9.0
 )
 

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.2 h1:phQCeD5zY8jTgNjkrs090JYUMpqNPO7a9DMXvnHcQ2
 github.com/go-webgpu/webgpu v0.4.2/go.mod h1:+gz9PjcckFCZ/Gv1vJXXEDrf7fqo7VHH6uV0nJrSuRk=
 github.com/gogpu/gg v0.35.1 h1:WE9JC9YekYIkR5DScFcOR3UAFKZnmkwYlgg/n4Kbnck=
 github.com/gogpu/gg v0.35.1/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
-github.com/gogpu/gogpu v0.23.0 h1:2gIovi+tRoeGm4gtfL0WUsQe077QLH3NRiUH6Odda/U=
-github.com/gogpu/gogpu v0.23.0/go.mod h1:cRElQjIvz0rGcUvYdn1dHhCs7voVQgKLevs64swNyW4=
+github.com/gogpu/gogpu v0.23.1 h1:lVdU9/18a1Td3ej66ng3l10MAVuQdaDA50ATHEHfzJw=
+github.com/gogpu/gogpu v0.23.1/go.mod h1:cRElQjIvz0rGcUvYdn1dHhCs7voVQgKLevs64swNyW4=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=

--- a/examples/gogpu_integration/main.go
+++ b/examples/gogpu_integration/main.go
@@ -19,8 +19,8 @@
 // only while animation is active. Press Space to pause/resume.
 //
 // Requirements:
-//   - gogpu v0.23.0+
-//   - gg v0.34.0+
+//   - gogpu v0.23.1+
+//   - gg v0.35.1+
 package main
 
 import (


### PR DESCRIPTION
## Summary

- Update `gogpu` dependency `v0.23.0` → `v0.23.1` in `examples/gogpu_integration`
- Update version requirements in `main.go` comments (`gogpu v0.23.1+`, `gg v0.35.1+`)

v0.23.1 fixes macOS Retina CAMetalLayer frame/bounds not set ([gogpu release](https://github.com/gogpu/gogpu/releases/tag/v0.23.1), related: #171).

## Test plan

- [ ] CI passes (build, test, lint, cross-compile)
- [ ] `examples/gogpu_integration` builds with `GOWORK=off go build ./...`
