### PR TITLE
chore(examples): update to gg v0.37.1, gogpu v0.24.2

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.37.0
+	github.com/gogpu/gg v0.37.1
 	github.com/gogpu/gogpu v0.24.2
 	github.com/gogpu/gpucontext v0.10.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU
 github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.2 h1:phQCeD5zY8jTgNjkrs090JYUMpqNPO7a9DMXvnHcQ2A=
 github.com/go-webgpu/webgpu v0.4.2/go.mod h1:+gz9PjcckFCZ/Gv1vJXXEDrf7fqo7VHH6uV0nJrSuRk=
-github.com/gogpu/gg v0.37.0 h1:Zpztq8pI9puL5QnG8OPJWqciyypkITDYkpcRlR8QGHI=
-github.com/gogpu/gg v0.37.0/go.mod h1:yUwgxTTWebIa0H/QNXlkQBpNKaNlPv87Q5Swzd8eD7w=
+github.com/gogpu/gg v0.37.1 h1:2x1dHWBmizdqtrioVv9ZyPqeb2EdvxCMHmJOHMZSCc4=
+github.com/gogpu/gg v0.37.1/go.mod h1:H6VUJijMHf6Q1DSSbGbgWERVw3SLERo9GsITphzBBvA=
 github.com/gogpu/gogpu v0.24.2 h1:8zIx3bzdfKyp4pT617ZQNdv5NXyQmzHcip63W2ZTAEQ=
 github.com/gogpu/gogpu v0.24.2/go.mod h1:35QdbmWn2m3EN+V5XtCveKY4YN+qSa24cwhPlJAauFQ=
 github.com/gogpu/gpucontext v0.10.0 h1:Uv9N/J9xJYWYgQNC3rJQVVKdjeakHmIpgUuIoSTXNYw=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.37.0
+require github.com/gogpu/gg v0.37.1
 
 require (
 	github.com/go-text/typesetting v0.3.4 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaF
 github.com/go-text/typesetting v0.3.4/go.mod h1:4qZCQphq4KSgGTAeI0uMEkVbROgfah8BuyF5LRYr7XY=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZzMgdYPbmyXqOto4YhhJGrFIQCX94FpR4MzTCsos=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.37.0 h1:Zpztq8pI9puL5QnG8OPJWqciyypkITDYkpcRlR8QGHI=
-github.com/gogpu/gg v0.37.0/go.mod h1:yUwgxTTWebIa0H/QNXlkQBpNKaNlPv87Q5Swzd8eD7w=
+github.com/gogpu/gg v0.37.1 h1:2x1dHWBmizdqtrioVv9ZyPqeb2EdvxCMHmJOHMZSCc4=
+github.com/gogpu/gg v0.37.1/go.mod h1:H6VUJijMHf6Q1DSSbGbgWERVw3SLERo9GsITphzBBvA=
 github.com/gogpu/gpucontext v0.10.0 h1:Uv9N/J9xJYWYgQNC3rJQVVKdjeakHmIpgUuIoSTXNYw=
 github.com/gogpu/gpucontext v0.10.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=


### PR DESCRIPTION
Examples dependency update.