### PR TITLE
test: add FontID collision regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collisions: Bold glyphs silently overwrote Regular glyphs (or vice versa), resulting
   in per-glyph weight inconsistency when rendering mixed-font text.
 
+### Added
+
+- Regression test for FontID collision (GoRegular vs GoBold same-family detection)
+
 ### Changed
 
 - Update gogpu v0.23.1 → v0.23.2 in examples (Retina contentsScale fix)

--- a/internal/gpu/gpu_text_test.go
+++ b/internal/gpu/gpu_text_test.go
@@ -1,0 +1,63 @@
+//go:build !nogpu
+
+package gpu
+
+import (
+	"testing"
+
+	"github.com/gogpu/gg/text"
+	"golang.org/x/image/font/gofont/gobold"
+	"golang.org/x/image/font/gofont/goregular"
+)
+
+func TestComputeFontID_DifferentFontsInSameFamily(t *testing.T) {
+	srcRegular, err := text.NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load GoRegular: %v", err)
+	}
+	srcBold, err := text.NewFontSource(gobold.TTF)
+	if err != nil {
+		t.Fatalf("failed to load GoBold: %v", err)
+	}
+
+	// Precondition: both fonts share the same family name and glyph count.
+	if srcRegular.Name() != srcBold.Name() {
+		t.Skipf("fonts have different family names (%q vs %q), test not applicable",
+			srcRegular.Name(), srcBold.Name())
+	}
+	if srcRegular.Parsed().NumGlyphs() != srcBold.Parsed().NumGlyphs() {
+		t.Skipf("fonts have different glyph counts (%d vs %d), test not applicable",
+			srcRegular.Parsed().NumGlyphs(), srcBold.Parsed().NumGlyphs())
+	}
+
+	idRegular := computeFontID(srcRegular)
+	idBold := computeFontID(srcBold)
+
+	if idRegular == idBold {
+		t.Errorf("GoRegular and GoBold must have different FontIDs to avoid atlas cache collision\n"+
+			"  GoRegular: name=%q fullName=%q numGlyphs=%d fontID=%d\n"+
+			"  GoBold:    name=%q fullName=%q numGlyphs=%d fontID=%d",
+			srcRegular.Name(), srcRegular.Parsed().FullName(), srcRegular.Parsed().NumGlyphs(), idRegular,
+			srcBold.Name(), srcBold.Parsed().FullName(), srcBold.Parsed().NumGlyphs(), idBold)
+	}
+}
+
+func TestComputeFontID_NilSource(t *testing.T) {
+	id := computeFontID(nil)
+	if id != 0 {
+		t.Errorf("nil source should return 0, got %d", id)
+	}
+}
+
+func TestComputeFontID_SameFontStableID(t *testing.T) {
+	src, err := text.NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load GoRegular: %v", err)
+	}
+
+	id1 := computeFontID(src)
+	id2 := computeFontID(src)
+	if id1 != id2 {
+		t.Errorf("same font source should produce stable ID: %d != %d", id1, id2)
+	}
+}


### PR DESCRIPTION
Regression test for PR #186 — ensures GoRegular and GoBold produce different FontIDs despite sharing the same family name and glyph count.