### PR TITLE
ci: switch Codecov to OIDC authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write  # Required for Codecov OIDC token
+
 jobs:
   # Build verification - Cross-platform
   build:
@@ -100,7 +104,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        use_oidc: true
         files: ./coverage.txt
         flags: unittests
         name: codecov-gg


### PR DESCRIPTION
Replace CODECOV_TOKEN with OIDC for secure tokenless coverage upload.