### PR TITLE
feat: GPU Glyph Mask Cache (Tier 6) — TEXT-010

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **GPU Glyph Mask Cache (Tier 6) — Phase 1+2** — enterprise text rendering pipeline
-  following the Skia/Chrome/DirectWrite pattern: CPU rasterizes glyphs at exact pixel
-  sizes via AnalyticFiller (256-level AA coverage), packs into R8 alpha atlas with shelf
-  allocator and LRU eviction, uploads to GPU as R8Unorm textures, composites via textured
-  quads in the render pass. Foundation for future ClearType (TEXT-011) and font hinting
-  (TEXT-012).
+- **GPU Glyph Mask Cache (Tier 6)** — enterprise text rendering pipeline following
+  the Skia/Chrome/DirectWrite pattern: CPU rasterizes glyphs at exact pixel sizes via
+  AnalyticFiller (256-level AA coverage), packs into R8 alpha atlas with shelf allocator
+  and LRU eviction, uploads to GPU as R8Unorm textures, composites via textured quads
+  in the render pass. Foundation for future ClearType (TEXT-011) and font hinting (TEXT-012).
   - `text/glyph_mask_atlas.go` — R8 atlas with shelf packing, LRU cache, dirty page tracking
   - `text/glyph_mask_rasterizer.go` — CPU glyph rasterization at exact device pixel size
   - `internal/gpu/glyph_mask_engine.go` — bridge between text shaping and GPU atlas
   - `internal/gpu/glyph_mask_pipeline.go` — Tier 6 GPU render pipeline
   - `internal/gpu/shaders/glyph_mask.wgsl` — R8 atlas sampling shader
   - Subpixel positioning (1/4 pixel, 16 variants per glyph)
+  - `TextModeGlyphMask` text mode + auto-selection: horizontal text ≤48px → GlyphMask,
+    else MSDF (Tier 4)
+  - `GPUGlyphMaskAccelerator` interface in `accelerator.go`
+
+### Fixed
+
+- **Glyph mask rasterizer Y-coordinate inversion** — `GlyphMaskRasterizer` applied an
+  unnecessary Y-flip to outline coordinates, but `sfnt.LoadGlyph` already returns Y-down
+  (screen convention). Glyphs in the R8 atlas were vertically flipped, causing mirrored
+  text appearance.
+- **Glyph mask text invisible on first frame** — `buildGlyphMaskResources` incorrectly
+  invalidated bind groups when creating vertex/index buffers. Bind groups reference
+  (uniform buffer, atlas texture, sampler) — not vertex/index buffers — so the
+  invalidation destroyed bind groups that were just configured by `syncGlyphMaskAtlases`,
+  causing all glyph mask draw calls to be skipped on the first render.
 
 ## [0.35.3] - 2026-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **GPU Glyph Mask Cache (Tier 6) — Phase 1+2** — enterprise text rendering pipeline
+  following the Skia/Chrome/DirectWrite pattern: CPU rasterizes glyphs at exact pixel
+  sizes via AnalyticFiller (256-level AA coverage), packs into R8 alpha atlas with shelf
+  allocator and LRU eviction, uploads to GPU as R8Unorm textures, composites via textured
+  quads in the render pass. Foundation for future ClearType (TEXT-011) and font hinting
+  (TEXT-012).
+  - `text/glyph_mask_atlas.go` — R8 atlas with shelf packing, LRU cache, dirty page tracking
+  - `text/glyph_mask_rasterizer.go` — CPU glyph rasterization at exact device pixel size
+  - `internal/gpu/glyph_mask_engine.go` — bridge between text shaping and GPU atlas
+  - `internal/gpu/glyph_mask_pipeline.go` — Tier 6 GPU render pipeline
+  - `internal/gpu/shaders/glyph_mask.wgsl` — R8 atlas sampling shader
+  - Subpixel positioning (1/4 pixel, 16 variants per glyph)
+
 ## [0.35.3] - 2026-03-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 <p align="center">
   <video src="https://github.com/user-attachments/assets/34243cff-5434-411c-a17c-3e52a80f1d57" width="100%" autoplay loop muted playsinline>
-    Five-Tier GPU Rendering: SDF shapes, convex polygons, stencil+cover paths, MSDF text, Vello compute pipeline
+    Six-Tier GPU Rendering: SDF shapes, convex polygons, stencil+cover paths, MSDF text, Vello compute pipeline, glyph mask cache
   </video>
   <br>
   <sub>Four-tier GPU rendering: SDF shapes, convex polygons, stencil+cover paths, and MSDF text in a single render pass.
@@ -38,9 +38,9 @@
 
 | Category | Capabilities |
 |----------|--------------|
-| **Rendering** | Immediate and retained mode, five-tier GPU acceleration (SDF, Convex, Stencil+Cover, MSDF Text, Compute), Vello analytic AA, CPU fallback |
+| **Rendering** | Immediate and retained mode, six-tier GPU acceleration (SDF, Convex, Stencil+Cover, MSDF Text, Compute, Glyph Mask), Vello analytic AA, CPU fallback |
 | **Shapes** | Rectangles, circles, ellipses, arcs, bezier curves, polygons, stars |
-| **Text** | TrueType fonts, MSDF rendering with stem darkening, TextMode strategy selection, DPI-aware HiDPI text, transform-aware CPU text (scale/rotate/shear), glyph outline caching, emoji support, bidirectional text, HarfBuzz shaping |
+| **Text** | TrueType fonts, MSDF + glyph mask dual-strategy rendering, TextMode auto-selection, DPI-aware HiDPI text, transform-aware CPU text (scale/rotate/shear), glyph outline caching, emoji support, bidirectional text, HarfBuzz shaping |
 | **Compositing** | 29 blend modes (Porter-Duff, Advanced, HSL), layer isolation |
 | **Images** | 7 pixel formats, PNG/JPEG/WebP I/O, mipmaps, affine transforms |
 | **Vector Export** | Recording system with PDF and SVG backends |
@@ -122,18 +122,20 @@ dc.SetRasterizerMode(gg.RasterizerSparseStrips)
 ### GPU Acceleration (Optional)
 
 gg supports optional GPU acceleration through the `GPUAccelerator` interface with
-a five-tier rendering pipeline:
+a six-tier rendering pipeline:
 
 | Tier | Method | Best For |
 |------|--------|----------|
 | **SDF** | Signed Distance Field | Circles, ellipses, rectangles, rounded rects |
 | **Convex** | Direct vertex emission | Convex polygons, single draw call |
 | **Stencil+Cover** | Fan tessellation + stencil buffer | Arbitrary complex paths, EvenOdd/NonZero fill |
-| **MSDF Text** | Multi-channel Signed Distance Field | Resolution-independent anti-aliased text |
+| **MSDF Text** | Multi-channel Signed Distance Field | Dynamic/animated text, resolution-independent |
 | **Compute** | 9-stage Vello compute pipeline | Full scenes with many paths (GPU parallel rasterization) |
+| **Glyph Mask** | CPU-rasterized R8 alpha atlas | Static UI text ≤48px, pixel-perfect quality |
 
-Tiers 1–4 use a render-pass pipeline; Tier 5 uses compute shaders dispatched
-via `PipelineMode` (Auto/RenderPass/Compute).
+Tiers 1–4, 6 use a render-pass pipeline; Tier 5 uses compute shaders dispatched
+via `PipelineMode` (Auto/RenderPass/Compute). Text auto-selection routes horizontal
+text ≤48px to Glyph Mask (Skia/Chrome pattern), else MSDF.
 
 When no GPU is registered, rendering uses the high-quality CPU rasterizer (default).
 

--- a/accelerator.go
+++ b/accelerator.go
@@ -153,6 +153,33 @@ type GPUTextAccelerator interface {
 	DrawText(target GPURenderTarget, face any, text string, x, y float64, color RGBA, matrix Matrix, deviceScale float64) error
 }
 
+// GPUGlyphMaskAccelerator is an optional interface for accelerators that
+// support Tier 6 glyph mask text rendering. When the registered accelerator
+// implements this interface, Context.DrawString routes small horizontal text
+// through the glyph mask pipeline instead of MSDF.
+//
+// Glyph mask rendering CPU-rasterizes glyphs at the exact device pixel size
+// into an R8 alpha atlas, then draws them as textured quads on the GPU. This
+// produces pixel-perfect hinted text for horizontal layouts at small sizes
+// (typically <48px), matching the quality of native platform text renderers.
+//
+// The MSDF pipeline (GPUTextAccelerator) remains the preferred path for
+// rotated, scaled, or large text where resolution-independence matters.
+type GPUGlyphMaskAccelerator interface {
+	// DrawGlyphMaskText renders text at position (x, y) in user space where
+	// y is the baseline. The face provides font metrics and glyph iteration.
+	//
+	// The paint parameter provides the text color. The matrix parameter is
+	// the context's current transformation matrix (CTM). The deviceScale
+	// parameter is the ratio of physical to logical pixels.
+	//
+	// viewportW and viewportH are the viewport dimensions for building the
+	// ortho projection in the vertex shader.
+	//
+	// Returns ErrFallbackToCPU if glyph mask rendering is not available.
+	DrawGlyphMaskText(target GPURenderTarget, face any, s string, x, y float64, color RGBA, matrix Matrix, deviceScale float64) error
+}
+
 var (
 	accelMu sync.RWMutex
 	accel   GPUAccelerator

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,21 +69,23 @@ Optional extension interfaces for gogpu integration:
 - **DeviceProviderAware** -- share GPU device with an external provider (e.g., gogpu window)
 - **SurfaceTargetAware** -- render directly to a surface texture view (zero-copy windowed rendering)
 
-### Five-Tier GPU Rendering
+### Six-Tier GPU Rendering
 
 The GPU accelerator in `internal/gpu/` uses a unified render session (`GPURenderSession`) that
-dispatches shapes and text to five rendering tiers:
+dispatches shapes and text to six rendering tiers:
 
 | Tier | Name | Content | Technique |
 |------|------|---------|-----------|
 | **1** | SDF | Circles, ellipses, rounded rects | SDF shader evaluation per-pixel |
 | **2a** | Convex | Convex polygons | Fan tessellation (no stencil needed) |
 | **2b** | Stencil+Cover | Arbitrary paths | Stencil buffer for winding, then cover pass |
-| **4** | MSDF Text | Text glyphs | Multi-channel SDF with median+smoothstep shader |
+| **4** | MSDF Text | Text glyphs (dynamic/animated) | Multi-channel SDF with median+smoothstep shader |
 | **5** | Compute | Full scenes (many paths) | Vello-style 9-stage compute pipeline (GPU or CPU fallback) |
+| **6** | Glyph Mask | Text glyphs (static/UI, ≤48px) | CPU-rasterized R8 alpha atlas, GPU textured quads |
 
-Tiers 1–4 use a render-pass pipeline (one render pass, multiple pipeline switches).
+Tiers 1–4, 6 use a render-pass pipeline (one render pass, multiple pipeline switches).
 Tier 5 uses a compute-only pipeline (9 dispatch stages, no render pass).
+Auto-selection routes horizontal text ≤48px to Tier 6 (pixel-perfect), else Tier 4 (scalable MSDF).
 
 This mirrors enterprise engines (Skia Ganesh/Graphite, Flutter Impeller, Gio).
 
@@ -397,7 +399,7 @@ gg/
 │   │   ├── path_geometry.go    # Y-monotonic curve chopping
 │   │   └── scene_adapter.go   # Scene to raster bridge
 │   │
-│   ├── gpu/                # GPU rendering pipeline (five-tier) + tile rasterizers
+│   ├── gpu/                # GPU rendering pipeline (six-tier) + tile rasterizers
 │   │   ├── backend.go      # GPU backend implementation
 │   │   ├── sdf_gpu.go      # SDFAccelerator (GPU-based, wgpu HAL, ForceSDFAware)
 │   │   ├── sdf_render.go   # SDF render pipeline (Tier 1)
@@ -424,6 +426,8 @@ gg/
 │   │   ├── texture.go      # Texture with lazy default view
 │   │   ├── buffer.go       # Buffer with async mapping
 │   │   ├── text_pipeline.go    # MSDF text rendering pipeline (Tier 4)
+│   │   ├── glyph_mask_engine.go   # Glyph mask engine (Tier 6, shaping → atlas → quads)
+│   │   ├── glyph_mask_pipeline.go # Glyph mask GPU pipeline (Tier 6, R8 alpha atlas)
 │   │   ├── vello_accelerator.go  # VelloAccelerator (Tier 5 compute integration)
 │   │   ├── vello_compute.go     # VelloComputeDispatcher (hal-based GPU dispatch)
 │   │   ├── scene_bridge.go # Scene to native bridge
@@ -745,7 +749,7 @@ gg and gogpu are **independent libraries** that can interoperate via gpucontext:
 |---------|--------|----------------|
 | **Scene Delegation** | Qt/Skia/Vello/Flutter | Scene orchestrates tiles, SoftwareRenderer rasterizes |
 | **GPU Accelerator** | gg v0.26.0 | Opt-in GPU via `import _ "github.com/gogpu/gg/gpu"` |
-| **Five-Tier Rendering** | Skia Ganesh/Impeller/Vello | SDF, convex, stencil+cover, MSDF text (render pass) + compute pipeline |
+| **Six-Tier Rendering** | Skia Ganesh/Impeller/Vello | SDF, convex, stencil+cover, MSDF text, glyph mask (render pass) + compute pipeline |
 | **9-Stage Compute** | vello | pathtag→draw→path_count→backdrop→coarse→path_tiling→fine GPU compute |
 | **SDF Shape Rendering** | Shadertoy/GPU Gems | Per-pixel signed distance field for circles/rrects |
 | **Stencil-Then-Cover** | GPU Gems 3, NV_path_rendering | Winding via stencil buffer, then cover fill |

--- a/internal/gpu/glyph_mask_engine.go
+++ b/internal/gpu/glyph_mask_engine.go
@@ -1,0 +1,306 @@
+//go:build !nogpu
+
+package gpu
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math"
+	"sync"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/text"
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+)
+
+// GlyphMaskEngine manages the CPU-rasterized glyph mask atlas and produces
+// GPU-ready GlyphMaskBatch data for Tier 6 rendering. It bridges the text
+// shaping infrastructure (Face, Glyph) with the GPU glyph mask pipeline
+// (GlyphMaskBatch, GlyphMaskQuad).
+//
+// Usage flow:
+//  1. Call LayoutText to convert a string into a GlyphMaskBatch (shapes glyphs,
+//     rasterizes missing glyphs into the R8 atlas, builds quads).
+//  2. Before rendering, call SyncAtlasTextures to upload dirty atlas pages
+//     to GPU textures.
+//  3. Pass the resulting GlyphMaskBatch slice to RenderFrame.
+//
+// GlyphMaskEngine is safe for concurrent use.
+type GlyphMaskEngine struct {
+	mu sync.Mutex
+
+	atlas      *text.GlyphMaskAtlas
+	rasterizer *text.GlyphMaskRasterizer
+
+	// GPU textures for atlas pages. Index matches atlas page index.
+	pageTextures []hal.Texture
+	pageViews    []hal.TextureView
+}
+
+// NewGlyphMaskEngine creates a new glyph mask engine with the default atlas
+// configuration.
+func NewGlyphMaskEngine() *GlyphMaskEngine {
+	return &GlyphMaskEngine{
+		atlas:      text.NewGlyphMaskAtlasDefault(),
+		rasterizer: text.NewGlyphMaskRasterizer(),
+	}
+}
+
+// LayoutText converts a text string with font face into a GPU-ready
+// GlyphMaskBatch. The text is shaped into glyphs, each glyph is rasterized
+// (or retrieved from cache) into the R8 alpha atlas, and GlyphMaskQuads are
+// produced with screen-space positions and atlas UV coordinates.
+//
+// Parameters:
+//   - face: font face (provides glyph iteration and metrics)
+//   - s: the string to render
+//   - x, y: baseline origin in user-space coordinates
+//   - color: text color as gg.RGBA
+//   - viewportW, viewportH: viewport dimensions for building the ortho projection
+//   - matrix: the context's current transformation matrix (CTM)
+//   - deviceScale: DPI scale factor (e.g., 2.0 on Retina)
+//
+// The returned GlyphMaskBatch contains quads in user-space coordinates. The
+// Transform field is set to CTM x ortho_projection so the vertex shader
+// transforms positions from user space to clip space.
+func (e *GlyphMaskEngine) LayoutText(
+	face text.Face,
+	s string,
+	x, y float64,
+	color gg.RGBA,
+	viewportW, viewportH int,
+	matrix gg.Matrix,
+	deviceScale float64,
+) (GlyphMaskBatch, error) {
+	if face == nil || s == "" {
+		return GlyphMaskBatch{}, nil
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	fontSize := face.Size() * deviceScale
+	if fontSize <= 0 {
+		fontSize = face.Size()
+	}
+	fontSource := face.Source()
+	fontID := computeGlyphMaskFontID(fontSource)
+	parsed := fontSource.Parsed()
+
+	// Premultiply color for per-vertex embedding.
+	premul := color.Premultiply()
+	vertColor := [4]float32{
+		float32(premul.R), float32(premul.G),
+		float32(premul.B), float32(premul.A),
+	}
+
+	var quads []GlyphMaskQuad
+
+	for glyph := range face.Glyphs(s) {
+		// Compute subpixel position (fractional part of absolute position).
+		absX := x + glyph.X
+		absY := y + glyph.Y
+		fracX := absX - math.Floor(absX)
+		fracY := absY - math.Floor(absY)
+
+		key := text.MakeGlyphMaskKey(fontID, glyph.GID, fontSize, fracX, fracY)
+
+		// GetOrRasterize: cache hit returns immediately, miss triggers
+		// CPU rasterization via AnalyticFiller.
+		region, err := e.atlas.GetOrRasterize(key, func() ([]byte, int, int, float32, float32, error) {
+			result, rErr := e.rasterizer.Rasterize(parsed, glyph.GID, fontSize, fracX, fracY)
+			if rErr != nil {
+				return nil, 0, 0, 0, 0, rErr
+			}
+			if result == nil {
+				return nil, 0, 0, 0, 0, nil // empty glyph (space)
+			}
+			return result.Mask, result.Width, result.Height, result.BearingX, result.BearingY, nil
+		})
+		if err != nil {
+			slogger().Warn("glyph mask rasterize failed", "gid", glyph.GID, "err", err)
+			continue
+		}
+
+		// Empty glyph (e.g., space) — no quad needed.
+		if region.Width <= 0 || region.Height <= 0 {
+			continue
+		}
+
+		// Position the quad in user space using glyph bearings.
+		// BearingX: offset from glyph origin to left edge of mask.
+		// BearingY: offset from baseline to top edge of mask (positive = above).
+		//
+		// The mask was rasterized at deviceScale * fontSize. We need to
+		// convert mask pixel coordinates back to user-space coordinates
+		// by dividing by deviceScale.
+		scale := 1.0 / deviceScale
+		qx0 := float32(absX + float64(region.BearingX)*scale)
+		qy0 := float32(absY - float64(region.BearingY)*scale) // flip Y: bearing is up, screen is down
+		qx1 := qx0 + float32(float64(region.Width)*scale)
+		qy1 := qy0 + float32(float64(region.Height)*scale)
+
+		quads = append(quads, GlyphMaskQuad{
+			X0: qx0, Y0: qy0,
+			X1: qx1, Y1: qy1,
+			U0: region.U0, V0: region.V0,
+			U1: region.U1, V1: region.V1,
+			Color: vertColor,
+		})
+	}
+
+	if len(quads) == 0 {
+		return GlyphMaskBatch{}, nil
+	}
+
+	// Build the composed transform: CTM x ortho_projection.
+	// The ortho projection maps pixel coordinates to NDC [-1, 1]:
+	//   ndc_x = x / w * 2 - 1
+	//   ndc_y = 1 - y / h * 2
+	vw := float64(viewportW)
+	vh := float64(viewportH)
+	ortho := gg.Matrix{
+		A: 2.0 / vw, B: 0, C: -1.0,
+		D: 0, E: -2.0 / vh, F: 1.0,
+	}
+	transform := ortho.Multiply(matrix)
+
+	return GlyphMaskBatch{
+		Quads:          quads,
+		Transform:      transform,
+		AtlasPageIndex: 0, // Currently single page support (first page).
+	}, nil
+}
+
+// SyncAtlasTextures uploads dirty atlas pages to the GPU as R8 textures.
+// Must be called before rendering any glyph mask batches. Creates new
+// textures on first use and re-uploads data when pages are modified.
+func (e *GlyphMaskEngine) SyncAtlasTextures(device hal.Device, queue hal.Queue) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	dirtyPages := e.atlas.DirtyPages()
+	if len(dirtyPages) == 0 {
+		return nil
+	}
+
+	for _, idx := range dirtyPages {
+		r8Data, pageSize, _ := e.atlas.PageR8Data(idx)
+		if r8Data == nil || pageSize == 0 {
+			continue
+		}
+
+		// Ensure texture/view slices are large enough.
+		for len(e.pageTextures) <= idx {
+			e.pageTextures = append(e.pageTextures, nil)
+			e.pageViews = append(e.pageViews, nil)
+		}
+
+		size := uint32(pageSize) //nolint:gosec // atlas size always fits uint32
+
+		// Create texture on first use.
+		if e.pageTextures[idx] == nil {
+			tex, err := device.CreateTexture(&hal.TextureDescriptor{
+				Label:         fmt.Sprintf("glyph_mask_atlas_%d", idx),
+				Size:          hal.Extent3D{Width: size, Height: size, DepthOrArrayLayers: 1},
+				MipLevelCount: 1,
+				SampleCount:   1,
+				Dimension:     gputypes.TextureDimension2D,
+				Format:        gputypes.TextureFormatR8Unorm,
+				Usage:         gputypes.TextureUsageTextureBinding | gputypes.TextureUsageCopyDst,
+			})
+			if err != nil {
+				return fmt.Errorf("create glyph mask atlas texture %d: %w", idx, err)
+			}
+			e.pageTextures[idx] = tex
+
+			view, err := device.CreateTextureView(tex, &hal.TextureViewDescriptor{
+				Label:         fmt.Sprintf("glyph_mask_atlas_%d_view", idx),
+				Format:        gputypes.TextureFormatR8Unorm,
+				Dimension:     gputypes.TextureViewDimension2D,
+				Aspect:        gputypes.TextureAspectAll,
+				MipLevelCount: 1,
+			})
+			if err != nil {
+				return fmt.Errorf("create glyph mask atlas view %d: %w", idx, err)
+			}
+			e.pageViews[idx] = view
+		}
+
+		// Upload R8 data. R8 format = 1 byte per pixel, so BytesPerRow = width.
+		if err := queue.WriteTexture(
+			&hal.ImageCopyTexture{
+				Texture:  e.pageTextures[idx],
+				MipLevel: 0,
+			},
+			r8Data,
+			&hal.ImageDataLayout{
+				Offset:       0,
+				BytesPerRow:  size,
+				RowsPerImage: size,
+			},
+			&hal.Extent3D{Width: size, Height: size, DepthOrArrayLayers: 1},
+		); err != nil {
+			return fmt.Errorf("upload glyph mask atlas %d: %w", idx, err)
+		}
+
+		e.atlas.MarkClean(idx)
+	}
+
+	return nil
+}
+
+// PageTextureView returns the GPU texture view for the given atlas page.
+// Returns nil if the page has not been uploaded.
+func (e *GlyphMaskEngine) PageTextureView(index int) hal.TextureView {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if index < 0 || index >= len(e.pageViews) {
+		return nil
+	}
+	return e.pageViews[index]
+}
+
+// Destroy releases all GPU textures held by the engine.
+func (e *GlyphMaskEngine) Destroy(device hal.Device) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for _, v := range e.pageViews {
+		if v != nil {
+			device.DestroyTextureView(v)
+		}
+	}
+	e.pageViews = nil
+
+	for _, t := range e.pageTextures {
+		if t != nil {
+			device.DestroyTexture(t)
+		}
+	}
+	e.pageTextures = nil
+
+	e.atlas.Clear()
+}
+
+// Atlas returns the underlying glyph mask atlas (for testing/introspection).
+func (e *GlyphMaskEngine) Atlas() *text.GlyphMaskAtlas {
+	return e.atlas
+}
+
+// computeGlyphMaskFontID generates a stable hash identifier for a font source.
+// Uses the same approach as computeFontID in gpu_text.go.
+func computeGlyphMaskFontID(source *text.FontSource) uint64 {
+	if source == nil {
+		return 0
+	}
+	h := fnv.New64a()
+	parsed := source.Parsed()
+	fullName := parsed.FullName()
+	if fullName == "" {
+		fullName = source.Name()
+	}
+	_, _ = fmt.Fprintf(h, "%s:%d", fullName, parsed.NumGlyphs())
+	return h.Sum64()
+}

--- a/internal/gpu/glyph_mask_pipeline.go
+++ b/internal/gpu/glyph_mask_pipeline.go
@@ -1,0 +1,471 @@
+//go:build !nogpu
+
+package gpu
+
+import (
+	_ "embed"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+)
+
+// Embedded glyph mask shader source.
+//
+//go:embed shaders/glyph_mask.wgsl
+var glyphMaskShaderSource string
+
+// glyphMaskVertexStride is the byte stride per vertex in the glyph mask pipeline.
+// Layout per vertex:
+//
+//	position  (vec2<f32>) =  8 bytes  (location 0)
+//	tex_coord (vec2<f32>) =  8 bytes  (location 1)
+//	color     (vec4<f32>) = 16 bytes  (location 2)
+//
+// Total = 32 bytes per vertex.
+const glyphMaskVertexStride = 32
+
+// glyphMaskUniformSize is the byte size of the glyph mask uniform buffer.
+// Layout: transform (mat4x4<f32>) = 64 bytes + color (vec4<f32>) = 16 bytes = 80 bytes.
+const glyphMaskUniformSize = 80
+
+// GlyphMaskPipeline manages GPU resources for alpha mask text rendering
+// (Tier 6). Each text run is rendered as a set of textured quads using
+// indexed drawing. The fragment shader samples a single-channel (R8) alpha
+// atlas and multiplies by the text color for premultiplied output.
+//
+// The pipeline uses the same MSAA+depth/stencil texture pattern as
+// MSDFTextPipeline for unified render pass integration. A pipelineWithStencil
+// variant is provided when the render pass includes a depth/stencil
+// attachment (stencil test is Always/Keep -- text does not interact with stencil).
+//
+// Architecture:
+//
+//	GPURenderSession owns persistent buffers (vertex, index, uniform)
+//	GlyphMaskPipeline owns shader, layout, pipeline, sampler
+//	bind groups are created per atlas texture (uniform + texture + sampler)
+type GlyphMaskPipeline struct {
+	device hal.Device
+	queue  hal.Queue
+
+	// GPU objects for the render pipeline.
+	shader        hal.ShaderModule
+	uniformLayout hal.BindGroupLayout
+	pipeLayout    hal.PipelineLayout
+	pipeline      hal.RenderPipeline
+
+	// Session-compatible pipeline variant with depth/stencil state.
+	// Used when text participates in a unified render pass that includes
+	// a stencil attachment (for stencil-then-cover paths).
+	// Stencil test is Always/Keep (text does not interact with stencil).
+	pipelineWithStencil hal.RenderPipeline
+
+	// Default sampler for R8 atlas textures (linear filtering for smooth
+	// alpha interpolation at subpixel positions).
+	sampler hal.Sampler
+}
+
+// NewGlyphMaskPipeline creates a new glyph mask pipeline with the given device
+// and queue. The render pipeline and GPU objects are not created until
+// ensurePipelineWithStencil is called.
+func NewGlyphMaskPipeline(device hal.Device, queue hal.Queue) *GlyphMaskPipeline {
+	return &GlyphMaskPipeline{
+		device: device,
+		queue:  queue,
+	}
+}
+
+// Destroy releases all GPU resources held by the pipeline. Safe to call
+// multiple times or on a pipeline with no allocated resources.
+func (p *GlyphMaskPipeline) Destroy() {
+	p.destroyPipeline()
+	if p.sampler != nil {
+		p.device.DestroySampler(p.sampler)
+		p.sampler = nil
+	}
+}
+
+// createPipeline compiles the glyph mask shader and creates the render
+// pipeline with premultiplied alpha blending and MSAA.
+func (p *GlyphMaskPipeline) createPipeline() error {
+	if glyphMaskShaderSource == "" {
+		return fmt.Errorf("glyph_mask shader source is empty")
+	}
+
+	shader, err := p.device.CreateShaderModule(&hal.ShaderModuleDescriptor{
+		Label:  "glyph_mask_shader",
+		Source: hal.ShaderSource{WGSL: glyphMaskShaderSource},
+	})
+	if err != nil {
+		return fmt.Errorf("compile glyph_mask shader: %w", err)
+	}
+	p.shader = shader
+
+	// Bind group layout:
+	//   Binding 0: GlyphMaskUniforms (uniform buffer, vertex+fragment)
+	//   Binding 1: R8 atlas texture (texture_2d, fragment)
+	//   Binding 2: Sampler (fragment)
+	uniformLayout, err := p.device.CreateBindGroupLayout(&hal.BindGroupLayoutDescriptor{
+		Label: "glyph_mask_uniform_layout",
+		Entries: []gputypes.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: gputypes.ShaderStageVertex | gputypes.ShaderStageFragment,
+				Buffer:     &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeUniform},
+			},
+			{
+				Binding:    1,
+				Visibility: gputypes.ShaderStageFragment,
+				Texture: &gputypes.TextureBindingLayout{
+					SampleType:    gputypes.TextureSampleTypeFloat,
+					ViewDimension: gputypes.TextureViewDimension2D,
+				},
+			},
+			{
+				Binding:    2,
+				Visibility: gputypes.ShaderStageFragment,
+				Sampler:    &gputypes.SamplerBindingLayout{Type: gputypes.SamplerBindingTypeFiltering},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create glyph_mask uniform layout: %w", err)
+	}
+	p.uniformLayout = uniformLayout
+
+	pipeLayout, err := p.device.CreatePipelineLayout(&hal.PipelineLayoutDescriptor{
+		Label:            "glyph_mask_pipe_layout",
+		BindGroupLayouts: []hal.BindGroupLayout{p.uniformLayout},
+	})
+	if err != nil {
+		return fmt.Errorf("create glyph_mask pipeline layout: %w", err)
+	}
+	p.pipeLayout = pipeLayout
+
+	// Create sampler for R8 atlas textures (linear filtering for smooth
+	// alpha interpolation at fractional positions).
+	sampler, err := p.device.CreateSampler(&hal.SamplerDescriptor{
+		Label:        "glyph_mask_sampler",
+		AddressModeU: gputypes.AddressModeClampToEdge,
+		AddressModeV: gputypes.AddressModeClampToEdge,
+		AddressModeW: gputypes.AddressModeClampToEdge,
+		MagFilter:    gputypes.FilterModeLinear,
+		MinFilter:    gputypes.FilterModeLinear,
+		MipmapFilter: gputypes.FilterModeLinear,
+	})
+	if err != nil {
+		return fmt.Errorf("create glyph_mask sampler: %w", err)
+	}
+	p.sampler = sampler
+
+	premulBlend := gputypes.BlendStatePremultiplied()
+	pipeline, err := p.device.CreateRenderPipeline(&hal.RenderPipelineDescriptor{
+		Label:  "glyph_mask_pipeline",
+		Layout: p.pipeLayout,
+		Vertex: hal.VertexState{
+			Module:     p.shader,
+			EntryPoint: "vs_main",
+			Buffers:    glyphMaskVertexLayout(),
+		},
+		Fragment: &hal.FragmentState{
+			Module:     p.shader,
+			EntryPoint: "fs_main",
+			Targets: []gputypes.ColorTargetState{
+				{
+					Format:    gputypes.TextureFormatBGRA8Unorm,
+					Blend:     &premulBlend,
+					WriteMask: gputypes.ColorWriteMaskAll,
+				},
+			},
+		},
+		Primitive: gputypes.PrimitiveState{
+			Topology: gputypes.PrimitiveTopologyTriangleList,
+			CullMode: gputypes.CullModeNone,
+		},
+		Multisample: gputypes.MultisampleState{
+			Count: sampleCount,
+			Mask:  0xFFFFFFFF,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create glyph_mask pipeline: %w", err)
+	}
+	p.pipeline = pipeline
+
+	return nil
+}
+
+// ensurePipelineWithStencil creates the session-compatible pipeline variant
+// that includes a depth/stencil state. This pipeline is used when text is
+// rendered in a unified render pass alongside stencil-then-cover paths.
+// The stencil test is Always/Keep (text does not interact with stencil).
+//
+// The base pipeline (shader, layout, sampler) is created first if it
+// doesn't exist.
+//
+//nolint:dupl // Intentional: each pipeline type owns its stencil variant with distinct labels and vertex layouts.
+func (p *GlyphMaskPipeline) ensurePipelineWithStencil() error {
+	// Ensure base resources exist (shader, layouts, sampler).
+	if p.shader == nil || p.uniformLayout == nil || p.pipeLayout == nil {
+		if err := p.createPipeline(); err != nil {
+			return err
+		}
+	}
+	if p.pipelineWithStencil != nil {
+		return nil
+	}
+
+	premulBlend := gputypes.BlendStatePremultiplied()
+	pipeline, err := p.device.CreateRenderPipeline(&hal.RenderPipelineDescriptor{
+		Label:  "glyph_mask_pipeline_with_stencil",
+		Layout: p.pipeLayout,
+		Vertex: hal.VertexState{
+			Module:     p.shader,
+			EntryPoint: "vs_main",
+			Buffers:    glyphMaskVertexLayout(),
+		},
+		Fragment: &hal.FragmentState{
+			Module:     p.shader,
+			EntryPoint: "fs_main",
+			Targets: []gputypes.ColorTargetState{
+				{
+					Format:    gputypes.TextureFormatBGRA8Unorm,
+					Blend:     &premulBlend,
+					WriteMask: gputypes.ColorWriteMaskAll,
+				},
+			},
+		},
+		DepthStencil: &hal.DepthStencilState{
+			Format:            gputypes.TextureFormatDepth24PlusStencil8,
+			DepthWriteEnabled: false,
+			DepthCompare:      gputypes.CompareFunctionAlways,
+			StencilFront: hal.StencilFaceState{
+				Compare:     gputypes.CompareFunctionAlways,
+				FailOp:      hal.StencilOperationKeep,
+				DepthFailOp: hal.StencilOperationKeep,
+				PassOp:      hal.StencilOperationKeep,
+			},
+			StencilBack: hal.StencilFaceState{
+				Compare:     gputypes.CompareFunctionAlways,
+				FailOp:      hal.StencilOperationKeep,
+				DepthFailOp: hal.StencilOperationKeep,
+				PassOp:      hal.StencilOperationKeep,
+			},
+			StencilReadMask:  0x00,
+			StencilWriteMask: 0x00,
+		},
+		Primitive: gputypes.PrimitiveState{
+			Topology: gputypes.PrimitiveTopologyTriangleList,
+			CullMode: gputypes.CullModeNone,
+		},
+		Multisample: gputypes.MultisampleState{
+			Count: sampleCount,
+			Mask:  0xFFFFFFFF,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create glyph mask pipeline with stencil: %w", err)
+	}
+	p.pipelineWithStencil = pipeline
+	return nil
+}
+
+// RecordDraws records glyph mask draw commands into an existing render pass.
+// The render pass is owned by GPURenderSession. This method uses the
+// pipelineWithStencil variant because the session's render pass includes
+// a depth/stencil attachment.
+//
+// The resources parameter holds pre-built vertex/index buffers, uniform buffer,
+// and bind group for the current frame.
+func (p *GlyphMaskPipeline) RecordDraws(rp hal.RenderPassEncoder, resources *glyphMaskFrameResources) {
+	if resources == nil || len(resources.drawCalls) == 0 {
+		return
+	}
+	rp.SetPipeline(p.pipelineWithStencil)
+	rp.SetVertexBuffer(0, resources.vertBuf, 0)
+	rp.SetIndexBuffer(resources.idxBuf, gputypes.IndexFormatUint16, 0)
+	for _, dc := range resources.drawCalls {
+		if dc.indexCount == 0 {
+			continue
+		}
+		rp.SetBindGroup(0, dc.bindGroup, nil)
+		rp.DrawIndexed(dc.indexCount, 1, dc.indexOffset, 0, 0)
+	}
+}
+
+// destroyPipeline releases all pipeline resources in reverse creation order.
+func (p *GlyphMaskPipeline) destroyPipeline() {
+	if p.device == nil {
+		return
+	}
+	if p.pipelineWithStencil != nil {
+		p.device.DestroyRenderPipeline(p.pipelineWithStencil)
+		p.pipelineWithStencil = nil
+	}
+	if p.pipeline != nil {
+		p.device.DestroyRenderPipeline(p.pipeline)
+		p.pipeline = nil
+	}
+	if p.pipeLayout != nil {
+		p.device.DestroyPipelineLayout(p.pipeLayout)
+		p.pipeLayout = nil
+	}
+	if p.uniformLayout != nil {
+		p.device.DestroyBindGroupLayout(p.uniformLayout)
+		p.uniformLayout = nil
+	}
+	if p.shader != nil {
+		p.device.DestroyShaderModule(p.shader)
+		p.shader = nil
+	}
+}
+
+// ---- Per-frame GPU resources ----
+
+// glyphMaskDrawCall represents a single draw call within a glyph mask batch.
+type glyphMaskDrawCall struct {
+	indexOffset uint32 // first index in the shared index buffer
+	indexCount  uint32 // number of indices for this draw
+	bindGroup   hal.BindGroup
+}
+
+// glyphMaskFrameResources holds per-frame GPU resources for glyph mask rendering.
+type glyphMaskFrameResources struct {
+	vertBuf   hal.Buffer
+	idxBuf    hal.Buffer
+	drawCalls []glyphMaskDrawCall
+}
+
+// ---- Vertex layout ----
+
+// glyphMaskVertexLayout returns the vertex buffer layout for the glyph mask pipeline.
+// Matches VertexInput in glyph_mask.wgsl:
+//
+//	location 0: position  (vec2<f32>)
+//	location 1: tex_coord (vec2<f32>)
+//	location 2: color     (vec4<f32>)
+func glyphMaskVertexLayout() []gputypes.VertexBufferLayout {
+	return []gputypes.VertexBufferLayout{
+		{
+			ArrayStride: glyphMaskVertexStride,
+			StepMode:    gputypes.VertexStepModeVertex,
+			Attributes: []gputypes.VertexAttribute{
+				{Format: gputypes.VertexFormatFloat32x2, Offset: 0, ShaderLocation: 0},  // position
+				{Format: gputypes.VertexFormatFloat32x2, Offset: 8, ShaderLocation: 1},  // tex_coord
+				{Format: gputypes.VertexFormatFloat32x4, Offset: 16, ShaderLocation: 2}, // color
+			},
+		},
+	}
+}
+
+// ---- Data types for GlyphMaskPipeline ----
+
+// GlyphMaskQuad represents a single glyph quad for alpha mask rendering.
+// Each glyph is rendered as a textured quad with position, UV, and color.
+type GlyphMaskQuad struct {
+	// Position of quad corners in screen/local space.
+	X0, Y0, X1, Y1 float32
+
+	// UV coordinates in R8 atlas [0, 1].
+	U0, V0, U1, V1 float32
+
+	// Text color (RGBA, premultiplied alpha).
+	Color [4]float32
+}
+
+// GlyphMaskBatch represents a batch of glyph mask quads with shared
+// rendering parameters. Multiple batches may use different atlas pages
+// or transforms.
+type GlyphMaskBatch struct {
+	// Quads is the list of glyph quads to render.
+	Quads []GlyphMaskQuad
+
+	// Transform is the 2D affine transform for this batch.
+	Transform gg.Matrix
+
+	// AtlasPageIndex identifies which atlas page (R8 texture) to use.
+	AtlasPageIndex int
+}
+
+// ---- Vertex/index/uniform data builders ----
+
+// buildGlyphMaskVertexData serializes GlyphMaskQuad slices into raw vertex
+// bytes suitable for GPU upload. Each quad produces 4 vertices x 32 bytes = 128 bytes.
+func buildGlyphMaskVertexData(quads []GlyphMaskQuad) []byte {
+	if len(quads) == 0 {
+		return nil
+	}
+	data := make([]byte, len(quads)*4*glyphMaskVertexStride)
+	off := 0
+	for _, q := range quads {
+		// Vertex 0: top-left
+		writeGlyphMaskVertex(data[off:], q.X0, q.Y0, q.U0, q.V0, q.Color)
+		off += glyphMaskVertexStride
+		// Vertex 1: top-right
+		writeGlyphMaskVertex(data[off:], q.X1, q.Y0, q.U1, q.V0, q.Color)
+		off += glyphMaskVertexStride
+		// Vertex 2: bottom-right
+		writeGlyphMaskVertex(data[off:], q.X1, q.Y1, q.U1, q.V1, q.Color)
+		off += glyphMaskVertexStride
+		// Vertex 3: bottom-left
+		writeGlyphMaskVertex(data[off:], q.X0, q.Y1, q.U0, q.V1, q.Color)
+		off += glyphMaskVertexStride
+	}
+	return data
+}
+
+// writeGlyphMaskVertex writes a single glyph mask vertex into buf.
+func writeGlyphMaskVertex(buf []byte, x, y, u, v float32, color [4]float32) {
+	binary.LittleEndian.PutUint32(buf[0:4], math.Float32bits(x))
+	binary.LittleEndian.PutUint32(buf[4:8], math.Float32bits(y))
+	binary.LittleEndian.PutUint32(buf[8:12], math.Float32bits(u))
+	binary.LittleEndian.PutUint32(buf[12:16], math.Float32bits(v))
+	binary.LittleEndian.PutUint32(buf[16:20], math.Float32bits(color[0]))
+	binary.LittleEndian.PutUint32(buf[20:24], math.Float32bits(color[1]))
+	binary.LittleEndian.PutUint32(buf[24:28], math.Float32bits(color[2]))
+	binary.LittleEndian.PutUint32(buf[28:32], math.Float32bits(color[3]))
+}
+
+// buildGlyphMaskIndexData serializes quad indices into raw bytes for GPU upload.
+// Uses the same index pattern as MSDF text: 0,1,2, 2,3,0 per quad.
+func buildGlyphMaskIndexData(numQuads int) []byte {
+	indices := generateQuadIndices(numQuads) // reuse from text_pipeline.go
+	data := make([]byte, len(indices)*2)
+	for i, idx := range indices {
+		binary.LittleEndian.PutUint16(data[i*2:], idx)
+	}
+	return data
+}
+
+// makeGlyphMaskUniform creates the 80-byte uniform buffer for a glyph mask batch.
+// The uniform contains the transform matrix and a dummy color (per-vertex color
+// is used instead, but the struct must match the WGSL layout).
+func makeGlyphMaskUniform(transform gg.Matrix) []byte {
+	buf := make([]byte, glyphMaskUniformSize)
+	off := 0
+
+	// Transform: WGSL mat4x4<f32> is stored COLUMN-MAJOR in memory.
+	// Column-major storage for WGSL:
+	//   col0=[A,D,0,0]  col1=[B,E,0,0]  col2=[0,0,1,0]  col3=[C,F,0,1]
+	t := [16]float32{
+		float32(transform.A), float32(transform.D), 0, 0, // column 0
+		float32(transform.B), float32(transform.E), 0, 0, // column 1
+		0, 0, 1, 0, // column 2
+		float32(transform.C), float32(transform.F), 0, 1, // column 3
+	}
+	for _, v := range t {
+		binary.LittleEndian.PutUint32(buf[off:], math.Float32bits(v))
+		off += 4
+	}
+
+	// Color: set to white (1,1,1,1) as default — actual color is per-vertex.
+	for range 4 {
+		binary.LittleEndian.PutUint32(buf[off:], math.Float32bits(1.0))
+		off += 4
+	}
+
+	return buf
+}

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -1022,7 +1022,8 @@ func (s *GPURenderSession) buildGlyphMaskResources(batches []GlyphMaskBatch) (*g
 	vertSize := uint64(len(vertexData))
 
 	if s.glyphMaskVertBuf == nil || s.glyphMaskVertBufCap < vertSize {
-		s.invalidateGlyphMaskBindGroups()
+		// Note: no bind group invalidation needed here — glyph mask bind groups
+		// reference (uniform, atlas texture, sampler), not vertex/index buffers.
 		if s.glyphMaskVertBuf != nil {
 			s.device.DestroyBuffer(s.glyphMaskVertBuf)
 		}
@@ -1049,7 +1050,6 @@ func (s *GPURenderSession) buildGlyphMaskResources(batches []GlyphMaskBatch) (*g
 	idxSize := uint64(len(indexData))
 
 	if s.glyphMaskIdxBuf == nil || s.glyphMaskIdxBufCap < idxSize {
-		s.invalidateGlyphMaskBindGroups()
 		if s.glyphMaskIdxBuf != nil {
 			s.device.DestroyBuffer(s.glyphMaskIdxBuf)
 		}
@@ -1133,17 +1133,6 @@ func (s *GPURenderSession) ensureGlyphMaskBatchPools(n int) {
 		}
 		s.glyphMaskUniformBufs = append(s.glyphMaskUniformBufs, buf)
 		s.glyphMaskBindGroups = append(s.glyphMaskBindGroups, nil) // bind group created lazily
-	}
-}
-
-// invalidateGlyphMaskBindGroups destroys all cached glyph mask bind groups so
-// they are recreated with updated buffer/texture references.
-func (s *GPURenderSession) invalidateGlyphMaskBindGroups() {
-	for i, bg := range s.glyphMaskBindGroups {
-		if bg != nil {
-			s.device.DestroyBindGroup(bg)
-			s.glyphMaskBindGroups[i] = nil
-		}
 	}
 }
 

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -113,6 +113,15 @@ type GPURenderSession struct {
 	textAtlasTex  hal.Texture
 	textAtlasView hal.TextureView
 
+	// Tier 6: Glyph mask text persistent buffers.
+	glyphMaskPipeline    *GlyphMaskPipeline
+	glyphMaskVertBuf     hal.Buffer
+	glyphMaskVertBufCap  uint64
+	glyphMaskIdxBuf      hal.Buffer
+	glyphMaskIdxBufCap   uint64
+	glyphMaskUniformBufs []hal.Buffer
+	glyphMaskBindGroups  []hal.BindGroup
+
 	// Stencil buffers are per-path, so we keep a pool of reusable buffer sets.
 	stencilBufPool []*stencilCoverBuffers
 
@@ -231,8 +240,8 @@ func (s *GPURenderSession) EnsureTextures(w, h uint32) error {
 }
 
 // RenderFrame renders all draw commands (SDF shapes + convex polygons +
-// stencil paths + MSDF text) in a single render pass. This is the main
-// entry point for unified rendering.
+// stencil paths + MSDF text + glyph mask text) in a single render pass.
+// This is the main entry point for unified rendering.
 //
 // The render pass uses the shared textures with:
 //   - MSAA color cleared to transparent black
@@ -248,14 +257,16 @@ func (s *GPURenderSession) RenderFrame(
 	convexCommands []ConvexDrawCommand,
 	stencilPaths []StencilPathCommand,
 	textBatches []TextBatch,
+	glyphMaskBatches ...GlyphMaskBatch,
 ) error {
-	if len(sdfShapes) == 0 && len(convexCommands) == 0 && len(stencilPaths) == 0 && len(textBatches) == 0 {
+	if len(sdfShapes) == 0 && len(convexCommands) == 0 && len(stencilPaths) == 0 && len(textBatches) == 0 && len(glyphMaskBatches) == 0 {
 		return nil
 	}
 
 	slogger().Debug("RenderFrame",
 		"sdf", len(sdfShapes), "convex", len(convexCommands),
 		"stencil", len(stencilPaths), "text", len(textBatches),
+		"glyphMask", len(glyphMaskBatches),
 		"surface", s.surfaceView != nil)
 
 	w, h := uint32(target.Width), uint32(target.Height) //nolint:gosec // dimensions always fit uint32
@@ -307,10 +318,15 @@ func (s *GPURenderSession) RenderFrame(
 		return err
 	}
 
-	if s.surfaceView != nil {
-		return s.encodeSubmitSurface(w, h, sdfResources, sdfShapes, convexRes, stencilResources, stencilPaths, textRes)
+	glyphMaskRes, err := s.prepareGlyphMaskResources(glyphMaskBatches)
+	if err != nil {
+		return err
 	}
-	return s.encodeSubmitReadback(w, h, sdfResources, sdfShapes, convexRes, stencilResources, stencilPaths, textRes, target)
+
+	if s.surfaceView != nil {
+		return s.encodeSubmitSurface(w, h, sdfResources, sdfShapes, convexRes, stencilResources, stencilPaths, textRes, glyphMaskRes)
+	}
+	return s.encodeSubmitReadback(w, h, sdfResources, sdfShapes, convexRes, stencilResources, stencilPaths, textRes, glyphMaskRes, target)
 }
 
 // prepareTextResources builds text GPU resources if there are text batches.
@@ -383,7 +399,7 @@ func (s *GPURenderSession) drainQueue() {
 	_, _ = s.device.Wait(fence, 1, 5*time.Second)
 }
 
-func (s *GPURenderSession) destroyPersistentBuffers() {
+func (s *GPURenderSession) destroyPersistentBuffers() { //nolint:gocyclo,cyclop,funlen // sequential resource cleanup across 6 tiers
 	if s.sdfBindGroup != nil {
 		s.device.DestroyBindGroup(s.sdfBindGroup)
 		s.sdfBindGroup = nil
@@ -441,6 +457,34 @@ func (s *GPURenderSession) destroyPersistentBuffers() {
 	if s.textAtlasTex != nil {
 		s.device.DestroyTexture(s.textAtlasTex)
 		s.textAtlasTex = nil
+	}
+	// Tier 6: Glyph mask text per-batch pools.
+	for i, bg := range s.glyphMaskBindGroups {
+		if bg != nil {
+			s.device.DestroyBindGroup(bg)
+			s.glyphMaskBindGroups[i] = nil
+		}
+	}
+	s.glyphMaskBindGroups = nil
+	for _, buf := range s.glyphMaskUniformBufs {
+		if buf != nil {
+			s.device.DestroyBuffer(buf)
+		}
+	}
+	s.glyphMaskUniformBufs = nil
+	if s.glyphMaskIdxBuf != nil {
+		s.device.DestroyBuffer(s.glyphMaskIdxBuf)
+		s.glyphMaskIdxBuf = nil
+		s.glyphMaskIdxBufCap = 0
+	}
+	if s.glyphMaskVertBuf != nil {
+		s.device.DestroyBuffer(s.glyphMaskVertBuf)
+		s.glyphMaskVertBuf = nil
+		s.glyphMaskVertBufCap = 0
+	}
+	if s.glyphMaskPipeline != nil {
+		s.glyphMaskPipeline.Destroy()
+		s.glyphMaskPipeline = nil
 	}
 	for _, b := range s.stencilBufPool {
 		b.destroy(s.device)
@@ -919,6 +963,228 @@ func (s *GPURenderSession) SetTextPipeline(p *MSDFTextPipeline) {
 	s.textPipeline = p
 }
 
+// ---- Tier 6: Glyph mask text rendering ----
+
+// prepareGlyphMaskResources builds glyph mask GPU resources if there are batches.
+// Pipeline failure is non-fatal: logs and skips glyph mask rendering.
+func (s *GPURenderSession) prepareGlyphMaskResources(batches []GlyphMaskBatch) (*glyphMaskFrameResources, error) {
+	if len(batches) == 0 {
+		return nil, nil //nolint:nilnil // no glyph mask text to render
+	}
+	if err := s.ensureGlyphMaskPipeline(); err != nil {
+		hal.Logger().Warn("glyph mask pipeline init failed", "err", err)
+		return nil, nil //nolint:nilnil // non-fatal, skip glyph mask text
+	}
+	res, err := s.buildGlyphMaskResources(batches)
+	if err != nil {
+		return nil, fmt.Errorf("build glyph mask resources: %w", err)
+	}
+	return res, nil
+}
+
+// ensureGlyphMaskPipeline creates the glyph mask pipeline on demand. Called
+// only when glyph mask batches are present.
+func (s *GPURenderSession) ensureGlyphMaskPipeline() error {
+	if s.glyphMaskPipeline == nil {
+		s.glyphMaskPipeline = NewGlyphMaskPipeline(s.device, s.queue)
+	}
+	if err := s.glyphMaskPipeline.ensurePipelineWithStencil(); err != nil {
+		return fmt.Errorf("glyph mask pipeline: %w", err)
+	}
+	return nil
+}
+
+// buildGlyphMaskResources updates persistent vertex, index, and per-batch
+// uniform buffers for glyph mask text rendering. Each batch gets its own
+// uniform buffer and bind group. Vertex and index buffers are shared across
+// all batches. Buffers are grow-only.
+func (s *GPURenderSession) buildGlyphMaskResources(batches []GlyphMaskBatch) (*glyphMaskFrameResources, error) {
+	if len(batches) == 0 {
+		return nil, nil //nolint:nilnil // empty batch list is a valid no-op
+	}
+
+	// Aggregate all quads into shared vertex/index buffers.
+	totalQuads := 0
+	for i := range batches {
+		totalQuads += len(batches[i].Quads)
+	}
+	if totalQuads == 0 {
+		return nil, nil //nolint:nilnil // no quads to render
+	}
+
+	allQuads := make([]GlyphMaskQuad, 0, totalQuads)
+	for i := range batches {
+		allQuads = append(allQuads, batches[i].Quads...)
+	}
+
+	// Build and upload shared vertex data (4 vertices per quad, 32 bytes per vertex).
+	vertexData := buildGlyphMaskVertexData(allQuads)
+	vertSize := uint64(len(vertexData))
+
+	if s.glyphMaskVertBuf == nil || s.glyphMaskVertBufCap < vertSize {
+		s.invalidateGlyphMaskBindGroups()
+		if s.glyphMaskVertBuf != nil {
+			s.device.DestroyBuffer(s.glyphMaskVertBuf)
+		}
+		allocSize := vertSize * 2
+		buf, err := s.device.CreateBuffer(&hal.BufferDescriptor{
+			Label: "session_glyph_mask_verts",
+			Size:  allocSize,
+			Usage: gputypes.BufferUsageVertex | gputypes.BufferUsageCopyDst,
+		})
+		if err != nil {
+			s.glyphMaskVertBuf = nil
+			s.glyphMaskVertBufCap = 0
+			return nil, fmt.Errorf("create glyph mask vertex buffer: %w", err)
+		}
+		s.glyphMaskVertBuf = buf
+		s.glyphMaskVertBufCap = allocSize
+	}
+	if err := s.queue.WriteBuffer(s.glyphMaskVertBuf, 0, vertexData); err != nil {
+		return nil, fmt.Errorf("write glyph mask vertex buffer: %w", err)
+	}
+
+	// Build and upload shared index data (6 indices per quad, 2 bytes per index).
+	indexData := buildGlyphMaskIndexData(totalQuads)
+	idxSize := uint64(len(indexData))
+
+	if s.glyphMaskIdxBuf == nil || s.glyphMaskIdxBufCap < idxSize {
+		s.invalidateGlyphMaskBindGroups()
+		if s.glyphMaskIdxBuf != nil {
+			s.device.DestroyBuffer(s.glyphMaskIdxBuf)
+		}
+		allocSize := idxSize * 2
+		buf, err := s.device.CreateBuffer(&hal.BufferDescriptor{
+			Label: "session_glyph_mask_indices",
+			Size:  allocSize,
+			Usage: gputypes.BufferUsageIndex | gputypes.BufferUsageCopyDst,
+		})
+		if err != nil {
+			s.glyphMaskIdxBuf = nil
+			s.glyphMaskIdxBufCap = 0
+			return nil, fmt.Errorf("create glyph mask index buffer: %w", err)
+		}
+		s.glyphMaskIdxBuf = buf
+		s.glyphMaskIdxBufCap = allocSize
+	}
+	if err := s.queue.WriteBuffer(s.glyphMaskIdxBuf, 0, indexData); err != nil {
+		return nil, fmt.Errorf("write glyph mask index buffer: %w", err)
+	}
+
+	// Grow uniform buffer and bind group pools to match batch count.
+	s.ensureGlyphMaskBatchPools(len(batches))
+
+	// Build per-batch draw calls with individual uniform buffers.
+	drawCalls := make([]glyphMaskDrawCall, 0, len(batches))
+	quadOffset := 0
+
+	for i, batch := range batches {
+		nQuads := len(batch.Quads)
+		if nQuads == 0 {
+			continue
+		}
+
+		// Write uniform data for this batch.
+		uniformData := makeGlyphMaskUniform(batch.Transform)
+		if err := s.queue.WriteBuffer(s.glyphMaskUniformBufs[i], 0, uniformData); err != nil {
+			return nil, fmt.Errorf("write glyph mask uniform[%d]: %w", i, err)
+		}
+
+		// Ensure bind group exists for this batch.
+		if s.glyphMaskBindGroups[i] == nil {
+			// Get the atlas page texture view for this batch.
+			// The caller (SDFAccelerator) must have synced atlas textures
+			// before calling RenderFrame, so PageTextureView should be valid.
+			// If not, skip this batch.
+			continue
+		}
+
+		indexOffset := uint32(quadOffset * 6) //nolint:gosec // bounded by quad capacity
+		indexCount := uint32(nQuads * 6)      //nolint:gosec // bounded by quad capacity
+
+		drawCalls = append(drawCalls, glyphMaskDrawCall{
+			indexOffset: indexOffset,
+			indexCount:  indexCount,
+			bindGroup:   s.glyphMaskBindGroups[i],
+		})
+
+		quadOffset += nQuads
+	}
+
+	return &glyphMaskFrameResources{
+		vertBuf:   s.glyphMaskVertBuf,
+		idxBuf:    s.glyphMaskIdxBuf,
+		drawCalls: drawCalls,
+	}, nil
+}
+
+// ensureGlyphMaskBatchPools grows the uniform buffer and bind group pools to
+// at least n entries. Existing entries are preserved.
+func (s *GPURenderSession) ensureGlyphMaskBatchPools(n int) {
+	for len(s.glyphMaskUniformBufs) < n {
+		buf, err := s.device.CreateBuffer(&hal.BufferDescriptor{
+			Label: fmt.Sprintf("session_glyph_mask_uniform_%d", len(s.glyphMaskUniformBufs)),
+			Size:  glyphMaskUniformSize,
+			Usage: gputypes.BufferUsageUniform | gputypes.BufferUsageCopyDst,
+		})
+		if err != nil {
+			hal.Logger().Warn("failed to create glyph mask uniform buffer", "err", err)
+			return
+		}
+		s.glyphMaskUniformBufs = append(s.glyphMaskUniformBufs, buf)
+		s.glyphMaskBindGroups = append(s.glyphMaskBindGroups, nil) // bind group created lazily
+	}
+}
+
+// invalidateGlyphMaskBindGroups destroys all cached glyph mask bind groups so
+// they are recreated with updated buffer/texture references.
+func (s *GPURenderSession) invalidateGlyphMaskBindGroups() {
+	for i, bg := range s.glyphMaskBindGroups {
+		if bg != nil {
+			s.device.DestroyBindGroup(bg)
+			s.glyphMaskBindGroups[i] = nil
+		}
+	}
+}
+
+// SetGlyphMaskAtlasView creates or updates the bind group for a glyph mask
+// batch at the given index, binding the provided atlas texture view. This must
+// be called after syncing atlas textures and before RenderFrame.
+func (s *GPURenderSession) SetGlyphMaskAtlasView(batchIndex int, atlasView hal.TextureView) {
+	if s.glyphMaskPipeline == nil || atlasView == nil {
+		return
+	}
+	s.ensureGlyphMaskBatchPools(batchIndex + 1)
+	if batchIndex >= len(s.glyphMaskBindGroups) {
+		return
+	}
+	// Destroy old bind group if it exists.
+	if s.glyphMaskBindGroups[batchIndex] != nil {
+		s.device.DestroyBindGroup(s.glyphMaskBindGroups[batchIndex])
+		s.glyphMaskBindGroups[batchIndex] = nil
+	}
+	bg, err := s.device.CreateBindGroup(&hal.BindGroupDescriptor{
+		Label:  fmt.Sprintf("session_glyph_mask_bind_%d", batchIndex),
+		Layout: s.glyphMaskPipeline.uniformLayout,
+		Entries: []gputypes.BindGroupEntry{
+			{Binding: 0, Resource: gputypes.BufferBinding{
+				Buffer: s.glyphMaskUniformBufs[batchIndex].NativeHandle(), Offset: 0, Size: glyphMaskUniformSize,
+			}},
+			{Binding: 1, Resource: gputypes.TextureViewBinding{
+				TextureView: atlasView.NativeHandle(),
+			}},
+			{Binding: 2, Resource: gputypes.SamplerBinding{
+				Sampler: s.glyphMaskPipeline.sampler.NativeHandle(),
+			}},
+		},
+	})
+	if err != nil {
+		hal.Logger().Warn("failed to create glyph mask bind group", "index", batchIndex, "err", err)
+		return
+	}
+	s.glyphMaskBindGroups[batchIndex] = bg
+}
+
 // encodeSubmitReadback encodes the unified render pass, copies the resolve
 // texture to a staging buffer, submits, waits, and reads back pixels.
 func (s *GPURenderSession) encodeSubmitReadback(
@@ -929,6 +1195,7 @@ func (s *GPURenderSession) encodeSubmitReadback(
 	stencilRes []*stencilCoverBuffers,
 	stencilPaths []StencilPathCommand,
 	textRes *textFrameResources,
+	glyphMaskRes *glyphMaskFrameResources,
 	target gg.GPURenderTarget,
 ) error {
 	encoder, err := s.device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{
@@ -979,9 +1246,14 @@ func (s *GPURenderSession) encodeSubmitReadback(
 		s.stencilRenderer.RecordPath(rp, bufs, stencilPaths[i].FillRule)
 	}
 
-	// Tier 4: MSDF text (rendered last, on top of all other geometry).
+	// Tier 4: MSDF text (rendered after shapes).
 	if textRes != nil && len(textRes.drawCalls) > 0 {
 		s.textPipeline.RecordDraws(rp, textRes)
+	}
+
+	// Tier 6: Glyph mask text (rendered last, on top of all other geometry).
+	if glyphMaskRes != nil && len(glyphMaskRes.drawCalls) > 0 {
+		s.glyphMaskPipeline.RecordDraws(rp, glyphMaskRes)
 	}
 
 	rp.End()
@@ -1106,6 +1378,7 @@ func (s *GPURenderSession) encodeSubmitSurface(
 	stencilRes []*stencilCoverBuffers,
 	stencilPaths []StencilPathCommand,
 	textRes *textFrameResources,
+	glyphMaskRes *glyphMaskFrameResources,
 ) error {
 	encoder, err := s.device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{
 		Label: "session_surface_encoder",
@@ -1167,9 +1440,14 @@ func (s *GPURenderSession) encodeSubmitSurface(
 		s.stencilRenderer.RecordPath(rp, bufs, stencilPaths[i].FillRule)
 	}
 
-	// Tier 4: MSDF text (rendered last, on top of all other geometry).
+	// Tier 4: MSDF text (rendered after shapes).
 	if textRes != nil && len(textRes.drawCalls) > 0 {
 		s.textPipeline.RecordDraws(rp, textRes)
+	}
+
+	// Tier 6: Glyph mask text (rendered last, on top of all other geometry).
+	if glyphMaskRes != nil && len(glyphMaskRes.drawCalls) > 0 {
+		s.glyphMaskPipeline.RecordDraws(rp, glyphMaskRes)
 	}
 
 	rp.End()

--- a/internal/gpu/sdf_gpu.go
+++ b/internal/gpu/sdf_gpu.go
@@ -70,6 +70,13 @@ type SDFAccelerator struct {
 	// Lazily created on first DrawText call.
 	textEngine *GPUTextEngine
 
+	// GlyphMaskEngine bridges text shaping with the CPU-rasterized R8 alpha
+	// atlas + Tier 6 quad pipeline. Lazily created on first glyph mask call.
+	glyphMaskEngine *GlyphMaskEngine
+
+	// Pending glyph mask batches for Tier 6 dispatch.
+	pendingGlyphMaskBatches []GlyphMaskBatch
+
 	pendingTarget *gg.GPURenderTarget // nil if no pending commands
 
 	cpuFallback    gg.SDFAccelerator
@@ -85,6 +92,7 @@ type SDFAccelerator struct {
 var _ gg.GPUAccelerator = (*SDFAccelerator)(nil)
 var _ gg.SurfaceTargetAware = (*SDFAccelerator)(nil)
 var _ gg.GPUTextAccelerator = (*SDFAccelerator)(nil)
+var _ gg.GPUGlyphMaskAccelerator = (*SDFAccelerator)(nil)
 var _ gg.PipelineModeAware = (*SDFAccelerator)(nil)
 var _ gg.ComputePipelineAware = (*SDFAccelerator)(nil)
 var _ gg.ForceSDFAware = (*SDFAccelerator)(nil)
@@ -146,7 +154,12 @@ func (a *SDFAccelerator) Close() {
 	a.pendingConvexCommands = nil
 	a.pendingStencilPaths = nil
 	a.pendingTextBatches = nil
+	a.pendingGlyphMaskBatches = nil
 	a.textEngine = nil
+	if a.glyphMaskEngine != nil && a.device != nil {
+		a.glyphMaskEngine.Destroy(a.device)
+		a.glyphMaskEngine = nil
+	}
 	a.pendingTarget = nil
 	a.sceneStats = gg.SceneStats{}
 	if a.velloAccel != nil {
@@ -332,6 +345,8 @@ func (a *SDFAccelerator) BeginFrame() {
 // vertex shader.
 //
 // Returns ErrFallbackToCPU if the GPU is not ready or the face type is wrong.
+//
+//nolint:dupl // Intentional: mirrors DrawGlyphMaskText structure; each method owns its engine/batch type.
 func (a *SDFAccelerator) DrawText(target gg.GPURenderTarget, face any, s string, x, y float64, color gg.RGBA, matrix gg.Matrix, deviceScale float64) error {
 	textFace, ok := face.(text.Face)
 	if !ok || textFace == nil {
@@ -638,6 +653,7 @@ func (a *SDFAccelerator) Flush(target gg.GPURenderTarget) error {
 		"convex", len(a.pendingConvexCommands),
 		"stencil", len(a.pendingStencilPaths),
 		"text", len(a.pendingTextBatches),
+		"glyphMask", len(a.pendingGlyphMaskBatches),
 		"mode", effectiveMode,
 	)
 
@@ -663,12 +679,13 @@ func (a *SDFAccelerator) Flush(target gg.GPURenderTarget) error {
 func (a *SDFAccelerator) PendingCount() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return len(a.pendingShapes) + len(a.pendingConvexCommands) + len(a.pendingStencilPaths) + len(a.pendingTextBatches)
+	return len(a.pendingShapes) + len(a.pendingConvexCommands) + len(a.pendingStencilPaths) + len(a.pendingTextBatches) + len(a.pendingGlyphMaskBatches)
 }
 
 func (a *SDFAccelerator) flushLocked(target gg.GPURenderTarget) error {
 	if len(a.pendingShapes) == 0 && len(a.pendingConvexCommands) == 0 &&
-		len(a.pendingStencilPaths) == 0 && len(a.pendingTextBatches) == 0 {
+		len(a.pendingStencilPaths) == 0 && len(a.pendingTextBatches) == 0 &&
+		len(a.pendingGlyphMaskBatches) == 0 {
 		return nil
 	}
 
@@ -716,6 +733,10 @@ func (a *SDFAccelerator) flushLocked(target gg.GPURenderTarget) error {
 	textBatches := make([]TextBatch, len(a.pendingTextBatches))
 	copy(textBatches, a.pendingTextBatches)
 	a.pendingTextBatches = a.pendingTextBatches[:0]
+
+	glyphMaskBatches := make([]GlyphMaskBatch, len(a.pendingGlyphMaskBatches))
+	copy(glyphMaskBatches, a.pendingGlyphMaskBatches)
+	a.pendingGlyphMaskBatches = a.pendingGlyphMaskBatches[:0]
 	a.pendingTarget = nil
 
 	// Upload dirty MSDF atlases to the GPU before rendering text.
@@ -726,11 +747,20 @@ func (a *SDFAccelerator) flushLocked(target gg.GPURenderTarget) error {
 		}
 	}
 
-	err := a.session.RenderFrame(target, shapes, convexCmds, paths, textBatches)
+	// Upload dirty glyph mask atlas pages to GPU before rendering.
+	if len(glyphMaskBatches) > 0 && a.glyphMaskEngine != nil {
+		if err := a.syncGlyphMaskAtlases(glyphMaskBatches); err != nil {
+			slogger().Warn("glyph mask atlas sync failed", "err", err)
+			glyphMaskBatches = nil
+		}
+	}
+
+	err := a.session.RenderFrame(target, shapes, convexCmds, paths, textBatches, glyphMaskBatches...)
 	if err != nil {
 		slogger().Warn("render session error",
 			"shapes", len(shapes), "convex", len(convexCmds),
-			"paths", len(paths), "text", len(textBatches), "err", err)
+			"paths", len(paths), "text", len(textBatches),
+			"glyphMask", len(glyphMaskBatches), "err", err)
 	}
 	return err
 }
@@ -798,6 +828,81 @@ func (a *SDFAccelerator) syncTextAtlases() error {
 		a.textEngine.MarkClean(idx)
 	}
 
+	return nil
+}
+
+// DrawGlyphMaskText queues text for GPU glyph mask rendering (Tier 6).
+// The face parameter must be a text.Face. Glyphs are CPU-rasterized into
+// the R8 alpha atlas at the exact device pixel size, then rendered as
+// textured quads in the unified render pass.
+//
+// Returns ErrFallbackToCPU if the GPU is not ready or the face type is wrong.
+//
+//nolint:dupl // Intentional: mirrors DrawText structure for MSDF; each method owns its engine/batch type.
+func (a *SDFAccelerator) DrawGlyphMaskText(target gg.GPURenderTarget, face any, s string, x, y float64, color gg.RGBA, matrix gg.Matrix, deviceScale float64) error {
+	textFace, ok := face.(text.Face)
+	if !ok || textFace == nil {
+		return gg.ErrFallbackToCPU
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Track text scene stats.
+	a.sceneStats.TextCount++
+
+	if !a.gpuReady {
+		return gg.ErrFallbackToCPU
+	}
+
+	// Lazily create the glyph mask engine.
+	if a.glyphMaskEngine == nil {
+		a.glyphMaskEngine = NewGlyphMaskEngine()
+	}
+
+	// If target changed, flush previous batch first.
+	if a.pendingTarget != nil && !sameTarget(a.pendingTarget, &target) {
+		if err := a.flushLocked(*a.pendingTarget); err != nil {
+			return err
+		}
+	}
+
+	batch, err := a.glyphMaskEngine.LayoutText(textFace, s, x, y, color, target.Width, target.Height, matrix, deviceScale)
+	if err != nil {
+		return gg.ErrFallbackToCPU
+	}
+	if len(batch.Quads) == 0 {
+		return nil // Empty text (e.g., all spaces), nothing to render.
+	}
+
+	a.pendingGlyphMaskBatches = append(a.pendingGlyphMaskBatches, batch)
+	targetCopy := target
+	a.pendingTarget = &targetCopy
+	return nil
+}
+
+// syncGlyphMaskAtlases uploads dirty R8 atlas pages to GPU textures and
+// sets atlas views on the render session for each batch. Must be called
+// after accumulating glyph mask batches and before RenderFrame.
+func (a *SDFAccelerator) syncGlyphMaskAtlases(batches []GlyphMaskBatch) error {
+	if err := a.glyphMaskEngine.SyncAtlasTextures(a.device, a.queue); err != nil {
+		return err
+	}
+
+	// Ensure the glyph mask pipeline is initialized before setting atlas views.
+	// SetGlyphMaskAtlasView requires the pipeline's uniformLayout and sampler.
+	if err := a.session.ensureGlyphMaskPipeline(); err != nil {
+		return err
+	}
+
+	// Bind the atlas texture view for each batch.
+	for i, batch := range batches {
+		view := a.glyphMaskEngine.PageTextureView(batch.AtlasPageIndex)
+		if view == nil {
+			continue
+		}
+		a.session.SetGlyphMaskAtlasView(i, view)
+	}
 	return nil
 }
 

--- a/internal/gpu/shaders/glyph_mask.wgsl
+++ b/internal/gpu/shaders/glyph_mask.wgsl
@@ -1,0 +1,106 @@
+// glyph_mask.wgsl - Alpha Mask Text Rendering Shader (Tier 6)
+//
+// Renders CPU-rasterized glyph alpha masks as textured quads. The atlas
+// stores R8 (single-channel) coverage data produced by AnalyticFiller.
+// The fragment shader multiplies the sampled alpha by the text color
+// and outputs premultiplied alpha.
+//
+// This is the Skia/Chrome approach: CPU rasterizes at exact pixel size
+// for pixel-perfect hinting, GPU composites as alpha-textured quad.
+//
+// References:
+// - Skia GrAtlasTextOp (R8 atlas compositing)
+// - Chrome cc::GlyphAtlas (alpha mask cache + GPU upload)
+
+// ============================================================================
+// Uniform structures
+// ============================================================================
+
+struct GlyphMaskUniforms {
+    // Transform matrix: column-major mat4x4 for pixel-to-NDC conversion.
+    transform: mat4x4<f32>,
+
+    // Text color (RGBA, premultiplied alpha).
+    color: vec4<f32>,
+}
+
+// ============================================================================
+// Vertex input/output structures
+// ============================================================================
+
+struct VertexInput {
+    // Position of quad vertex in local space.
+    @location(0) position: vec2<f32>,
+
+    // UV coordinates for sampling R8 alpha atlas.
+    @location(1) tex_coord: vec2<f32>,
+
+    // Per-vertex text color (RGBA, premultiplied alpha).
+    @location(2) color: vec4<f32>,
+}
+
+struct VertexOutput {
+    // Clip-space position for rasterization.
+    @builtin(position) position: vec4<f32>,
+
+    // Interpolated UV for fragment shader.
+    @location(0) tex_coord: vec2<f32>,
+
+    // Interpolated text color.
+    @location(1) color: vec4<f32>,
+}
+
+// ============================================================================
+// Bindings
+// ============================================================================
+
+@group(0) @binding(0) var<uniform> uniforms: GlyphMaskUniforms;
+@group(0) @binding(1) var atlas_texture: texture_2d<f32>;
+@group(0) @binding(2) var atlas_sampler: sampler;
+
+// ============================================================================
+// Vertex shader
+// ============================================================================
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+
+    // Apply 2D transform (using mat4x4 for alignment, treating as affine 2D).
+    // Manual column multiply: naga SPIR-V backend does not yet support
+    // mat4x4 * vec4 as a single binary operator.
+    let p = vec4<f32>(in.position, 0.0, 1.0);
+    let col0 = uniforms.transform[0];
+    let col1 = uniforms.transform[1];
+    let col2 = uniforms.transform[2];
+    let col3 = uniforms.transform[3];
+    let pos = p.x * col0 + p.y * col1 + p.z * col2 + p.w * col3;
+    out.position = pos;
+
+    // Pass through texture coordinates.
+    out.tex_coord = in.tex_coord;
+
+    // Per-vertex color (allows batching glyphs with different colors).
+    out.color = in.color;
+
+    return out;
+}
+
+// ============================================================================
+// Fragment shader
+// ============================================================================
+
+// fs_main: Sample R8 alpha atlas and composite with text color.
+// The atlas stores pre-rasterized coverage (256-level AA from AnalyticFiller).
+// Output is premultiplied alpha: rgb = color.rgb * alpha, a = color.a * alpha.
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Sample the R8 atlas texture. The .r channel contains the alpha coverage.
+    let alpha = textureSample(atlas_texture, atlas_sampler, in.tex_coord).r;
+
+    // Multiply coverage by the text color's alpha for final alpha.
+    let a = alpha * in.color.a;
+
+    // Premultiplied alpha output.
+    return vec4<f32>(in.color.rgb * a, a);
+}

--- a/text.go
+++ b/text.go
@@ -57,6 +57,15 @@ func (c *Context) DrawString(s string, x, y float64) {
 	}
 
 	switch c.selectTextStrategy() {
+	case TextModeGlyphMask:
+		// Try GPU glyph mask (Tier 6) first; fall back to MSDF, then CPU.
+		if c.tryGPUGlyphMaskText(s, x, y) {
+			return
+		}
+		if c.tryGPUText(s, x, y) {
+			return
+		}
+		c.drawStringCPU(s, x, y)
 	case TextModeMSDF:
 		// Try GPU MSDF first; fall back to CPU if unavailable.
 		if c.tryGPUText(s, x, y) {
@@ -106,12 +115,87 @@ func (c *Context) tryGPUText(s string, x, y float64) bool {
 	return err == nil
 }
 
+// glyphMaskMaxSize is the maximum font size (in device pixels) for which
+// the glyph mask pipeline is preferred over MSDF in TextModeAuto.
+// Above this threshold, MSDF provides better quality per atlas byte.
+const glyphMaskMaxSize = 48.0
+
+// tryGPUGlyphMaskText attempts to render text via the GPU glyph mask pipeline
+// (Tier 6). Glyphs are CPU-rasterized at the exact device pixel size into an
+// R8 alpha atlas, then drawn as textured quads by the GPU.
+// Returns true if text was successfully queued for glyph mask rendering.
+func (c *Context) tryGPUGlyphMaskText(s string, x, y float64) bool {
+	a := Accelerator()
+	if a == nil {
+		return false
+	}
+	gma, ok := a.(GPUGlyphMaskAccelerator)
+	if !ok {
+		return false
+	}
+	col := FromColor(c.currentColor())
+	target := c.gpuRenderTarget()
+	err := gma.DrawGlyphMaskText(target, c.face, s, x, y, col, c.matrix, c.deviceScale)
+	return err == nil
+}
+
 // selectTextStrategy returns the effective text rendering strategy.
-// When TextModeAuto, it returns TextModeAuto to preserve the current
-// auto-selection behavior (try GPU MSDF first, then CPU).
-// Future: smarter auto-selection based on transform, size, animation state.
+//
+// When TextModeAuto, the strategy is selected based on the current
+// transformation matrix and font size:
+//   - Horizontal text (no rotation/skew) at size < 48px: GlyphMask (Tier 6)
+//     if a GPUGlyphMaskAccelerator is registered.
+//   - Everything else: falls through to TextModeAuto (MSDF -> CPU).
+//
+// Explicit modes (MSDF, Vector, Bitmap, GlyphMask) are returned as-is.
 func (c *Context) selectTextStrategy() TextMode {
-	return c.textMode
+	if c.textMode != TextModeAuto {
+		return c.textMode
+	}
+	if c.shouldUseGlyphMask() {
+		return TextModeGlyphMask
+	}
+	return TextModeAuto
+}
+
+// shouldUseGlyphMask returns true when auto-selection should prefer glyph
+// mask rendering (Tier 6). Conditions: GPU with glyph mask support, horizontal
+// matrix (no rotation/skew), font size in device pixels <= glyphMaskMaxSize.
+func (c *Context) shouldUseGlyphMask() bool {
+	a := Accelerator()
+	if a == nil {
+		return false
+	}
+	if _, ok := a.(GPUGlyphMaskAccelerator); !ok {
+		return false
+	}
+
+	// Check if the matrix is horizontal-only (no rotation or skew).
+	// Matrix [A B C; D E F]: B == 0 && D == 0 means no rotation/skew.
+	m := c.matrix
+	if m.B != 0 || m.D != 0 {
+		return false
+	}
+
+	if c.face == nil {
+		return false
+	}
+
+	return c.glyphMaskDeviceSize() <= glyphMaskMaxSize
+}
+
+// glyphMaskDeviceSize returns the effective font size in device pixels,
+// accounting for deviceScale and the Y scale component of the matrix.
+func (c *Context) glyphMaskDeviceSize() float64 {
+	deviceSize := c.face.Size() * c.deviceScale
+	absScale := c.matrix.E
+	if absScale < 0 {
+		absScale = -absScale
+	}
+	if absScale != 0 {
+		deviceSize *= absScale
+	}
+	return deviceSize
 }
 
 // DrawStringAnchored draws text with an anchor point.

--- a/text/glyph_mask_atlas.go
+++ b/text/glyph_mask_atlas.go
@@ -1,0 +1,652 @@
+package text
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+// GlyphMaskKey uniquely identifies a rasterized glyph mask in the atlas.
+// The key captures all parameters that affect the rendered appearance:
+// font identity, glyph index, pixel size (quantized to 1/16 px), and
+// subpixel position (quantized to 1/4 px).
+//
+// This follows the Skia/Chrome pattern where each (font, glyph, size, subpixel)
+// combination produces a distinct alpha mask.
+type GlyphMaskKey struct {
+	// FontID identifies the font (hash of font data or name).
+	FontID uint64
+
+	// GlyphID is the glyph index within the font.
+	GlyphID uint16
+
+	// SizeQ4 is the font size multiplied by 16, giving 1/16 pixel precision.
+	// For example, 13px = 208, 14.5px = 232.
+	// Range: 1..32767 covers sizes 0.0625..2048 px.
+	SizeQ4 int16
+
+	// SubpixelXQ2 is the fractional X position multiplied by 4 (0..3).
+	// This gives 4 horizontal subpixel variants per glyph (1/4 pixel positioning).
+	SubpixelXQ2 uint8
+
+	// SubpixelYQ2 is the fractional Y position multiplied by 4 (0..3).
+	// Typically 0 for horizontal text (no vertical subpixel positioning).
+	SubpixelYQ2 uint8
+}
+
+// MakeGlyphMaskKey creates a GlyphMaskKey from rendering parameters.
+// The size is in pixels (ppem). The subpixelX/Y are fractional pixel offsets [0, 1).
+func MakeGlyphMaskKey(fontID uint64, glyphID GlyphID, size float64, subpixelX, subpixelY float64) GlyphMaskKey {
+	// Quantize size to 1/16 pixel (Q4 fixed-point).
+	sizeQ4 := int16(size * 16) //nolint:gosec // intentional truncation for quantization
+	sizeQ4 = max(sizeQ4, 1)
+
+	// Quantize subpixel position to 1/4 pixel (Q2 fixed-point).
+	// Clamp to [0, 0.75] range (4 variants: 0, 0.25, 0.5, 0.75).
+	spxQ2 := uint8(subpixelX * 4) //nolint:gosec // fractional [0,1) * 4 fits uint8
+	spyQ2 := uint8(subpixelY * 4) //nolint:gosec // fractional [0,1) * 4 fits uint8
+	if spxQ2 > 3 {
+		spxQ2 = 3
+	}
+	if spyQ2 > 3 {
+		spyQ2 = 3
+	}
+
+	return GlyphMaskKey{
+		FontID:      fontID,
+		GlyphID:     uint16(glyphID), //nolint:gosec // GlyphID is uint16
+		SizeQ4:      sizeQ4,
+		SubpixelXQ2: spxQ2,
+		SubpixelYQ2: spyQ2,
+	}
+}
+
+// GlyphMaskRegion describes a glyph mask's location and metrics in the atlas.
+type GlyphMaskRegion struct {
+	// AtlasIndex indicates which atlas page this glyph is in.
+	AtlasIndex int
+
+	// X, Y are the pixel coordinates of the mask in the atlas.
+	X, Y int
+
+	// Width, Height are the dimensions of the mask in pixels.
+	Width, Height int
+
+	// BearingX is the horizontal offset from the glyph origin to the left edge
+	// of the mask, in pixels. Used to position the quad correctly.
+	BearingX float32
+
+	// BearingY is the vertical offset from the baseline to the top edge of the
+	// mask, in pixels. Positive = above baseline (standard glyph rendering).
+	BearingY float32
+
+	// UV coordinates [0, 1] for texture sampling.
+	// Inset by 0.5 texels to prevent bilinear bleed.
+	U0, V0, U1, V1 float32
+}
+
+// GlyphMaskAtlasConfig holds configuration for the glyph mask atlas.
+type GlyphMaskAtlasConfig struct {
+	// Size is the atlas texture size (width = height).
+	// Must be power of 2. Default: 1024.
+	Size int
+
+	// Padding between glyphs to prevent texture bleeding.
+	// Default: 1.
+	Padding int
+
+	// MaxAtlases limits the number of atlas pages.
+	// Default: 4.
+	MaxAtlases int
+
+	// MaxEntries is the maximum number of cached glyph masks.
+	// When exceeded, LRU eviction removes the least recently used entries.
+	// Default: 8192.
+	MaxEntries int
+}
+
+// DefaultGlyphMaskAtlasConfig returns the default configuration.
+func DefaultGlyphMaskAtlasConfig() GlyphMaskAtlasConfig {
+	return GlyphMaskAtlasConfig{
+		Size:       1024,
+		Padding:    1,
+		MaxAtlases: 4,
+		MaxEntries: 8192,
+	}
+}
+
+// Validate checks if the configuration is valid.
+func (c *GlyphMaskAtlasConfig) Validate() error {
+	if c.Size < 64 {
+		return errors.New("text: glyph mask atlas size must be at least 64")
+	}
+	if c.Size > 8192 {
+		return errors.New("text: glyph mask atlas size must be at most 8192")
+	}
+	if c.Size&(c.Size-1) != 0 {
+		return errors.New("text: glyph mask atlas size must be power of 2")
+	}
+	if c.Padding < 0 {
+		return errors.New("text: glyph mask atlas padding must be non-negative")
+	}
+	if c.MaxAtlases < 1 {
+		return errors.New("text: glyph mask atlas must have at least 1 page")
+	}
+	if c.MaxEntries < 1 {
+		return errors.New("text: glyph mask atlas must allow at least 1 entry")
+	}
+	return nil
+}
+
+// glyphMaskPage is a single atlas texture page containing R8 alpha masks.
+type glyphMaskPage struct {
+	// Data is the R8 pixel data (1 byte per pixel, alpha only).
+	Data []byte
+
+	// Size is width = height of the atlas page.
+	Size int
+
+	// allocator packs variable-sized glyph masks using shelf algorithm.
+	allocator *glyphMaskShelfAllocator
+
+	// dirty marks if the page needs GPU re-upload.
+	dirty bool
+
+	// index is the page index in the manager.
+	index int
+}
+
+// newGlyphMaskPage creates a new atlas page.
+func newGlyphMaskPage(index, size, padding int) *glyphMaskPage {
+	return &glyphMaskPage{
+		Data:      make([]byte, size*size),
+		Size:      size,
+		allocator: newGlyphMaskShelfAllocator(size, size, padding),
+		dirty:     false,
+		index:     index,
+	}
+}
+
+// copyMask copies an alpha mask into the page at the given position.
+func (p *glyphMaskPage) copyMask(mask []byte, maskW, maskH, dstX, dstY int) {
+	for row := range maskH {
+		srcOffset := row * maskW
+		dstOffset := (dstY+row)*p.Size + dstX
+		if srcOffset+maskW > len(mask) || dstOffset+maskW > len(p.Data) {
+			continue
+		}
+		copy(p.Data[dstOffset:dstOffset+maskW], mask[srcOffset:srcOffset+maskW])
+	}
+	p.dirty = true
+}
+
+// glyphMaskShelfAllocator is a shelf-based allocator for variable-sized glyph masks.
+// Unlike the MSDF GridAllocator (fixed-size cells), glyph masks vary in size
+// depending on the glyph and font size, so we use shelf packing.
+type glyphMaskShelfAllocator struct {
+	width   int
+	height  int
+	padding int
+	shelves []glyphMaskShelf
+}
+
+// glyphMaskShelf represents a horizontal strip in the atlas page.
+type glyphMaskShelf struct {
+	y      int // Y position of shelf top
+	height int // Height of the shelf (tallest item)
+	x      int // Current X position (next free slot)
+}
+
+// newGlyphMaskShelfAllocator creates a new shelf allocator.
+func newGlyphMaskShelfAllocator(width, height, padding int) *glyphMaskShelfAllocator {
+	return &glyphMaskShelfAllocator{
+		width:   width,
+		height:  height,
+		padding: padding,
+		shelves: make([]glyphMaskShelf, 0, 32),
+	}
+}
+
+// Allocate finds space for a rectangle of size (w, h).
+// Returns (x, y, true) on success, or (-1, -1, false) if the page is full.
+func (a *glyphMaskShelfAllocator) Allocate(w, h int) (x, y int, ok bool) {
+	paddedW := w + a.padding
+	paddedH := h + a.padding
+
+	// Try existing shelves
+	for i := range a.shelves {
+		s := &a.shelves[i]
+
+		// Must fit horizontally
+		if s.x+paddedW > a.width {
+			continue
+		}
+
+		// Must fit in shelf height (or be extendable if last shelf)
+		if h > s.height {
+			if i == len(a.shelves)-1 {
+				newBottom := s.y + paddedH
+				if newBottom <= a.height {
+					s.height = h
+					x, y = s.x, s.y
+					s.x += paddedW
+					return x, y, true
+				}
+			}
+			continue
+		}
+
+		x, y = s.x, s.y
+		s.x += paddedW
+		return x, y, true
+	}
+
+	// Create new shelf
+	newY := 0
+	if len(a.shelves) > 0 {
+		last := a.shelves[len(a.shelves)-1]
+		newY = last.y + last.height + a.padding
+	}
+
+	if newY+paddedH > a.height {
+		return -1, -1, false
+	}
+
+	newShelf := glyphMaskShelf{
+		y:      newY,
+		height: h,
+		x:      paddedW,
+	}
+	a.shelves = append(a.shelves, newShelf)
+	return 0, newY, true
+}
+
+// CanFit returns true if a rectangle of the given size could fit.
+func (a *glyphMaskShelfAllocator) CanFit(w, h int) bool {
+	paddedW := w + a.padding
+	paddedH := h + a.padding
+
+	if paddedW > a.width || paddedH > a.height {
+		return false
+	}
+
+	for i := range a.shelves {
+		s := &a.shelves[i]
+		if s.x+paddedW <= a.width && h <= s.height {
+			return true
+		}
+		if i == len(a.shelves)-1 && s.x+paddedW <= a.width && s.y+paddedH <= a.height {
+			return true
+		}
+	}
+
+	newY := 0
+	if len(a.shelves) > 0 {
+		last := a.shelves[len(a.shelves)-1]
+		newY = last.y + last.height + a.padding
+	}
+	return newY+paddedH <= a.height
+}
+
+// Reset clears all allocations.
+func (a *glyphMaskShelfAllocator) Reset() {
+	a.shelves = a.shelves[:0]
+}
+
+// glyphMaskEntry is an LRU cache entry for a glyph mask.
+type glyphMaskEntry struct {
+	key    GlyphMaskKey
+	region GlyphMaskRegion
+
+	// LRU doubly-linked list pointers
+	prev *glyphMaskEntry
+	next *glyphMaskEntry
+
+	// lastAccessFrame for frame-based eviction
+	lastAccessFrame uint64
+}
+
+// GlyphMaskAtlas manages R8 alpha mask atlases for CPU-rasterized glyphs.
+//
+// Architecture (Skia/Chrome pattern):
+//  1. CPU rasterizes glyph at exact device pixel size via AnalyticFiller (256-level AA)
+//  2. Alpha mask is packed into R8 atlas page using shelf allocator
+//  3. GPU composites as textured quad in render pass (Tier 6)
+//
+// The atlas uses LRU eviction: when MaxEntries is reached, the least recently
+// used glyphs are evicted. Page-level eviction happens when all entries on a
+// page are evicted.
+//
+// GlyphMaskAtlas is safe for concurrent use.
+type GlyphMaskAtlas struct {
+	mu     sync.Mutex
+	config GlyphMaskAtlasConfig
+
+	// Atlas pages (R8 textures)
+	pages []*glyphMaskPage
+
+	// Cache: key -> entry
+	lookup map[GlyphMaskKey]*glyphMaskEntry
+
+	// LRU list: head = most recently used, tail = least recently used
+	head *glyphMaskEntry
+	tail *glyphMaskEntry
+
+	// Current frame counter for frame-based access tracking
+	currentFrame atomic.Uint64
+
+	// Statistics
+	hits   atomic.Uint64
+	misses atomic.Uint64
+}
+
+// NewGlyphMaskAtlas creates a new glyph mask atlas with the given configuration.
+func NewGlyphMaskAtlas(config GlyphMaskAtlasConfig) (*GlyphMaskAtlas, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &GlyphMaskAtlas{
+		config: config,
+		pages:  make([]*glyphMaskPage, 0, config.MaxAtlases),
+		lookup: make(map[GlyphMaskKey]*glyphMaskEntry, 256),
+	}, nil
+}
+
+// NewGlyphMaskAtlasDefault creates a new glyph mask atlas with default configuration.
+func NewGlyphMaskAtlasDefault() *GlyphMaskAtlas {
+	atlas, _ := NewGlyphMaskAtlas(DefaultGlyphMaskAtlasConfig())
+	return atlas
+}
+
+// Get retrieves a cached glyph mask region.
+// Returns the region and true if found, or zero region and false if not cached.
+func (a *GlyphMaskAtlas) Get(key GlyphMaskKey) (GlyphMaskRegion, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	entry, ok := a.lookup[key]
+	if !ok {
+		a.misses.Add(1)
+		return GlyphMaskRegion{}, false
+	}
+
+	// Update LRU position
+	entry.lastAccessFrame = a.currentFrame.Load()
+	a.moveToFront(entry)
+
+	a.hits.Add(1)
+	return entry.region, true
+}
+
+// Put stores a rasterized glyph mask in the atlas.
+// The mask is an R8 alpha buffer of dimensions (maskW x maskH).
+// BearingX/BearingY are the glyph positioning offsets from the origin.
+//
+// Returns the region where the mask was stored, or an error if the atlas is full.
+func (a *GlyphMaskAtlas) Put(key GlyphMaskKey, mask []byte, maskW, maskH int, bearingX, bearingY float32) (GlyphMaskRegion, error) {
+	if maskW <= 0 || maskH <= 0 || len(mask) < maskW*maskH {
+		return GlyphMaskRegion{}, errors.New("text: invalid glyph mask dimensions")
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Check if already cached (race with concurrent Put)
+	if entry, ok := a.lookup[key]; ok {
+		entry.lastAccessFrame = a.currentFrame.Load()
+		a.moveToFront(entry)
+		return entry.region, nil
+	}
+
+	// Evict LRU entries if at capacity
+	for len(a.lookup) >= a.config.MaxEntries {
+		a.evictTail()
+	}
+
+	// Find or create a page with space
+	page, err := a.findOrCreatePage(maskW, maskH)
+	if err != nil {
+		return GlyphMaskRegion{}, err
+	}
+
+	// Allocate space in the page
+	x, y, ok := page.allocator.Allocate(maskW, maskH)
+	if !ok {
+		return GlyphMaskRegion{}, fmt.Errorf("text: failed to allocate %dx%d glyph mask in atlas page %d", maskW, maskH, page.index)
+	}
+
+	// Copy mask data into the page
+	page.copyMask(mask, maskW, maskH, x, y)
+
+	// Compute UV coordinates with half-texel inset
+	atlasSize := float32(a.config.Size)
+	halfTexel := float32(0.5) / atlasSize
+
+	region := GlyphMaskRegion{
+		AtlasIndex: page.index,
+		X:          x,
+		Y:          y,
+		Width:      maskW,
+		Height:     maskH,
+		BearingX:   bearingX,
+		BearingY:   bearingY,
+		U0:         float32(x)/atlasSize + halfTexel,
+		V0:         float32(y)/atlasSize + halfTexel,
+		U1:         float32(x+maskW)/atlasSize - halfTexel,
+		V1:         float32(y+maskH)/atlasSize - halfTexel,
+	}
+
+	// Create cache entry and add to LRU
+	entry := &glyphMaskEntry{
+		key:             key,
+		region:          region,
+		lastAccessFrame: a.currentFrame.Load(),
+	}
+	a.lookup[key] = entry
+	a.addToFront(entry)
+
+	return region, nil
+}
+
+// GetOrRasterize retrieves a cached glyph mask or rasterizes it using the
+// provided function. This is the primary API for the glyph mask pipeline.
+//
+// The rasterize function is called on cache miss and should return:
+//   - mask: R8 alpha buffer
+//   - maskW, maskH: mask dimensions
+//   - bearingX, bearingY: glyph positioning offsets
+//   - err: any error during rasterization
+func (a *GlyphMaskAtlas) GetOrRasterize(
+	key GlyphMaskKey,
+	rasterize func() (mask []byte, maskW, maskH int, bearingX, bearingY float32, err error),
+) (GlyphMaskRegion, error) {
+	// Fast path: check cache
+	if region, ok := a.Get(key); ok {
+		return region, nil
+	}
+
+	// Slow path: rasterize and store
+	mask, maskW, maskH, bearingX, bearingY, err := rasterize()
+	if err != nil {
+		return GlyphMaskRegion{}, fmt.Errorf("text: glyph mask rasterization failed: %w", err)
+	}
+
+	// Empty glyph (e.g., space) — return zero region without storing
+	if maskW <= 0 || maskH <= 0 {
+		return GlyphMaskRegion{}, nil
+	}
+
+	return a.Put(key, mask, maskW, maskH, bearingX, bearingY)
+}
+
+// findOrCreatePage finds a page with space for the given dimensions, or creates a new one.
+// Must be called with a.mu held.
+func (a *GlyphMaskAtlas) findOrCreatePage(w, h int) (*glyphMaskPage, error) {
+	// Try existing pages
+	for _, page := range a.pages {
+		if page.allocator.CanFit(w, h) {
+			return page, nil
+		}
+	}
+
+	// Create new page
+	if len(a.pages) >= a.config.MaxAtlases {
+		return nil, fmt.Errorf("text: all %d glyph mask atlas pages are full", a.config.MaxAtlases)
+	}
+
+	page := newGlyphMaskPage(len(a.pages), a.config.Size, a.config.Padding)
+	a.pages = append(a.pages, page)
+	return page, nil
+}
+
+// evictTail removes the least recently used entry.
+// Must be called with a.mu held.
+func (a *GlyphMaskAtlas) evictTail() {
+	if a.tail == nil {
+		return
+	}
+	entry := a.tail
+	a.removeFromList(entry)
+	delete(a.lookup, entry.key)
+	// Note: we do NOT reclaim atlas space. The shelf allocator does not support
+	// freeing individual allocations. Pages are only fully reset when compacted.
+}
+
+// LRU list operations. Must be called with a.mu held.
+
+func (a *GlyphMaskAtlas) addToFront(entry *glyphMaskEntry) {
+	entry.prev = nil
+	entry.next = a.head
+	if a.head != nil {
+		a.head.prev = entry
+	}
+	a.head = entry
+	if a.tail == nil {
+		a.tail = entry
+	}
+}
+
+func (a *GlyphMaskAtlas) moveToFront(entry *glyphMaskEntry) {
+	if entry == a.head {
+		return
+	}
+	a.removeFromList(entry)
+	a.addToFront(entry)
+}
+
+func (a *GlyphMaskAtlas) removeFromList(entry *glyphMaskEntry) {
+	if entry.prev != nil {
+		entry.prev.next = entry.next
+	} else {
+		a.head = entry.next
+	}
+	if entry.next != nil {
+		entry.next.prev = entry.prev
+	} else {
+		a.tail = entry.prev
+	}
+	entry.prev = nil
+	entry.next = nil
+}
+
+// AdvanceFrame increments the frame counter. Call once per frame for
+// frame-based access tracking.
+func (a *GlyphMaskAtlas) AdvanceFrame() {
+	a.currentFrame.Add(1)
+}
+
+// DirtyPages returns indices of pages that have been modified since
+// the last MarkClean call and need GPU upload.
+func (a *GlyphMaskAtlas) DirtyPages() []int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var dirty []int
+	for i, page := range a.pages {
+		if page.dirty {
+			dirty = append(dirty, i)
+		}
+	}
+	return dirty
+}
+
+// PageR8Data returns the R8 pixel data for a page.
+// Returns nil if the index is out of range.
+func (a *GlyphMaskAtlas) PageR8Data(index int) (data []byte, width, height int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if index < 0 || index >= len(a.pages) {
+		return nil, 0, 0
+	}
+	page := a.pages[index]
+	return page.Data, page.Size, page.Size
+}
+
+// MarkClean marks a page as uploaded to GPU.
+func (a *GlyphMaskAtlas) MarkClean(index int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if index >= 0 && index < len(a.pages) {
+		a.pages[index].dirty = false
+	}
+}
+
+// Clear removes all cached glyphs and resets all pages.
+func (a *GlyphMaskAtlas) Clear() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.pages = a.pages[:0]
+	a.lookup = make(map[GlyphMaskKey]*glyphMaskEntry, 256)
+	a.head = nil
+	a.tail = nil
+	a.hits.Store(0)
+	a.misses.Store(0)
+}
+
+// Stats returns cache statistics.
+func (a *GlyphMaskAtlas) Stats() (hits, misses uint64, entryCount, pageCount int) {
+	a.mu.Lock()
+	entryCount = len(a.lookup)
+	pageCount = len(a.pages)
+	a.mu.Unlock()
+
+	hits = a.hits.Load()
+	misses = a.misses.Load()
+	return
+}
+
+// Config returns the atlas configuration.
+func (a *GlyphMaskAtlas) Config() GlyphMaskAtlasConfig {
+	return a.config
+}
+
+// PageCount returns the number of atlas pages currently in use.
+func (a *GlyphMaskAtlas) PageCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.pages)
+}
+
+// EntryCount returns the number of cached glyph masks.
+func (a *GlyphMaskAtlas) EntryCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.lookup)
+}
+
+// MemoryUsage returns the total memory used by all atlas pages in bytes.
+func (a *GlyphMaskAtlas) MemoryUsage() int64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var total int64
+	for _, page := range a.pages {
+		total += int64(len(page.Data))
+	}
+	return total
+}

--- a/text/glyph_mask_atlas_test.go
+++ b/text/glyph_mask_atlas_test.go
@@ -1,0 +1,418 @@
+package text
+
+import (
+	"testing"
+)
+
+func TestGlyphMaskAtlasConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  GlyphMaskAtlasConfig
+		wantErr bool
+	}{
+		{"default is valid", DefaultGlyphMaskAtlasConfig(), false},
+		{"size too small", GlyphMaskAtlasConfig{Size: 32, Padding: 1, MaxAtlases: 1, MaxEntries: 100}, true},
+		{"size too large", GlyphMaskAtlasConfig{Size: 16384, Padding: 1, MaxAtlases: 1, MaxEntries: 100}, true},
+		{"size not power of 2", GlyphMaskAtlasConfig{Size: 500, Padding: 1, MaxAtlases: 1, MaxEntries: 100}, true},
+		{"negative padding", GlyphMaskAtlasConfig{Size: 256, Padding: -1, MaxAtlases: 1, MaxEntries: 100}, true},
+		{"zero atlases", GlyphMaskAtlasConfig{Size: 256, Padding: 1, MaxAtlases: 0, MaxEntries: 100}, true},
+		{"zero entries", GlyphMaskAtlasConfig{Size: 256, Padding: 1, MaxAtlases: 1, MaxEntries: 0}, true},
+		{"valid small", GlyphMaskAtlasConfig{Size: 64, Padding: 0, MaxAtlases: 1, MaxEntries: 1}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMakeGlyphMaskKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		fontID    uint64
+		glyphID   GlyphID
+		size      float64
+		subpixelX float64
+		subpixelY float64
+		wantQ4    int16
+		wantSpxQ2 uint8
+		wantSpyQ2 uint8
+	}{
+		{"13px no subpixel", 1, 65, 13.0, 0, 0, 208, 0, 0},
+		{"14.5px", 1, 65, 14.5, 0, 0, 232, 0, 0},
+		{"13px 0.25 subpixel", 1, 65, 13.0, 0.25, 0, 208, 1, 0},
+		{"13px 0.5 subpixel", 1, 65, 13.0, 0.5, 0, 208, 2, 0},
+		{"13px 0.75 subpixel", 1, 65, 13.0, 0.75, 0, 208, 3, 0},
+		{"tiny size clamped", 1, 65, 0.01, 0, 0, 1, 0, 0},
+		{"vertical subpixel", 1, 65, 13.0, 0, 0.5, 208, 0, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := MakeGlyphMaskKey(tt.fontID, tt.glyphID, tt.size, tt.subpixelX, tt.subpixelY)
+			if key.SizeQ4 != tt.wantQ4 {
+				t.Errorf("SizeQ4 = %d, want %d", key.SizeQ4, tt.wantQ4)
+			}
+			if key.SubpixelXQ2 != tt.wantSpxQ2 {
+				t.Errorf("SubpixelXQ2 = %d, want %d", key.SubpixelXQ2, tt.wantSpxQ2)
+			}
+			if key.SubpixelYQ2 != tt.wantSpyQ2 {
+				t.Errorf("SubpixelYQ2 = %d, want %d", key.SubpixelYQ2, tt.wantSpyQ2)
+			}
+		})
+	}
+}
+
+func TestGlyphMaskAtlas_PutGet(t *testing.T) {
+	atlas := NewGlyphMaskAtlasDefault()
+
+	// Create a small 8x8 mask with some coverage
+	mask := make([]byte, 64)
+	for i := range mask {
+		mask[i] = uint8(i * 4) //nolint:gosec // test data
+	}
+
+	key := MakeGlyphMaskKey(1, 65, 13.0, 0, 0)
+
+	// Put
+	region, err := atlas.Put(key, mask, 8, 8, -1.0, 10.0)
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if region.Width != 8 || region.Height != 8 {
+		t.Errorf("region dimensions = %dx%d, want 8x8", region.Width, region.Height)
+	}
+	if region.BearingX != -1.0 || region.BearingY != 10.0 {
+		t.Errorf("bearings = (%f, %f), want (-1.0, 10.0)", region.BearingX, region.BearingY)
+	}
+
+	// Get — should be cached
+	got, ok := atlas.Get(key)
+	if !ok {
+		t.Fatal("Get() returned false for cached glyph")
+	}
+	if got.Width != region.Width || got.Height != region.Height {
+		t.Errorf("Get() returned different region")
+	}
+
+	// Different key — should miss
+	key2 := MakeGlyphMaskKey(1, 66, 13.0, 0, 0)
+	_, ok = atlas.Get(key2)
+	if ok {
+		t.Error("Get() returned true for uncached glyph")
+	}
+}
+
+func TestGlyphMaskAtlas_DuplicatePut(t *testing.T) {
+	atlas := NewGlyphMaskAtlasDefault()
+
+	mask := make([]byte, 16)
+	key := MakeGlyphMaskKey(1, 65, 13.0, 0, 0)
+
+	// Put twice — should return same region
+	r1, err := atlas.Put(key, mask, 4, 4, 0, 0)
+	if err != nil {
+		t.Fatalf("first Put() error = %v", err)
+	}
+
+	r2, err := atlas.Put(key, mask, 4, 4, 0, 0)
+	if err != nil {
+		t.Fatalf("second Put() error = %v", err)
+	}
+
+	if r1.X != r2.X || r1.Y != r2.Y {
+		t.Errorf("duplicate Put() returned different positions: (%d,%d) vs (%d,%d)", r1.X, r1.Y, r2.X, r2.Y)
+	}
+
+	if atlas.EntryCount() != 1 {
+		t.Errorf("EntryCount() = %d, want 1", atlas.EntryCount())
+	}
+}
+
+func TestGlyphMaskAtlas_LRUEviction(t *testing.T) {
+	config := GlyphMaskAtlasConfig{
+		Size:       256,
+		Padding:    1,
+		MaxAtlases: 1,
+		MaxEntries: 3,
+	}
+	atlas, err := NewGlyphMaskAtlas(config)
+	if err != nil {
+		t.Fatalf("NewGlyphMaskAtlas() error = %v", err)
+	}
+
+	mask := make([]byte, 4)
+
+	// Fill to capacity
+	for i := range 3 {
+		key := MakeGlyphMaskKey(1, GlyphID(i), 13.0, 0, 0)
+		_, err := atlas.Put(key, mask, 2, 2, 0, 0)
+		if err != nil {
+			t.Fatalf("Put(%d) error = %v", i, err)
+		}
+	}
+
+	if atlas.EntryCount() != 3 {
+		t.Fatalf("EntryCount() = %d, want 3", atlas.EntryCount())
+	}
+
+	// Access glyph 0 to make it recently used
+	key0 := MakeGlyphMaskKey(1, 0, 13.0, 0, 0)
+	_, ok := atlas.Get(key0)
+	if !ok {
+		t.Fatal("Get(0) failed")
+	}
+
+	// Add a 4th entry — should evict glyph 1 (LRU)
+	key3 := MakeGlyphMaskKey(1, 3, 13.0, 0, 0)
+	_, err = atlas.Put(key3, mask, 2, 2, 0, 0)
+	if err != nil {
+		t.Fatalf("Put(3) error = %v", err)
+	}
+
+	// Glyph 0 should still be cached (was accessed)
+	_, ok = atlas.Get(key0)
+	if !ok {
+		t.Error("glyph 0 was evicted but shouldn't have been")
+	}
+
+	// Glyph 1 should have been evicted (LRU)
+	key1 := MakeGlyphMaskKey(1, 1, 13.0, 0, 0)
+	_, ok = atlas.Get(key1)
+	if ok {
+		t.Error("glyph 1 should have been evicted")
+	}
+
+	// Glyph 2 should still be cached
+	key2 := MakeGlyphMaskKey(1, 2, 13.0, 0, 0)
+	_, ok = atlas.Get(key2)
+	if !ok {
+		t.Error("glyph 2 was evicted but shouldn't have been")
+	}
+}
+
+func TestGlyphMaskAtlas_Stats(t *testing.T) {
+	atlas := NewGlyphMaskAtlasDefault()
+
+	mask := make([]byte, 4)
+	key := MakeGlyphMaskKey(1, 65, 13.0, 0, 0)
+
+	// Miss
+	_, _ = atlas.Get(key)
+
+	// Put + Hit
+	_, _ = atlas.Put(key, mask, 2, 2, 0, 0)
+	_, _ = atlas.Get(key)
+
+	hits, misses, entries, pages := atlas.Stats()
+	if hits != 1 {
+		t.Errorf("hits = %d, want 1", hits)
+	}
+	if misses != 1 {
+		t.Errorf("misses = %d, want 1", misses)
+	}
+	if entries != 1 {
+		t.Errorf("entries = %d, want 1", entries)
+	}
+	if pages != 1 {
+		t.Errorf("pages = %d, want 1", pages)
+	}
+}
+
+func TestGlyphMaskAtlas_Clear(t *testing.T) {
+	atlas := NewGlyphMaskAtlasDefault()
+
+	mask := make([]byte, 4)
+	key := MakeGlyphMaskKey(1, 65, 13.0, 0, 0)
+	_, _ = atlas.Put(key, mask, 2, 2, 0, 0)
+
+	atlas.Clear()
+
+	if atlas.EntryCount() != 0 {
+		t.Errorf("EntryCount() after Clear = %d, want 0", atlas.EntryCount())
+	}
+	if atlas.PageCount() != 0 {
+		t.Errorf("PageCount() after Clear = %d, want 0", atlas.PageCount())
+	}
+}
+
+func TestGlyphMaskAtlas_DirtyPages(t *testing.T) {
+	atlas := NewGlyphMaskAtlasDefault()
+
+	mask := make([]byte, 4)
+	key := MakeGlyphMaskKey(1, 65, 13.0, 0, 0)
+	_, _ = atlas.Put(key, mask, 2, 2, 0, 0)
+
+	dirty := atlas.DirtyPages()
+	if len(dirty) != 1 || dirty[0] != 0 {
+		t.Errorf("DirtyPages() = %v, want [0]", dirty)
+	}
+
+	atlas.MarkClean(0)
+
+	dirty = atlas.DirtyPages()
+	if len(dirty) != 0 {
+		t.Errorf("DirtyPages() after MarkClean = %v, want []", dirty)
+	}
+}
+
+func TestGlyphMaskAtlas_InvalidMask(t *testing.T) {
+	atlas := NewGlyphMaskAtlasDefault()
+
+	key := MakeGlyphMaskKey(1, 65, 13.0, 0, 0)
+
+	// Empty mask
+	_, err := atlas.Put(key, nil, 0, 0, 0, 0)
+	if err == nil {
+		t.Error("Put() with empty mask should return error")
+	}
+
+	// Mask too small for dimensions
+	mask := make([]byte, 2)
+	_, err = atlas.Put(key, mask, 4, 4, 0, 0)
+	if err == nil {
+		t.Error("Put() with undersized mask should return error")
+	}
+}
+
+func TestGlyphMaskAtlas_GetOrRasterize(t *testing.T) {
+	atlas := NewGlyphMaskAtlasDefault()
+	key := MakeGlyphMaskKey(1, 65, 13.0, 0, 0)
+
+	callCount := 0
+	rasterize := func() ([]byte, int, int, float32, float32, error) {
+		callCount++
+		mask := make([]byte, 16)
+		for i := range mask {
+			mask[i] = 128
+		}
+		return mask, 4, 4, -1.0, 10.0, nil
+	}
+
+	// First call — rasterizes
+	region, err := atlas.GetOrRasterize(key, rasterize)
+	if err != nil {
+		t.Fatalf("GetOrRasterize() error = %v", err)
+	}
+	if region.Width != 4 || region.Height != 4 {
+		t.Errorf("region = %dx%d, want 4x4", region.Width, region.Height)
+	}
+	if callCount != 1 {
+		t.Errorf("rasterize called %d times, want 1", callCount)
+	}
+
+	// Second call — cached
+	region2, err := atlas.GetOrRasterize(key, rasterize)
+	if err != nil {
+		t.Fatalf("second GetOrRasterize() error = %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("rasterize called %d times on cache hit, want 1", callCount)
+	}
+	if region2.X != region.X || region2.Y != region.Y {
+		t.Error("cached region differs from original")
+	}
+}
+
+func TestGlyphMaskAtlas_MemoryUsage(t *testing.T) {
+	config := GlyphMaskAtlasConfig{
+		Size:       64,
+		Padding:    0,
+		MaxAtlases: 2,
+		MaxEntries: 100,
+	}
+	atlas, err := NewGlyphMaskAtlas(config)
+	if err != nil {
+		t.Fatalf("NewGlyphMaskAtlas() error = %v", err)
+	}
+
+	if atlas.MemoryUsage() != 0 {
+		t.Errorf("MemoryUsage() before any Put = %d, want 0", atlas.MemoryUsage())
+	}
+
+	mask := make([]byte, 4)
+	key := MakeGlyphMaskKey(1, 65, 13.0, 0, 0)
+	_, _ = atlas.Put(key, mask, 2, 2, 0, 0)
+
+	// One 64x64 R8 page = 4096 bytes
+	if atlas.MemoryUsage() != 64*64 {
+		t.Errorf("MemoryUsage() = %d, want %d", atlas.MemoryUsage(), 64*64)
+	}
+}
+
+func TestGlyphMaskAtlas_SubpixelVariants(t *testing.T) {
+	atlas := NewGlyphMaskAtlasDefault()
+	mask := make([]byte, 4)
+
+	// Same glyph, 4 different subpixel X positions should produce 4 distinct cache entries
+	for i := range 4 {
+		key := MakeGlyphMaskKey(1, 65, 13.0, float64(i)*0.25, 0)
+		_, err := atlas.Put(key, mask, 2, 2, 0, 0)
+		if err != nil {
+			t.Fatalf("Put(subpixel=%d) error = %v", i, err)
+		}
+	}
+
+	if atlas.EntryCount() != 4 {
+		t.Errorf("EntryCount() = %d, want 4 (one per subpixel variant)", atlas.EntryCount())
+	}
+}
+
+func TestGlyphMaskShelfAllocator(t *testing.T) {
+	alloc := newGlyphMaskShelfAllocator(64, 64, 1)
+
+	// Allocate a few items
+	x1, y1, ok := alloc.Allocate(10, 12)
+	if !ok {
+		t.Fatal("first Allocate failed")
+	}
+	if x1 != 0 || y1 != 0 {
+		t.Errorf("first allocation at (%d, %d), want (0, 0)", x1, y1)
+	}
+
+	x2, y2, ok := alloc.Allocate(10, 12)
+	if !ok {
+		t.Fatal("second Allocate failed")
+	}
+	if x2 != 11 || y2 != 0 {
+		t.Errorf("second allocation at (%d, %d), want (11, 0)", x2, y2)
+	}
+
+	// Fill the row, then start new shelf
+	for i := range 3 {
+		_, _, ok = alloc.Allocate(10, 12)
+		if !ok {
+			t.Fatalf("allocation %d failed", i+3)
+		}
+	}
+
+	// Should start a new shelf
+	x5, y5, ok := alloc.Allocate(10, 8)
+	if !ok {
+		t.Fatal("new shelf Allocate failed")
+	}
+	if y5 <= y1 {
+		t.Errorf("new shelf at y=%d should be below first shelf at y=%d", y5, y1)
+	}
+	_ = x5
+}
+
+func TestGlyphMaskShelfAllocator_CanFit(t *testing.T) {
+	alloc := newGlyphMaskShelfAllocator(64, 64, 1)
+
+	if !alloc.CanFit(10, 10) {
+		t.Error("should be able to fit 10x10 in empty 64x64 atlas")
+	}
+
+	if alloc.CanFit(65, 10) {
+		t.Error("should not fit 65-wide in 64-wide atlas")
+	}
+
+	if alloc.CanFit(10, 65) {
+		t.Error("should not fit 65-tall in 64-tall atlas")
+	}
+}

--- a/text/glyph_mask_rasterizer.go
+++ b/text/glyph_mask_rasterizer.go
@@ -108,14 +108,13 @@ func (r *GlyphMaskRasterizer) rasterizeOutline(
 	// We add a 1-pixel margin for anti-aliasing coverage.
 	const aaMargin = 1
 
-	// Outline Y coordinates from sfnt are in the "Y-up" convention:
-	// positive Y = above baseline. For rasterization we need Y-down
-	// (screen coordinates). We flip Y: screenY = -outlineY.
-	// So MinY in outline becomes -MaxY in screen, and vice versa.
+	// Outline Y coordinates from sfnt are already in Y-down (screen) convention:
+	// Y=0 at baseline, Y<0 above baseline, Y>0 below baseline.
+	// No Y-flip needed — OutlineExtractor preserves sfnt's Y-down convention.
 	boundsMinX := float64(outline.Bounds.MinX) + subpixelX
 	boundsMaxX := float64(outline.Bounds.MaxX) + subpixelX
-	boundsMinY := -outline.Bounds.MaxY + subpixelY // flip Y
-	boundsMaxY := -outline.Bounds.MinY + subpixelY // flip Y
+	boundsMinY := outline.Bounds.MinY + subpixelY
+	boundsMaxY := outline.Bounds.MaxY + subpixelY
 
 	// Compute pixel-aligned bounding box
 	pixMinX := int(math.Floor(boundsMinX)) - aaMargin
@@ -137,8 +136,8 @@ func (r *GlyphMaskRasterizer) rasterizeOutline(
 	}
 
 	// Build raster path from outline segments.
-	// Translate so that the glyph bbox starts at (aaMargin, aaMargin) in the mask,
-	// and flip Y for screen coordinates.
+	// Translate so that the glyph bbox starts at (aaMargin, aaMargin) in the mask.
+	// No Y-flip: sfnt coordinates are already Y-down (screen convention).
 	offsetX := float32(-pixMinX) + float32(subpixelX)
 	offsetY := float32(-pixMinY) + float32(subpixelY)
 
@@ -151,31 +150,31 @@ func (r *GlyphMaskRasterizer) rasterizeOutline(
 			r.pathVerbs = append(r.pathVerbs, raster.VerbMoveTo)
 			r.pathPoints = append(r.pathPoints,
 				seg.Points[0].X+offsetX,
-				-seg.Points[0].Y+offsetY, // flip Y
+				seg.Points[0].Y+offsetY,
 			)
 		case OutlineOpLineTo:
 			r.pathVerbs = append(r.pathVerbs, raster.VerbLineTo)
 			r.pathPoints = append(r.pathPoints,
 				seg.Points[0].X+offsetX,
-				-seg.Points[0].Y+offsetY,
+				seg.Points[0].Y+offsetY,
 			)
 		case OutlineOpQuadTo:
 			r.pathVerbs = append(r.pathVerbs, raster.VerbQuadTo)
 			r.pathPoints = append(r.pathPoints,
 				seg.Points[0].X+offsetX,
-				-seg.Points[0].Y+offsetY,
+				seg.Points[0].Y+offsetY,
 				seg.Points[1].X+offsetX,
-				-seg.Points[1].Y+offsetY,
+				seg.Points[1].Y+offsetY,
 			)
 		case OutlineOpCubicTo:
 			r.pathVerbs = append(r.pathVerbs, raster.VerbCubicTo)
 			r.pathPoints = append(r.pathPoints,
 				seg.Points[0].X+offsetX,
-				-seg.Points[0].Y+offsetY,
+				seg.Points[0].Y+offsetY,
 				seg.Points[1].X+offsetX,
-				-seg.Points[1].Y+offsetY,
+				seg.Points[1].Y+offsetY,
 				seg.Points[2].X+offsetX,
-				-seg.Points[2].Y+offsetY,
+				seg.Points[2].Y+offsetY,
 			)
 		}
 	}
@@ -202,9 +201,13 @@ func (r *GlyphMaskRasterizer) rasterizeOutline(
 	mask := make([]byte, maskW*maskH)
 	raster.FillToBuffer(eb, maskW, maskH, raster.FillRuleNonZero, mask)
 
-	// Compute bearings: offset from glyph origin to mask top-left
+	// Compute bearings: offset from glyph origin to mask top-left.
+	// BearingX: horizontal offset in pixels (negative = left of origin).
+	// BearingY: vertical offset in pixels (positive = above baseline).
+	// In Y-down coords, pixMinY is negative for above-baseline content,
+	// so -pixMinY gives positive distance above baseline.
 	bearingX := float32(pixMinX) - float32(subpixelX)
-	bearingY := float32(-pixMinY) + float32(subpixelY) // flip Y back: screen pixMinY maps to outline -pixMinY
+	bearingY := float32(-pixMinY) + float32(subpixelY)
 
 	return &GlyphMaskResult{
 		Mask:     mask,

--- a/text/glyph_mask_rasterizer.go
+++ b/text/glyph_mask_rasterizer.go
@@ -1,0 +1,226 @@
+package text
+
+import (
+	"math"
+
+	"github.com/gogpu/gg/internal/raster"
+)
+
+// GlyphMaskRasterizer renders glyph outlines into R8 alpha masks using the
+// AnalyticFiller (256-level analytic anti-aliasing). This is the CPU side of
+// the Tier 6 glyph mask cache pipeline.
+//
+// The rasterizer extracts glyph outlines from the font at the exact device
+// pixel size, builds edges via EdgeBuilder, and fills to an alpha buffer.
+// The result is a tight-bbox alpha mask suitable for packing into the
+// GlyphMaskAtlas R8 texture.
+//
+// This follows the Skia/Chrome pattern:
+//   - CPU rasterizes at exact pixel size (no scaling artifacts)
+//   - 256-level coverage (vs MSDF's distance-based approximation)
+//   - Hinting-ready (future TEXT-012)
+//   - Subpixel positioning via fractional offset in outline coordinates
+//
+// GlyphMaskRasterizer is NOT safe for concurrent use. Each goroutine should
+// use its own instance, or protect access with a mutex.
+type GlyphMaskRasterizer struct {
+	extractor *OutlineExtractor
+
+	// Reusable path buffer to avoid allocations per glyph.
+	pathVerbs  []raster.PathVerb
+	pathPoints []float32
+}
+
+// NewGlyphMaskRasterizer creates a new glyph mask rasterizer.
+func NewGlyphMaskRasterizer() *GlyphMaskRasterizer {
+	return &GlyphMaskRasterizer{
+		extractor:  NewOutlineExtractor(),
+		pathVerbs:  make([]raster.PathVerb, 0, 64),
+		pathPoints: make([]float32, 0, 256),
+	}
+}
+
+// GlyphMaskResult holds the output of rasterizing a single glyph.
+type GlyphMaskResult struct {
+	// Mask is the R8 alpha buffer (1 byte per pixel, row-major).
+	Mask []byte
+
+	// Width and Height of the mask in pixels.
+	Width, Height int
+
+	// BearingX is the horizontal offset from the glyph origin to the left
+	// edge of the mask bounding box, in pixels.
+	BearingX float32
+
+	// BearingY is the vertical offset from the baseline to the top edge
+	// of the mask bounding box, in pixels. Positive = above baseline.
+	BearingY float32
+}
+
+// Rasterize renders a single glyph into an R8 alpha mask.
+//
+// Parameters:
+//   - font: parsed font to extract outlines from
+//   - gid: glyph index in the font
+//   - size: font size in pixels (ppem)
+//   - subpixelX: fractional X offset in pixels [0, 1) for subpixel positioning
+//   - subpixelY: fractional Y offset in pixels [0, 1) for subpixel positioning
+//
+// Returns nil result for empty glyphs (e.g., space character).
+func (r *GlyphMaskRasterizer) Rasterize(
+	font ParsedFont,
+	gid GlyphID,
+	size float64,
+	subpixelX, subpixelY float64,
+) (*GlyphMaskResult, error) {
+	// Extract outline at the target size (exact pixel size, not reference size).
+	outline, err := r.extractor.ExtractOutline(font, gid, size)
+	if err != nil {
+		return nil, err
+	}
+	if outline == nil || outline.IsEmpty() {
+		// Empty glyph (space, control char) — no mask needed.
+		return nil, nil //nolint:nilnil // nil result = empty glyph, not an error
+	}
+
+	return r.rasterizeOutline(outline, subpixelX, subpixelY)
+}
+
+// RasterizeOutline renders a pre-extracted glyph outline into an R8 alpha mask.
+// This is useful when the outline has already been extracted (e.g., from cache).
+func (r *GlyphMaskRasterizer) RasterizeOutline(
+	outline *GlyphOutline,
+	subpixelX, subpixelY float64,
+) (*GlyphMaskResult, error) {
+	if outline == nil || outline.IsEmpty() {
+		return nil, nil //nolint:nilnil // nil result = empty glyph, not an error
+	}
+	return r.rasterizeOutline(outline, subpixelX, subpixelY)
+}
+
+// rasterizeOutline is the internal implementation.
+func (r *GlyphMaskRasterizer) rasterizeOutline(
+	outline *GlyphOutline,
+	subpixelX, subpixelY float64,
+) (*GlyphMaskResult, error) {
+	// Compute tight bounding box with subpixel offset.
+	// The outline bounds are in pixel coordinates at the target size.
+	// We add a 1-pixel margin for anti-aliasing coverage.
+	const aaMargin = 1
+
+	// Outline Y coordinates from sfnt are in the "Y-up" convention:
+	// positive Y = above baseline. For rasterization we need Y-down
+	// (screen coordinates). We flip Y: screenY = -outlineY.
+	// So MinY in outline becomes -MaxY in screen, and vice versa.
+	boundsMinX := float64(outline.Bounds.MinX) + subpixelX
+	boundsMaxX := float64(outline.Bounds.MaxX) + subpixelX
+	boundsMinY := -outline.Bounds.MaxY + subpixelY // flip Y
+	boundsMaxY := -outline.Bounds.MinY + subpixelY // flip Y
+
+	// Compute pixel-aligned bounding box
+	pixMinX := int(math.Floor(boundsMinX)) - aaMargin
+	pixMinY := int(math.Floor(boundsMinY)) - aaMargin
+	pixMaxX := int(math.Ceil(boundsMaxX)) + aaMargin
+	pixMaxY := int(math.Ceil(boundsMaxY)) + aaMargin
+
+	maskW := pixMaxX - pixMinX
+	maskH := pixMaxY - pixMinY
+
+	if maskW <= 0 || maskH <= 0 {
+		return nil, nil //nolint:nilnil // degenerate bbox = no renderable content
+	}
+
+	// Safety cap: prevent absurdly large masks from bad outline data
+	const maxMaskDim = 512
+	if maskW > maxMaskDim || maskH > maxMaskDim {
+		return nil, nil //nolint:nilnil // oversized glyph = skip rendering
+	}
+
+	// Build raster path from outline segments.
+	// Translate so that the glyph bbox starts at (aaMargin, aaMargin) in the mask,
+	// and flip Y for screen coordinates.
+	offsetX := float32(-pixMinX) + float32(subpixelX)
+	offsetY := float32(-pixMinY) + float32(subpixelY)
+
+	r.pathVerbs = r.pathVerbs[:0]
+	r.pathPoints = r.pathPoints[:0]
+
+	for _, seg := range outline.Segments {
+		switch seg.Op {
+		case OutlineOpMoveTo:
+			r.pathVerbs = append(r.pathVerbs, raster.VerbMoveTo)
+			r.pathPoints = append(r.pathPoints,
+				seg.Points[0].X+offsetX,
+				-seg.Points[0].Y+offsetY, // flip Y
+			)
+		case OutlineOpLineTo:
+			r.pathVerbs = append(r.pathVerbs, raster.VerbLineTo)
+			r.pathPoints = append(r.pathPoints,
+				seg.Points[0].X+offsetX,
+				-seg.Points[0].Y+offsetY,
+			)
+		case OutlineOpQuadTo:
+			r.pathVerbs = append(r.pathVerbs, raster.VerbQuadTo)
+			r.pathPoints = append(r.pathPoints,
+				seg.Points[0].X+offsetX,
+				-seg.Points[0].Y+offsetY,
+				seg.Points[1].X+offsetX,
+				-seg.Points[1].Y+offsetY,
+			)
+		case OutlineOpCubicTo:
+			r.pathVerbs = append(r.pathVerbs, raster.VerbCubicTo)
+			r.pathPoints = append(r.pathPoints,
+				seg.Points[0].X+offsetX,
+				-seg.Points[0].Y+offsetY,
+				seg.Points[1].X+offsetX,
+				-seg.Points[1].Y+offsetY,
+				seg.Points[2].X+offsetX,
+				-seg.Points[2].Y+offsetY,
+			)
+		}
+	}
+
+	// Close the path (fonts always have closed contours)
+	if len(r.pathVerbs) > 0 {
+		r.pathVerbs = append(r.pathVerbs, raster.VerbClose)
+	}
+
+	if len(r.pathVerbs) == 0 {
+		return nil, nil //nolint:nilnil // no path segments = nothing to rasterize
+	}
+
+	// Build edges and fill to alpha buffer
+	eb := raster.NewEdgeBuilder(2) // 4x AA (Skia default)
+	eb.SetFlattenCurves(true)      // Flatten curves to lines for AnalyticFiller
+	eb.BuildFromPath(&glyphPath{verbs: r.pathVerbs, points: r.pathPoints}, raster.IdentityTransform{})
+
+	if eb.IsEmpty() {
+		return nil, nil //nolint:nilnil // no edges produced = nothing to rasterize
+	}
+
+	// Rasterize to alpha buffer
+	mask := make([]byte, maskW*maskH)
+	raster.FillToBuffer(eb, maskW, maskH, raster.FillRuleNonZero, mask)
+
+	// Compute bearings: offset from glyph origin to mask top-left
+	bearingX := float32(pixMinX) - float32(subpixelX)
+	bearingY := float32(-pixMinY) + float32(subpixelY) // flip Y back: screen pixMinY maps to outline -pixMinY
+
+	return &GlyphMaskResult{
+		Mask:     mask,
+		Width:    maskW,
+		Height:   maskH,
+		BearingX: bearingX,
+		BearingY: bearingY,
+	}, nil
+}
+
+// glyphPath implements raster.PathLike for glyph outline data.
+type glyphPath struct {
+	verbs  []raster.PathVerb
+	points []float32
+}
+
+func (p *glyphPath) IsEmpty() bool      { return len(p.verbs) == 0 }
+func (p *glyphPath) Verbs() []raster.PathVerb { return p.verbs }
+func (p *glyphPath) Points() []float32  { return p.points }

--- a/text/glyph_mask_rasterizer.go
+++ b/text/glyph_mask_rasterizer.go
@@ -224,6 +224,6 @@ type glyphPath struct {
 	points []float32
 }
 
-func (p *glyphPath) IsEmpty() bool      { return len(p.verbs) == 0 }
+func (p *glyphPath) IsEmpty() bool            { return len(p.verbs) == 0 }
 func (p *glyphPath) Verbs() []raster.PathVerb { return p.verbs }
-func (p *glyphPath) Points() []float32  { return p.points }
+func (p *glyphPath) Points() []float32        { return p.points }

--- a/text/glyph_mask_rasterizer_test.go
+++ b/text/glyph_mask_rasterizer_test.go
@@ -1,0 +1,204 @@
+package text
+
+import (
+	"testing"
+)
+
+func TestGlyphMaskRasterizer_New(t *testing.T) {
+	r := NewGlyphMaskRasterizer()
+	if r == nil {
+		t.Fatal("NewGlyphMaskRasterizer() returned nil")
+	}
+	if r.extractor == nil {
+		t.Error("extractor is nil")
+	}
+}
+
+func TestGlyphMaskRasterizer_RasterizeNilOutline(t *testing.T) {
+	r := NewGlyphMaskRasterizer()
+
+	result, err := r.RasterizeOutline(nil, 0, 0)
+	if err != nil {
+		t.Fatalf("RasterizeOutline(nil) error = %v", err)
+	}
+	if result != nil {
+		t.Error("RasterizeOutline(nil) should return nil result")
+	}
+}
+
+func TestGlyphMaskRasterizer_RasterizeEmptyOutline(t *testing.T) {
+	r := NewGlyphMaskRasterizer()
+
+	outline := &GlyphOutline{
+		Segments: nil,
+		GID:      0,
+	}
+
+	result, err := r.RasterizeOutline(outline, 0, 0)
+	if err != nil {
+		t.Fatalf("RasterizeOutline(empty) error = %v", err)
+	}
+	if result != nil {
+		t.Error("RasterizeOutline(empty) should return nil result")
+	}
+}
+
+func TestGlyphMaskRasterizer_RasterizeTriangle(t *testing.T) {
+	r := NewGlyphMaskRasterizer()
+
+	// Create a simple triangle outline (10x10 pixels)
+	outline := &GlyphOutline{
+		Segments: []OutlineSegment{
+			{Op: OutlineOpMoveTo, Points: [3]OutlinePoint{{X: 5, Y: 0}}},
+			{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{X: 10, Y: 10}}},
+			{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{X: 0, Y: 10}}},
+		},
+		Bounds: Rect{
+			MinX: 0, MinY: 0,
+			MaxX: 10, MaxY: 10,
+		},
+		GID: 1,
+	}
+
+	result, err := r.RasterizeOutline(outline, 0, 0)
+	if err != nil {
+		t.Fatalf("RasterizeOutline() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("RasterizeOutline() returned nil for valid outline")
+	}
+
+	// Check dimensions are reasonable (should be ~12x12 with AA margin)
+	if result.Width <= 0 || result.Height <= 0 {
+		t.Errorf("invalid dimensions: %dx%d", result.Width, result.Height)
+	}
+
+	// Check mask has some non-zero coverage
+	hasNonZero := false
+	for _, b := range result.Mask {
+		if b > 0 {
+			hasNonZero = true
+			break
+		}
+	}
+	if !hasNonZero {
+		t.Error("mask has no coverage — triangle not rasterized")
+	}
+
+	// Check mask is correct size
+	if len(result.Mask) != result.Width*result.Height {
+		t.Errorf("mask length = %d, want %d", len(result.Mask), result.Width*result.Height)
+	}
+}
+
+func TestGlyphMaskRasterizer_RasterizeSquare(t *testing.T) {
+	r := NewGlyphMaskRasterizer()
+
+	// Create a 10x10 square outline
+	outline := &GlyphOutline{
+		Segments: []OutlineSegment{
+			{Op: OutlineOpMoveTo, Points: [3]OutlinePoint{{X: 0, Y: 0}}},
+			{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{X: 10, Y: 0}}},
+			{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{X: 10, Y: 10}}},
+			{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{X: 0, Y: 10}}},
+		},
+		Bounds: Rect{
+			MinX: 0, MinY: 0,
+			MaxX: 10, MaxY: 10,
+		},
+		GID: 2,
+	}
+
+	result, err := r.RasterizeOutline(outline, 0, 0)
+	if err != nil {
+		t.Fatalf("RasterizeOutline() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("RasterizeOutline() returned nil for valid square")
+	}
+
+	// A 10x10 square should have many fully-covered interior pixels
+	fullCoverage := 0
+	for _, b := range result.Mask {
+		if b == 255 {
+			fullCoverage++
+		}
+	}
+
+	// Interior of a 10x10 square should have at least 64 fully covered pixels
+	// (8x8 interior minus AA edges)
+	if fullCoverage < 40 {
+		t.Errorf("only %d fully covered pixels for 10x10 square, expected at least 40", fullCoverage)
+	}
+}
+
+func TestGlyphMaskRasterizer_SubpixelOffset(t *testing.T) {
+	r := NewGlyphMaskRasterizer()
+
+	outline := &GlyphOutline{
+		Segments: []OutlineSegment{
+			{Op: OutlineOpMoveTo, Points: [3]OutlinePoint{{X: 0, Y: 0}}},
+			{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{X: 8, Y: 0}}},
+			{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{X: 8, Y: 8}}},
+			{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{X: 0, Y: 8}}},
+		},
+		Bounds: Rect{
+			MinX: 0, MinY: 0,
+			MaxX: 8, MaxY: 8,
+		},
+		GID: 3,
+	}
+
+	// Rasterize at 0 subpixel and 0.5 subpixel — masks should differ
+	result0, err := r.RasterizeOutline(outline, 0, 0)
+	if err != nil {
+		t.Fatalf("RasterizeOutline(0) error = %v", err)
+	}
+
+	result05, err := r.RasterizeOutline(outline, 0.5, 0)
+	if err != nil {
+		t.Fatalf("RasterizeOutline(0.5) error = %v", err)
+	}
+
+	if result0 == nil || result05 == nil {
+		t.Fatal("one of the results is nil")
+	}
+
+	// The two masks should differ — either in bearings, dimensions, or pixel content.
+	differs := result0.BearingX != result05.BearingX ||
+		result0.BearingY != result05.BearingY ||
+		result0.Width != result05.Width ||
+		result0.Height != result05.Height ||
+		!masksEqual(result0.Mask, result05.Mask)
+
+	if !differs {
+		t.Error("subpixel=0 and subpixel=0.5 produced identical masks — subpixel positioning not working")
+	}
+}
+
+// masksEqual reports whether two alpha masks have identical content.
+func masksEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestGlyphPath_Interface(t *testing.T) {
+	// Verify glyphPath implements raster.PathLike
+	p := &glyphPath{}
+	if !p.IsEmpty() {
+		t.Error("empty glyphPath should report IsEmpty() = true")
+	}
+	if p.Verbs() != nil {
+		t.Error("empty glyphPath Verbs() should be nil")
+	}
+	if p.Points() != nil {
+		t.Error("empty glyphPath Points() should be nil")
+	}
+}

--- a/text_mode.go
+++ b/text_mode.go
@@ -36,6 +36,13 @@ const (
 	// Bypasses GPU entirely, using the CPU text pipeline directly.
 	// Best for: PNG/PDF export, translation-only static text.
 	TextModeBitmap
+
+	// TextModeGlyphMask forces GPU glyph mask rendering (Tier 6).
+	// Glyphs are CPU-rasterized into an R8 alpha atlas at the exact pixel
+	// size and rendered as textured quads on the GPU. This produces
+	// pixel-perfect hinted text for horizontal layouts at small sizes.
+	// Best for: UI labels, small body text (<48px), horizontal-only text.
+	TextModeGlyphMask
 )
 
 // String returns the text mode name.
@@ -49,6 +56,8 @@ func (m TextMode) String() string {
 		return "Vector"
 	case TextModeBitmap:
 		return "Bitmap"
+	case TextModeGlyphMask:
+		return "GlyphMask"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
## Summary

GPU Glyph Mask Cache (Tier 6) — complete implementation of TEXT-010 (all 3 phases).

**Skia/Chrome pattern**: CPU rasterizes glyph outlines at exact pixel size → R8 alpha atlas → GPU composites with color uniform. Optimal for horizontal text at small-to-medium sizes (≤48px).

### What's included

- **Phase 1**: `text/glyph_mask_rasterizer.go` — CPU outline rasterizer using gg's own AnalyticFiller (anti-aliased, subpixel-positioned)
- **Phase 2**: `text/glyph_mask_atlas.go` — LRU shelf-packed R8 atlas (2048x2048, auto-eviction, multi-atlas support)
- **Phase 3**: GPU integration — `glyph_mask_engine.go` + `glyph_mask_pipeline.go` + `glyph_mask.wgsl` shader, wired into `DrawString` pipeline with auto-selection

### Auto-selection (in `text.go`)

| Condition | Strategy |
|-----------|----------|
| Horizontal text, size ≤48px | GlyphMask (Tier 6) — pixel-perfect |
| Larger text, transforms | MSDF (Tier 4) — resolution-independent |
| No GPU | CPU bitmap fallback |

### Bug fixes (found during integration)

- **Y-flip in rasterizer**: sfnt returns Y-down coordinates, rasterizer was flipping again → mirrored glyphs
- **First-frame invisibility**: `buildGlyphMaskResources` invalidated bind groups when creating vertex/index buffers, destroying bind groups just set by `syncGlyphMaskAtlases`

### Architecture update

- Five-Tier → **Six-Tier** GPU rendering (SDF, Convex, Stencil+Cover, MSDF Text, Compute, Glyph Mask)
- Dual-strategy → **Triple-strategy** text rendering (GlyphMask + MSDF + Bitmap)

## Stats

- 15 files changed, +2944 / -29 lines
- 2 new test files (622 lines of tests)

## Test plan

- [x] `GOWORK=off go build ./...` compiles
- [x] `GOWORK=off go test ./text/...` — atlas + rasterizer tests pass
- [x] Manual: UI signals example — text renders correctly on first frame
- [x] Manual: text is not mirrored/flipped
- [ ] CI green

Part of #174 (TEXT-010 Phase 4 complete)

Follow-up: #191 (ClearType subpixel rendering), #192 (font hinting)
