### PR TITLE
perf: single render pass with per-group scissor rect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.2] - 2026-03-13
+
+### Fixed
+
+- **GPU scissor rect performance regression** — v0.36.1 scissor clipping created
+  multiple render passes per frame (one per scissor change), causing GPU utilization
+  to spike from ~3% to ~45% during scrolling. Replaced batch-breaking approach with
+  `ScissorGroup` timeline tracking — all draws accumulate within a single render
+  pass, scissor rect is changed per group via `SetScissorRect()` (WebGPU dynamic
+  state, zero cost). GPU utilization back to ~3%.
+  - `ScissorGroup` type in `GPURenderSession` for per-group scissor tracking
+  - `RenderFrameGrouped` render path (single render pass, multiple scissor groups)
+  - Removed `flushOnScissorChange` — no more extra render passes
+
 ## [0.36.1] - 2026-03-13
 
 ### Fixed

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -11,6 +11,24 @@ import (
 	"github.com/gogpu/wgpu/hal"
 )
 
+// ScissorGroup holds a subset of draw commands that share the same scissor
+// rect. During rendering, the scissor rect is applied before recording the
+// group's draws, allowing multiple scissor states within a single render pass.
+// This eliminates the need for multiple render pass submissions when clipping
+// is used (e.g., scroll views, panels), reducing GPU utilization from ~45%
+// to ~3% on Intel iGPUs.
+type ScissorGroup struct {
+	// Rect is the scissor rect in device pixels. nil means full framebuffer.
+	Rect *[4]uint32
+
+	// Per-tier draw command subsets for this scissor state.
+	SDFShapes        []SDFRenderShape
+	ConvexCommands   []ConvexDrawCommand
+	StencilPaths     []StencilPathCommand
+	TextBatches      []TextBatch
+	GlyphMaskBatches []GlyphMaskBatch
+}
+
 // StencilPathCommand holds a path and paint for stencil-then-cover rendering
 // within a unified render session. The vertices are pre-tessellated fan
 // triangles from FanTessellator.
@@ -353,6 +371,105 @@ func (s *GPURenderSession) RenderFrame(
 		return s.encodeSubmitSurface(w, h, sdfResources, sdfShapes, convexRes, stencilResources, stencilPaths, textRes, glyphMaskRes)
 	}
 	return s.encodeSubmitReadback(w, h, sdfResources, sdfShapes, convexRes, stencilResources, stencilPaths, textRes, glyphMaskRes, target)
+}
+
+// groupResources holds pre-built GPU resources for a single ScissorGroup.
+type groupResources struct {
+	scissorRect  *[4]uint32
+	sdfRes       *sdfFrameResources
+	sdfShapes    []SDFRenderShape
+	convexRes    *convexFrameResources
+	stencilRes   []*stencilCoverBuffers
+	stencilPaths []StencilPathCommand
+	textRes      *textFrameResources
+	glyphMaskRes *glyphMaskFrameResources
+}
+
+// RenderFrameGrouped renders multiple scissor groups in a single render pass.
+// Each group's draw commands are rendered with the group's scissor rect applied,
+// then the scissor is changed for the next group. This eliminates multiple
+// render pass submissions when clipping is used.
+//
+// For frames with no scissor changes (single group with nil rect), this
+// behaves identically to the original RenderFrame.
+func (s *GPURenderSession) RenderFrameGrouped(target gg.GPURenderTarget, groups []ScissorGroup) error {
+	if len(groups) == 0 {
+		return nil
+	}
+
+	// Check if all groups are empty.
+	totalItems := 0
+	for i := range groups {
+		totalItems += len(groups[i].SDFShapes) + len(groups[i].ConvexCommands) + len(groups[i].StencilPaths) +
+			len(groups[i].TextBatches) + len(groups[i].GlyphMaskBatches)
+	}
+	if totalItems == 0 {
+		return nil
+	}
+
+	slogger().Debug("RenderFrameGrouped",
+		"groups", len(groups),
+		"totalItems", totalItems,
+		"surface", s.surfaceView != nil)
+
+	w, h := uint32(target.Width), uint32(target.Height) //nolint:gosec // dimensions always fit uint32
+	if s.surfaceView != nil && s.surfaceWidth > 0 && s.surfaceHeight > 0 {
+		w, h = s.surfaceWidth, s.surfaceHeight
+	}
+	if err := s.EnsureTextures(w, h); err != nil {
+		return fmt.Errorf("ensure textures: %w", err)
+	}
+	if err := s.ensurePipelines(); err != nil {
+		return fmt.Errorf("ensure pipelines: %w", err)
+	}
+
+	// Build GPU resources for each group.
+	grpRes := make([]groupResources, len(groups))
+	for i := range groups {
+		g := &groups[i]
+		grpRes[i].scissorRect = g.Rect
+		grpRes[i].sdfShapes = g.SDFShapes
+		grpRes[i].stencilPaths = g.StencilPaths
+
+		if len(g.SDFShapes) > 0 {
+			res, err := s.buildSDFResources(g.SDFShapes, w, h)
+			if err != nil {
+				return fmt.Errorf("build SDF resources (group %d): %w", i, err)
+			}
+			grpRes[i].sdfRes = res
+		}
+
+		if len(g.ConvexCommands) > 0 {
+			res, err := s.buildConvexResources(g.ConvexCommands, w, h)
+			if err != nil {
+				return fmt.Errorf("build convex resources (group %d): %w", i, err)
+			}
+			grpRes[i].convexRes = res
+		}
+
+		stencilRes, err := s.buildStencilResourcesBatch(g.StencilPaths, w, h)
+		if err != nil {
+			return fmt.Errorf("build stencil resources (group %d): %w", i, err)
+		}
+		grpRes[i].stencilRes = stencilRes
+
+		textRes, err := s.prepareTextResources(g.TextBatches)
+		if err != nil {
+			return err
+		}
+		grpRes[i].textRes = textRes
+
+		glyphMaskRes, err := s.prepareGlyphMaskResources(g.GlyphMaskBatches)
+		if err != nil {
+			return err
+		}
+		grpRes[i].glyphMaskRes = glyphMaskRes
+	}
+
+	if s.surfaceView != nil {
+		return s.encodeSubmitSurfaceGrouped(w, h, grpRes)
+	}
+	return s.encodeSubmitReadbackGrouped(w, h, grpRes, target)
 }
 
 // prepareTextResources builds text GPU resources if there are text batches.
@@ -1494,6 +1611,196 @@ func (s *GPURenderSession) encodeSubmitSurface(
 
 	// Mark that at least one render pass has been submitted this frame.
 	// Subsequent mid-frame flushes will use LoadOpLoad to preserve content.
+	s.frameRendered = true
+
+	return nil
+}
+
+// recordGroupDraws records all tier draw commands for a single group into
+// the given render pass encoder. This is the inner loop of the grouped
+// encode methods — called once per scissor group within a single render pass.
+func (s *GPURenderSession) recordGroupDraws(rp hal.RenderPassEncoder, gr groupResources) {
+	// Tier 1: SDF shapes (no stencil interaction).
+	if gr.sdfRes != nil && len(gr.sdfShapes) > 0 {
+		s.sdfPipeline.RecordDraws(rp, gr.sdfRes)
+	}
+
+	// Tier 2a: Convex polygon fast-path (no stencil interaction).
+	if gr.convexRes != nil {
+		s.convexRenderer.RecordDraws(rp, gr.convexRes)
+	}
+
+	// Tier 2b: Stencil-then-cover paths.
+	for i, bufs := range gr.stencilRes {
+		s.stencilRenderer.RecordPath(rp, bufs, gr.stencilPaths[i].FillRule)
+	}
+
+	// Tier 4: MSDF text (rendered after shapes).
+	if gr.textRes != nil && len(gr.textRes.drawCalls) > 0 {
+		s.textPipeline.RecordDraws(rp, gr.textRes)
+	}
+
+	// Tier 6: Glyph mask text (rendered last, on top of all other geometry).
+	if gr.glyphMaskRes != nil && len(gr.glyphMaskRes.drawCalls) > 0 {
+		s.glyphMaskPipeline.RecordDraws(rp, gr.glyphMaskRes)
+	}
+}
+
+// applyGroupScissor sets or clears the scissor rect on the render pass for
+// a given group. When rect is nil, the scissor is reset to the full
+// framebuffer (w x h). When non-nil, the scissor clips to the given rect.
+func (s *GPURenderSession) applyGroupScissor(rp hal.RenderPassEncoder, rect *[4]uint32, w, h uint32) {
+	if rect != nil {
+		rp.SetScissorRect(rect[0], rect[1], rect[2], rect[3])
+	} else {
+		rp.SetScissorRect(0, 0, w, h)
+	}
+}
+
+// encodeSubmitReadbackGrouped encodes a single render pass with per-group
+// scissor state changes, then copies the resolve texture to a staging buffer
+// for CPU readback. This is the grouped version of encodeSubmitReadback.
+func (s *GPURenderSession) encodeSubmitReadbackGrouped(
+	w, h uint32,
+	grpRes []groupResources,
+	target gg.GPURenderTarget,
+) error {
+	encoder, err := s.device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{
+		Label: "session_encoder",
+	})
+	if err != nil {
+		return fmt.Errorf("create command encoder: %w", err)
+	}
+	if err := encoder.BeginEncoding("session_frame"); err != nil {
+		return fmt.Errorf("begin encoding: %w", err)
+	}
+
+	// Unified render pass descriptor with MSAA color + stencil + resolve.
+	rpDesc := &hal.RenderPassDescriptor{
+		Label: "session_unified_pass",
+		ColorAttachments: []hal.RenderPassColorAttachment{{
+			View:          s.textures.msaaView,
+			ResolveTarget: s.textures.resolveView,
+			LoadOp:        gputypes.LoadOpClear,
+			StoreOp:       gputypes.StoreOpStore,
+			ClearValue:    gputypes.Color{R: 0, G: 0, B: 0, A: 0},
+		}},
+		DepthStencilAttachment: &hal.RenderPassDepthStencilAttachment{
+			View:              s.textures.stencilView,
+			DepthLoadOp:       gputypes.LoadOpClear,
+			DepthStoreOp:      gputypes.StoreOpDiscard,
+			DepthClearValue:   1.0,
+			StencilLoadOp:     gputypes.LoadOpClear,
+			StencilStoreOp:    gputypes.StoreOpStore,
+			StencilClearValue: 0,
+		},
+	}
+
+	rp := encoder.BeginRenderPass(rpDesc)
+
+	// Render each group with its scissor rect applied.
+	for _, gr := range grpRes {
+		s.applyGroupScissor(rp, gr.scissorRect, w, h)
+		s.recordGroupDraws(rp, gr)
+	}
+
+	rp.End()
+
+	// VK-LAYOUT-001: After MSAA resolve the texture is in
+	// COLOR_ATTACHMENT_OPTIMAL layout. CopyTextureToBuffer requires
+	// TRANSFER_SRC_OPTIMAL. Insert an explicit barrier to transition.
+	encoder.TransitionTextures([]hal.TextureBarrier{{
+		Texture: s.textures.resolveTex,
+		Usage: hal.TextureUsageTransition{
+			OldUsage: gputypes.TextureUsageRenderAttachment,
+			NewUsage: gputypes.TextureUsageCopySrc,
+		},
+	}})
+
+	// Encode copy and submit, then read back pixels to the target.
+	return s.copySubmitAndReadback(encoder, w, h, target)
+}
+
+// encodeSubmitSurfaceGrouped encodes a single render pass with per-group
+// scissor state changes, resolving directly to the surface view. No readback
+// occurs. This is the grouped version of encodeSubmitSurface.
+func (s *GPURenderSession) encodeSubmitSurfaceGrouped(
+	w, h uint32,
+	grpRes []groupResources,
+) error {
+	encoder, err := s.device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{
+		Label: "session_surface_encoder",
+	})
+	if err != nil {
+		return fmt.Errorf("create command encoder: %w", err)
+	}
+	if err := encoder.BeginEncoding("session_surface_frame"); err != nil {
+		return fmt.Errorf("begin encoding: %w", err)
+	}
+
+	// Surface render pass LoadOp: first pass clears, subsequent passes
+	// preserve existing content. This handles mid-frame flushes caused by
+	// CPU fallback operations (e.g., DrawImage between GPU draw calls).
+	colorLoadOp := gputypes.LoadOpClear
+	stencilLoadOp := gputypes.LoadOpClear
+	depthLoadOp := gputypes.LoadOpClear
+	if s.frameRendered {
+		colorLoadOp = gputypes.LoadOpLoad
+		stencilLoadOp = gputypes.LoadOpLoad
+		depthLoadOp = gputypes.LoadOpLoad
+	}
+
+	rpDesc := &hal.RenderPassDescriptor{
+		Label: "session_surface_pass",
+		ColorAttachments: []hal.RenderPassColorAttachment{{
+			View:          s.textures.msaaView,
+			ResolveTarget: s.surfaceView,
+			LoadOp:        colorLoadOp,
+			StoreOp:       gputypes.StoreOpStore,
+			ClearValue:    gputypes.Color{R: 0, G: 0, B: 0, A: 0},
+		}},
+		DepthStencilAttachment: &hal.RenderPassDepthStencilAttachment{
+			View:              s.textures.stencilView,
+			DepthLoadOp:       depthLoadOp,
+			DepthStoreOp:      gputypes.StoreOpDiscard,
+			DepthClearValue:   1.0,
+			StencilLoadOp:     stencilLoadOp,
+			StencilStoreOp:    gputypes.StoreOpStore,
+			StencilClearValue: 0,
+		},
+	}
+
+	rp := encoder.BeginRenderPass(rpDesc)
+
+	// Render each group with its scissor rect applied.
+	for _, gr := range grpRes {
+		s.applyGroupScissor(rp, gr.scissorRect, w, h)
+		s.recordGroupDraws(rp, gr)
+	}
+
+	rp.End()
+
+	// No CopyTextureToBuffer -- the surface is the resolve target.
+	cmdBuf, err := encoder.EndEncoding()
+	if err != nil {
+		return fmt.Errorf("end encoding: %w", err)
+	}
+
+	// Free the previous frame's command buffer. By now VSync has
+	// guaranteed the GPU finished with it.
+	if s.prevCmdBuf != nil {
+		s.device.FreeCommandBuffer(s.prevCmdBuf)
+	}
+
+	if err := s.queue.Submit([]hal.CommandBuffer{cmdBuf}, nil, 0); err != nil {
+		s.prevCmdBuf = nil
+		return fmt.Errorf("submit: %w", err)
+	}
+
+	// Keep reference so next frame can free it after GPU is done.
+	s.prevCmdBuf = cmdBuf
+
+	// Mark that at least one render pass has been submitted this frame.
 	s.frameRendered = true
 
 	return nil

--- a/internal/gpu/sdf_gpu.go
+++ b/internal/gpu/sdf_gpu.go
@@ -87,6 +87,13 @@ type SDFAccelerator struct {
 	velloAccel   *VelloAccelerator // Internal compute accelerator (Tier 5)
 	pipelineMode gg.PipelineMode   // Current pipeline mode (from Context)
 	sceneStats   gg.SceneStats     // Accumulated per-frame stats for Auto selection
+
+	// Scissor state: tracks the current clip rect and a timeline of scissor
+	// changes within a frame. Instead of flushing on every scissor change
+	// (which creates multiple render passes), we record scissor boundaries
+	// and replay them within a single render pass on Flush().
+	clipRect        *[4]uint32       // Current scissor rect (nil = full framebuffer)
+	scissorSegments []scissorSegment // Timeline of scissor changes within a frame
 }
 
 var _ gg.GPUAccelerator = (*SDFAccelerator)(nil)
@@ -108,52 +115,60 @@ func (a *SDFAccelerator) SetForceSDF(force bool) {
 }
 
 // SetClipRect sets the scissor rect for subsequent GPU draw commands.
-// The scissor rect is forwarded to the GPURenderSession, which applies
-// it to the render pass encoder via hal.RenderPassEncoder.SetScissorRect().
-//
-// If there are pending draw commands with a different (or no) scissor rect,
-// they are flushed first so each batch has consistent scissor state.
-// This matches Skia's approach: scissor change breaks the batch.
+// The scissor rect is recorded in the scissor timeline so that all
+// pending commands can be rendered in a single render pass on Flush(),
+// with per-batch scissor state changes. This avoids creating multiple
+// render passes per frame when clipping is used.
 func (a *SDFAccelerator) SetClipRect(x, y, w, h uint32) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	// Flush pending commands that were queued with the previous scissor state.
-	a.flushOnScissorChange()
-	if a.session != nil {
-		a.session.SetScissorRect(x, y, w, h)
-	}
+	rect := [4]uint32{x, y, w, h}
+	a.clipRect = &rect
+	a.recordScissorSegment(&rect)
 }
 
 // ClearClipRect removes the scissor rect, restoring full-framebuffer
-// rendering for subsequent draw commands.
-//
-// Pending draw commands queued with the previous scissor rect are flushed
-// first so they render correctly clipped.
+// rendering for subsequent draw commands. The change is recorded in the
+// scissor timeline for deferred application during Flush().
 func (a *SDFAccelerator) ClearClipRect() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	// Flush pending commands that were queued with the active scissor rect.
-	a.flushOnScissorChange()
-	if a.session != nil {
-		a.session.ClearScissorRect()
-	}
+	a.clipRect = nil
+	a.recordScissorSegment(nil)
 }
 
-// flushOnScissorChange flushes pending draw commands if any exist.
-// Called before changing the scissor rect to ensure each batch renders
-// with the correct scissor state. Must be called with a.mu held.
-func (a *SDFAccelerator) flushOnScissorChange() {
-	if a.pendingTarget == nil {
-		return // No pending commands — nothing to flush.
+// recordScissorSegment records a scissor state change in the timeline.
+// Each segment marks the current pending counts at the time of the change.
+// During Flush(), the timeline is used to slice pending arrays into groups,
+// each rendered with the correct scissor rect within a single render pass.
+// Must be called with a.mu held.
+func (a *SDFAccelerator) recordScissorSegment(rect *[4]uint32) {
+	// Copy the rect so it's immutable (caller may reuse the value).
+	var copied *[4]uint32
+	if rect != nil {
+		c := *rect
+		copied = &c
 	}
-	pending := len(a.pendingShapes) + len(a.pendingConvexCommands) +
-		len(a.pendingStencilPaths) + len(a.pendingTextBatches) +
-		len(a.pendingGlyphMaskBatches)
-	if pending == 0 {
-		return
-	}
-	// Flush with current scissor state before changing it.
-	_ = a.flushLocked(*a.pendingTarget)
+	a.scissorSegments = append(a.scissorSegments, scissorSegment{
+		rect:         copied,
+		sdfCount:     len(a.pendingShapes),
+		convexCount:  len(a.pendingConvexCommands),
+		stencilCount: len(a.pendingStencilPaths),
+		textCount:    len(a.pendingTextBatches),
+		glyphCount:   len(a.pendingGlyphMaskBatches),
+	})
+}
+
+// scissorSegment records a scissor state change along with the cumulative
+// pending counts at the time of the change. Used to slice pending arrays
+// into per-scissor groups during Flush().
+type scissorSegment struct {
+	rect         *[4]uint32 // nil = full framebuffer
+	sdfCount     int        // len(pendingShapes) at time of change
+	convexCount  int        // len(pendingConvexCommands) at time of change
+	stencilCount int        // len(pendingStencilPaths) at time of change
+	textCount    int        // len(pendingTextBatches) at time of change
+	glyphCount   int        // len(pendingGlyphMaskBatches) at time of change
 }
 
 // CanAccelerate reports whether this accelerator supports the given operation.
@@ -211,6 +226,8 @@ func (a *SDFAccelerator) Close() {
 		a.glyphMaskEngine = nil
 	}
 	a.pendingTarget = nil
+	a.clipRect = nil
+	a.scissorSegments = nil
 	a.sceneStats = gg.SceneStats{}
 	if a.velloAccel != nil {
 		a.velloAccel.Close()
@@ -375,6 +392,8 @@ func (a *SDFAccelerator) SetSurfaceTarget(view any, width, height uint32) {
 func (a *SDFAccelerator) BeginFrame() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	a.clipRect = nil
+	a.scissorSegments = a.scissorSegments[:0]
 	if a.session != nil {
 		a.session.BeginFrame()
 	}
@@ -732,7 +751,82 @@ func (a *SDFAccelerator) PendingCount() int {
 	return len(a.pendingShapes) + len(a.pendingConvexCommands) + len(a.pendingStencilPaths) + len(a.pendingTextBatches) + len(a.pendingGlyphMaskBatches)
 }
 
-func (a *SDFAccelerator) flushLocked(target gg.GPURenderTarget) error {
+// buildScissorGroups slices the pending arrays into ScissorGroup entries
+// based on the recorded scissor timeline. Each group contains the subset
+// of shapes/commands/batches that were submitted under the same scissor
+// state, and the scissor rect to apply when rendering that group.
+//
+// If no scissor changes were recorded (common case: no clipping), returns
+// a single group covering all pending items with nil scissor (full framebuffer).
+func (a *SDFAccelerator) buildScissorGroups() []ScissorGroup {
+	// No scissor changes: single group with all items and no scissor.
+	if len(a.scissorSegments) == 0 {
+		return []ScissorGroup{{
+			Rect:             nil,
+			SDFShapes:        a.pendingShapes,
+			ConvexCommands:   a.pendingConvexCommands,
+			StencilPaths:     a.pendingStencilPaths,
+			TextBatches:      a.pendingTextBatches,
+			GlyphMaskBatches: a.pendingGlyphMaskBatches,
+		}}
+	}
+
+	var groups []ScissorGroup
+
+	// Items before the first scissor change use nil scissor (full framebuffer).
+	firstSeg := a.scissorSegments[0]
+	if firstSeg.sdfCount > 0 || firstSeg.convexCount > 0 || firstSeg.stencilCount > 0 ||
+		firstSeg.textCount > 0 || firstSeg.glyphCount > 0 {
+		groups = append(groups, ScissorGroup{
+			Rect:             nil,
+			SDFShapes:        a.pendingShapes[:firstSeg.sdfCount],
+			ConvexCommands:   a.pendingConvexCommands[:firstSeg.convexCount],
+			StencilPaths:     a.pendingStencilPaths[:firstSeg.stencilCount],
+			TextBatches:      a.pendingTextBatches[:firstSeg.textCount],
+			GlyphMaskBatches: a.pendingGlyphMaskBatches[:firstSeg.glyphCount],
+		})
+	}
+
+	// Each segment defines a scissor state and the start of its range.
+	for i, seg := range a.scissorSegments {
+		// End index is the start of the next segment, or len(pending).
+		var endSDF, endConvex, endStencil, endText, endGlyph int
+		if i+1 < len(a.scissorSegments) {
+			next := a.scissorSegments[i+1]
+			endSDF = next.sdfCount
+			endConvex = next.convexCount
+			endStencil = next.stencilCount
+			endText = next.textCount
+			endGlyph = next.glyphCount
+		} else {
+			endSDF = len(a.pendingShapes)
+			endConvex = len(a.pendingConvexCommands)
+			endStencil = len(a.pendingStencilPaths)
+			endText = len(a.pendingTextBatches)
+			endGlyph = len(a.pendingGlyphMaskBatches)
+		}
+
+		// Skip empty groups.
+		if seg.sdfCount == endSDF && seg.convexCount == endConvex &&
+			seg.stencilCount == endStencil && seg.textCount == endText &&
+			seg.glyphCount == endGlyph {
+			continue
+		}
+
+		groups = append(groups, ScissorGroup{
+			Rect:             seg.rect,
+			SDFShapes:        a.pendingShapes[seg.sdfCount:endSDF],
+			ConvexCommands:   a.pendingConvexCommands[seg.convexCount:endConvex],
+			StencilPaths:     a.pendingStencilPaths[seg.stencilCount:endStencil],
+			TextBatches:      a.pendingTextBatches[seg.textCount:endText],
+			GlyphMaskBatches: a.pendingGlyphMaskBatches[seg.glyphCount:endGlyph],
+		})
+	}
+
+	return groups
+}
+
+func (a *SDFAccelerator) flushLocked(target gg.GPURenderTarget) error { //nolint:cyclop,gocognit,gocyclo,funlen // sequential resource setup + group dispatch
 	if len(a.pendingShapes) == 0 && len(a.pendingConvexCommands) == 0 &&
 		len(a.pendingStencilPaths) == 0 && len(a.pendingTextBatches) == 0 &&
 		len(a.pendingGlyphMaskBatches) == 0 {
@@ -767,50 +861,84 @@ func (a *SDFAccelerator) flushLocked(target gg.GPURenderTarget) error {
 		a.session.SetStencilRenderer(a.stencilRenderer)
 	}
 
-	// Take ownership of pending data.
-	shapes := make([]SDFRenderShape, len(a.pendingShapes))
-	copy(shapes, a.pendingShapes)
+	// Build scissor groups from the timeline BEFORE taking ownership of data.
+	// The groups reference slices of the pending arrays (shallow copy).
+	groups := a.buildScissorGroups()
+
+	// Deep-copy each group's slices so we own the data, then clear pending.
+	ownedGroups := make([]ScissorGroup, len(groups))
+	for i := range groups {
+		g := &groups[i]
+		ownedGroups[i] = ScissorGroup{Rect: g.Rect}
+		if len(g.SDFShapes) > 0 {
+			ownedGroups[i].SDFShapes = make([]SDFRenderShape, len(g.SDFShapes))
+			copy(ownedGroups[i].SDFShapes, g.SDFShapes)
+		}
+		if len(g.ConvexCommands) > 0 {
+			ownedGroups[i].ConvexCommands = make([]ConvexDrawCommand, len(g.ConvexCommands))
+			copy(ownedGroups[i].ConvexCommands, g.ConvexCommands)
+		}
+		if len(g.StencilPaths) > 0 {
+			ownedGroups[i].StencilPaths = make([]StencilPathCommand, len(g.StencilPaths))
+			copy(ownedGroups[i].StencilPaths, g.StencilPaths)
+		}
+		if len(g.TextBatches) > 0 {
+			ownedGroups[i].TextBatches = make([]TextBatch, len(g.TextBatches))
+			copy(ownedGroups[i].TextBatches, g.TextBatches)
+		}
+		if len(g.GlyphMaskBatches) > 0 {
+			ownedGroups[i].GlyphMaskBatches = make([]GlyphMaskBatch, len(g.GlyphMaskBatches))
+			copy(ownedGroups[i].GlyphMaskBatches, g.GlyphMaskBatches)
+		}
+	}
+
+	// Clear pending state.
 	a.pendingShapes = a.pendingShapes[:0]
-
-	convexCmds := make([]ConvexDrawCommand, len(a.pendingConvexCommands))
-	copy(convexCmds, a.pendingConvexCommands)
 	a.pendingConvexCommands = a.pendingConvexCommands[:0]
-
-	paths := make([]StencilPathCommand, len(a.pendingStencilPaths))
-	copy(paths, a.pendingStencilPaths)
 	a.pendingStencilPaths = a.pendingStencilPaths[:0]
-
-	textBatches := make([]TextBatch, len(a.pendingTextBatches))
-	copy(textBatches, a.pendingTextBatches)
 	a.pendingTextBatches = a.pendingTextBatches[:0]
-
-	glyphMaskBatches := make([]GlyphMaskBatch, len(a.pendingGlyphMaskBatches))
-	copy(glyphMaskBatches, a.pendingGlyphMaskBatches)
 	a.pendingGlyphMaskBatches = a.pendingGlyphMaskBatches[:0]
+	a.scissorSegments = a.scissorSegments[:0]
 	a.pendingTarget = nil
 
+	// Collect all text and glyph mask batches across groups for atlas sync.
+	var allTextBatches []TextBatch
+	var allGlyphMaskBatches []GlyphMaskBatch
+	for i := range ownedGroups {
+		allTextBatches = append(allTextBatches, ownedGroups[i].TextBatches...)
+		allGlyphMaskBatches = append(allGlyphMaskBatches, ownedGroups[i].GlyphMaskBatches...)
+	}
+
 	// Upload dirty MSDF atlases to the GPU before rendering text.
-	if len(textBatches) > 0 && a.textEngine != nil {
+	if len(allTextBatches) > 0 && a.textEngine != nil {
 		if err := a.syncTextAtlases(); err != nil {
 			slogger().Warn("atlas sync failed", "err", err)
-			textBatches = nil
+			// Clear text batches from all groups on atlas failure.
+			for i := range ownedGroups {
+				ownedGroups[i].TextBatches = nil
+			}
 		}
 	}
 
 	// Upload dirty glyph mask atlas pages to GPU before rendering.
-	if len(glyphMaskBatches) > 0 && a.glyphMaskEngine != nil {
-		if err := a.syncGlyphMaskAtlases(glyphMaskBatches); err != nil {
+	if len(allGlyphMaskBatches) > 0 && a.glyphMaskEngine != nil {
+		if err := a.syncGlyphMaskAtlases(allGlyphMaskBatches); err != nil {
 			slogger().Warn("glyph mask atlas sync failed", "err", err)
-			glyphMaskBatches = nil
+			for i := range ownedGroups {
+				ownedGroups[i].GlyphMaskBatches = nil
+			}
 		}
 	}
 
-	err := a.session.RenderFrame(target, shapes, convexCmds, paths, textBatches, glyphMaskBatches...)
+	err := a.session.RenderFrameGrouped(target, ownedGroups)
 	if err != nil {
+		total := 0
+		for i := range ownedGroups {
+			total += len(ownedGroups[i].SDFShapes) + len(ownedGroups[i].ConvexCommands) + len(ownedGroups[i].StencilPaths) +
+				len(ownedGroups[i].TextBatches) + len(ownedGroups[i].GlyphMaskBatches)
+		}
 		slogger().Warn("render session error",
-			"shapes", len(shapes), "convex", len(convexCmds),
-			"paths", len(paths), "text", len(textBatches),
-			"glyphMask", len(glyphMaskBatches), "err", err)
+			"groups", len(ownedGroups), "totalItems", total, "err", err)
 	}
 	return err
 }


### PR DESCRIPTION
## Summary

- **Fix GPU scissor rect performance regression** from v0.36.1 — scissor clipping
  created multiple render passes per frame (one per scissor change), causing GPU
  utilization to spike from ~3% to ~45% during ListView scrolling
- Replaced batch-breaking `flushOnScissorChange` with `ScissorGroup` timeline
  tracking — all draws accumulate within a single render pass, scissor rect changed
  per group via `SetScissorRect()` (WebGPU dynamic state, zero cost)
- GPU utilization back to ~3% during scrolling (validated in gogpu/ui Widget Demo)

## Changes

- `internal/gpu/render_session.go` — `ScissorGroup` type, `RenderFrameGrouped`,
  `encodeSubmitReadbackGrouped`/`encodeSubmitSurfaceGrouped`, `recordGroupDraws`
  helper for DRY 5-tier draw recording
- `internal/gpu/sdf_gpu.go` — `scissorSegment` timeline tracking,
  `buildScissorGroups` replaces `flushOnScissorChange`
- `CHANGELOG.md` — v0.36.2 entry

## Test plan

- [x] `GOWORK=off go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] Manual validation: gogpu/ui Widget Demo, ListView 1000 items scrolling, GPU ~3%
