### PR TITLE
chore: update gg v0.35.3 in examples (FontID collision fix)

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,10 +3,9 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25
 
 require (
-	github.com/gogpu/gg v0.35.2
+	github.com/gogpu/gg v0.35.3
 	github.com/gogpu/gogpu v0.23.2
 	github.com/gogpu/gpucontext v0.9.0
-	golang.org/x/image v0.36.0
 )
 
 require (
@@ -16,6 +15,7 @@ require (
 	github.com/gogpu/gputypes v0.3.0 // indirect
 	github.com/gogpu/naga v0.14.6 // indirect
 	github.com/gogpu/wgpu v0.20.1 // indirect
+	golang.org/x/image v0.36.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU
 github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.2 h1:phQCeD5zY8jTgNjkrs090JYUMpqNPO7a9DMXvnHcQ2A=
 github.com/go-webgpu/webgpu v0.4.2/go.mod h1:+gz9PjcckFCZ/Gv1vJXXEDrf7fqo7VHH6uV0nJrSuRk=
-github.com/gogpu/gg v0.35.2 h1:hgbvA/O4/oZuJ/Ld9MAK2kBX6vu1OiWyeK5E/NTWqdA=
-github.com/gogpu/gg v0.35.2/go.mod h1:z3pNk7MjWyARYyEeEeYrxOsP0LOt9g5GExMQSuvGPoM=
+github.com/gogpu/gg v0.35.3 h1:+b75tBszZ93weYn2TSyzfaAMAsAHGZIEAfOwSNPl/SU=
+github.com/gogpu/gg v0.35.3/go.mod h1:z3pNk7MjWyARYyEeEeYrxOsP0LOt9g5GExMQSuvGPoM=
 github.com/gogpu/gogpu v0.23.2 h1:hYr1MNtrtWqSjdTeEmkz7sIINzaO6n6lLxQkHBExvDc=
 github.com/gogpu/gogpu v0.23.2/go.mod h1:cRElQjIvz0rGcUvYdn1dHhCs7voVQgKLevs64swNyW4=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25
 
-require github.com/gogpu/gg v0.35.1
+require github.com/gogpu/gg v0.35.3
 
 require (
 	github.com/go-text/typesetting v0.3.3 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4
 github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.35.1 h1:WE9JC9YekYIkR5DScFcOR3UAFKZnmkwYlgg/n4Kbnck=
-github.com/gogpu/gg v0.35.1/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
+github.com/gogpu/gg v0.35.3 h1:+b75tBszZ93weYn2TSyzfaAMAsAHGZIEAfOwSNPl/SU=
+github.com/gogpu/gg v0.35.3/go.mod h1:z3pNk7MjWyARYyEeEeYrxOsP0LOt9g5GExMQSuvGPoM=
 golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
 golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=


### PR DESCRIPTION
Update gg dependency to v0.35.3 in examples (gogpu_integration, sdf).