### PR TITLE
fix: DrawImage with rotation — ImagePattern affine transform (v0.38.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.38.1] - 2026-03-22
+
+### Fixed
+
+- **DrawImage with rotation/skew** — `ImagePattern` now uses pre-computed inverse
+  affine matrix for device-to-image coordinate mapping (Cairo/Skia/tiny-skia pattern).
+  Previously used simple anchor+offset which only worked for axis-aligned transforms.
+  Fixes [#224](https://github.com/gogpu/gg/issues/224).
+
 ## [0.38.0] - 2026-03-21
 
 ### Added

--- a/context_image.go
+++ b/context_image.go
@@ -177,22 +177,32 @@ func (c *Context) DrawImageEx(img *ImageBuf, opts DrawImageOptions) {
 	scaleX := dstWidth / float64(srcW)
 	scaleY := dstHeight / float64(srcH)
 
-	// Transform destination rectangle to device coordinates for the anchor.
-	topLeft := c.totalMatrix().TransformPoint(Pt(opts.X, opts.Y))
+	// Compose the full forward transform: image-space -> device-space.
+	//
+	// The transform chain is:
+	//   1. Scale source pixels to destination size: Scale(scaleX, scaleY)
+	//   2. Position at destination: Translate(opts.X, opts.Y)
+	//   3. Apply current CTM to device space: totalMatrix()
+	//
+	// Forward: device = totalMatrix * Translate(x,y) * Scale(sx,sy) * imageCoord
+	// Inverse: imageCoord = inverse(totalMatrix * Translate(x,y) * Scale(sx,sy)) * device
+	//
+	// This follows the Cairo/Skia/tiny-skia pattern (see IMAGE-PATTERN-TRANSFORM-RESEARCH.md).
+	patternTransform := c.totalMatrix().
+		Multiply(Translate(opts.X, opts.Y)).
+		Multiply(Scale(scaleX, scaleY))
+	inverse := patternTransform.Invert()
 
-	// Create image pattern anchored at the destination position.
+	// Create image pattern with pre-computed inverse transform.
 	pattern := &ImagePattern{
 		image:   img,
 		x:       srcX,
 		y:       srcY,
 		w:       srcW,
 		h:       srcH,
-		anchorX: topLeft.X,
-		anchorY: topLeft.Y,
+		inverse: inverse,
 		opacity: opts.Opacity,
 		clamp:   true, // Don't tile — clamp to image bounds
-		scaleX:  scaleX,
-		scaleY:  scaleY,
 	}
 
 	// Save current state (paint, path, transform).
@@ -223,11 +233,12 @@ func (c *Context) DrawImageEx(img *ImageBuf, opts DrawImageOptions) {
 //	dc.Fill()
 func (c *Context) CreateImagePattern(img *ImageBuf, x, y, w, h int) Pattern {
 	return &ImagePattern{
-		image: img,
-		x:     x,
-		y:     y,
-		w:     w,
-		h:     h,
+		image:   img,
+		x:       x,
+		y:       y,
+		w:       w,
+		h:       h,
+		inverse: Identity(), // identity transform: device coords = image coords (tiling from origin)
 	}
 }
 
@@ -245,18 +256,26 @@ func (c *Context) SetStrokePattern(pattern Pattern) {
 	c.paint.Brush = BrushFromPattern(pattern)
 }
 
-// ImagePattern represents an image-based pattern.
-// When anchorX/anchorY are set, the pattern is positioned at that canvas
-// location instead of tiling from (0,0). Coordinates outside the image region
-// return transparent black (clamp mode) when clamp is true.
+// ImagePattern represents an image-based pattern with full affine transform support.
+// The pattern stores a pre-computed inverse matrix that maps device-space coordinates
+// back to image-space for sampling. This enables correct rendering under rotation,
+// scale, skew, and any combination of affine transforms.
+//
+// For backward compatibility, SetAnchor/SetScale convenience methods rebuild
+// the inverse from anchor+scale parameters. For full affine control, the inverse
+// is set directly by DrawImageEx or via SetTransform.
 type ImagePattern struct {
 	image   *ImageBuf
 	x, y    int     // source region offset within the image
 	w, h    int     // source region size (0 = full image dimension)
-	anchorX float64 // canvas anchor X
-	anchorY float64 // canvas anchor Y
+	inverse Matrix  // maps device-space -> image-space (pre-computed)
 	opacity float64 // opacity multiplier (0=transparent, 1=opaque; 0 means default=1)
 	clamp   bool    // when true, out-of-bounds returns transparent instead of tiling
+
+	// Legacy fields for SetAnchor/SetScale backward compatibility.
+	// When these are used, rebuildInverse() computes the inverse from them.
+	anchorX float64
+	anchorY float64
 	scaleX  float64 // horizontal scale factor (0 means 1.0)
 	scaleY  float64 // vertical scale factor (0 means 1.0)
 }
@@ -264,9 +283,11 @@ type ImagePattern struct {
 // SetAnchor sets the canvas position where the pattern is anchored.
 // This offsets all coordinate lookups so the image appears at (x, y)
 // on the canvas rather than tiled from the origin.
+// The inverse transform is rebuilt to reflect the new anchor.
 func (p *ImagePattern) SetAnchor(x, y float64) {
 	p.anchorX = x
 	p.anchorY = y
+	p.rebuildInverse()
 }
 
 // SetOpacity sets the opacity multiplier for the pattern (0.0 to 1.0).
@@ -283,31 +304,50 @@ func (p *ImagePattern) SetClamp(clamp bool) {
 // SetScale sets the scale factors for the pattern. The source image is scaled
 // by these factors before being sampled. For example, SetScale(2, 2) makes
 // each source pixel cover 2x2 destination pixels.
+// The inverse transform is rebuilt to reflect the new scale.
 func (p *ImagePattern) SetScale(sx, sy float64) {
 	p.scaleX = sx
 	p.scaleY = sy
+	p.rebuildInverse()
+}
+
+// SetTransform sets the full forward transform (image-space to device-space)
+// for the pattern. The inverse is computed and cached for sampling.
+// This overrides any anchor/scale settings.
+func (p *ImagePattern) SetTransform(m Matrix) {
+	p.inverse = m.Invert()
+}
+
+// rebuildInverse computes the inverse transform from the legacy anchor+scale fields.
+// The forward transform is: Translate(anchorX, anchorY) * Scale(scaleX, scaleY),
+// mapping image coordinates to device coordinates.
+func (p *ImagePattern) rebuildInverse() {
+	sx := p.scaleX
+	if sx == 0 {
+		sx = 1
+	}
+	sy := p.scaleY
+	if sy == 0 {
+		sy = 1
+	}
+	// Forward: device = Translate(anchor) * Scale(s) * imageCoord
+	// Inverse: imageCoord = Scale(1/s) * Translate(-anchor) * device
+	//        = (device - anchor) / s
+	forward := Translate(p.anchorX, p.anchorY).Multiply(Scale(sx, sy))
+	p.inverse = forward.Invert()
 }
 
 // ColorAt implements the Pattern interface.
-// It samples the image at the given coordinates. If an anchor is set,
-// coordinates are offset by the anchor position. In clamp mode, out-of-bounds
-// coordinates return transparent black; otherwise the pattern tiles.
+// It samples the image at the given device-space coordinates by applying the
+// pre-computed inverse transform to map back to image-space. In clamp mode,
+// out-of-bounds coordinates return transparent black; otherwise the pattern tiles.
 func (p *ImagePattern) ColorAt(x, y float64) RGBA {
-	// Subtract anchor to get local coordinates relative to the image origin.
-	lx := x - p.anchorX
-	ly := y - p.anchorY
+	// Apply inverse transform: device-space -> image-space.
+	imgPt := p.inverse.TransformPoint(Pt(x, y))
+	lx := imgPt.X
+	ly := imgPt.Y
 
-	// Apply inverse scale (map destination coords to source coords).
-	sx := p.scaleX
-	sy := p.scaleY
-	if sx != 0 {
-		lx /= sx
-	}
-	if sy != 0 {
-		ly /= sy
-	}
-
-	// Get image bounds
+	// Get image bounds.
 	imgW, imgH := p.image.Bounds()
 
 	// Determine pattern region.

--- a/context_image_test.go
+++ b/context_image_test.go
@@ -3,6 +3,7 @@ package gg
 import (
 	"image"
 	"image/color"
+	"math"
 	"testing"
 )
 
@@ -224,11 +225,12 @@ func TestImagePattern_Tiling(t *testing.T) {
 	_ = img.SetRGBA(1, 1, 255, 255, 0, 255) // Yellow
 
 	pattern := &ImagePattern{
-		image: img,
-		x:     0,
-		y:     0,
-		w:     2,
-		h:     2,
+		image:   img,
+		x:       0,
+		y:       0,
+		w:       2,
+		h:       2,
+		inverse: Identity(),
 	}
 
 	// Test wrapping behavior
@@ -604,10 +606,10 @@ func TestImagePattern_Anchor(t *testing.T) {
 		image:   img,
 		w:       10,
 		h:       10,
-		anchorX: 50,
-		anchorY: 50,
+		inverse: Identity(),
 		clamp:   true,
 	}
+	pattern.SetAnchor(50, 50)
 
 	// At the anchor position, should return red.
 	col := pattern.ColorAt(50, 50)
@@ -634,13 +636,13 @@ func TestImagePattern_Scale(t *testing.T) {
 	img := makeTestImage(t, 10, 10, 255, 0, 0, 255)
 
 	pattern := &ImagePattern{
-		image:  img,
-		w:      10,
-		h:      10,
-		scaleX: 2.0, // Each pixel covers 2 destination pixels.
-		scaleY: 2.0,
-		clamp:  true,
+		image:   img,
+		w:       10,
+		h:       10,
+		inverse: Identity(),
+		clamp:   true,
 	}
+	pattern.SetScale(2.0, 2.0)
 
 	// At (0, 0), maps to source (0, 0) — should be red.
 	col := pattern.ColorAt(0, 0)
@@ -670,6 +672,7 @@ func TestImagePattern_Opacity(t *testing.T) {
 		w:       10,
 		h:       10,
 		opacity: 0.5,
+		inverse: Identity(),
 	}
 
 	col := pattern.ColorAt(0, 0)
@@ -830,7 +833,7 @@ func TestStrokeClipped(t *testing.T) {
 
 func TestImagePatternSetters(t *testing.T) {
 	img := makeTestImage(t, 10, 10, 255, 0, 0, 255)
-	p := &ImagePattern{image: img, w: 10, h: 10}
+	p := &ImagePattern{image: img, w: 10, h: 10, inverse: Identity()}
 
 	// SetAnchor
 	p.SetAnchor(100, 200)
@@ -858,6 +861,273 @@ func TestImagePatternSetters(t *testing.T) {
 	p.SetScale(3.0, 4.0)
 	if p.scaleX != 3.0 || p.scaleY != 4.0 {
 		t.Errorf("SetScale: got (%f,%f), want (3,4)", p.scaleX, p.scaleY)
+	}
+}
+
+// --- Rotation / Transform tests (IMG-002, issue #224) ---
+
+// TestDrawImage_Rotation90 reproduces the bug from issue #224:
+// DrawImage with 90-degree rotation should fill the rotated rectangle,
+// not produce a 1px sliver.
+func TestDrawImage_Rotation90(t *testing.T) {
+	// Create a tall narrow red image (100x400).
+	srcImg := makeTestImage(t, 100, 400, 255, 0, 0, 255)
+
+	// Create a wide short canvas (400x100).
+	dc := NewContext(400, 100)
+	dc.ClearWithColor(White)
+
+	// Rotate 90 degrees: the 100x400 image should fill the 400x100 canvas.
+	dc.Translate(400, 0)
+	dc.Rotate(math.Pi / 2)
+	dc.DrawImage(srcImg, 0, 0)
+
+	result := dc.Image()
+
+	// Center pixel should be red.
+	r, _, _, a := result.At(200, 50).RGBA()
+	if a == 0 || r == 0 {
+		t.Errorf("expected red pixel at center (200,50) after 90-degree rotation, got RGBA=(%d,%d,%d,%d)",
+			r>>8, 0, 0, a>>8)
+	}
+
+	// Near top-left corner should also be red (inside the rotated image).
+	r2, _, _, a2 := result.At(10, 10).RGBA()
+	if a2 == 0 || r2 == 0 {
+		t.Errorf("expected red pixel at (10,10) after 90-degree rotation, got RGBA=(%d,%d,%d,%d)",
+			r2>>8, 0, 0, a2>>8)
+	}
+}
+
+// TestDrawImage_Rotation45 verifies drawing with a 45-degree rotation.
+func TestDrawImage_Rotation45(t *testing.T) {
+	srcImg := makeTestImage(t, 50, 50, 0, 0, 255, 255)
+
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+
+	// Center the image and rotate 45 degrees.
+	dc.Translate(100, 100)
+	dc.Rotate(math.Pi / 4)
+	dc.DrawImage(srcImg, -25, -25) // center the 50x50 image
+
+	result := dc.Image()
+
+	// Center pixel (100, 100) should be blue.
+	_, _, b, a := result.At(100, 100).RGBA()
+	if a == 0 || b == 0 {
+		t.Errorf("expected blue pixel at center (100,100) after 45-degree rotation, got B=%d A=%d",
+			b>>8, a>>8)
+	}
+}
+
+// TestDrawImage_NoTransformRegression verifies that DrawImage without any
+// transform continues to work correctly after the affine refactoring.
+func TestDrawImage_NoTransformRegression(t *testing.T) {
+	srcImg := makeTestImage(t, 50, 50, 255, 0, 0, 255)
+
+	dc := NewContext(200, 200)
+	dc.Clear()
+	dc.DrawImage(srcImg, 10, 10)
+
+	// Pixel at (10, 10) should be red.
+	pixel := dc.pixmap.GetPixel(10, 10)
+	if pixel.R < 0.9 {
+		t.Errorf("expected red at (10,10), got R=%.2f", pixel.R)
+	}
+
+	// Pixel at (59, 59) should be red (10+50-1).
+	pixel2 := dc.pixmap.GetPixel(59, 59)
+	if pixel2.R < 0.9 {
+		t.Errorf("expected red at (59,59), got R=%.2f", pixel2.R)
+	}
+
+	// Pixel outside at (60, 10) should NOT be red.
+	pixel3 := dc.pixmap.GetPixel(60, 10)
+	if pixel3.R > 0.1 {
+		t.Errorf("expected no red at (60,10), got R=%.2f", pixel3.R)
+	}
+}
+
+// TestDrawImage_Scale2x verifies DrawImage with Scale(2,2) transform.
+func TestDrawImage_Scale2x(t *testing.T) {
+	srcImg := makeTestImage(t, 50, 50, 0, 255, 0, 255)
+
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+	dc.Scale(2, 2)
+	dc.DrawImage(srcImg, 10, 10)
+
+	result := dc.Image()
+
+	// In device space, the image at user (10,10) with 2x scale is at device (20,20).
+	// The 50x50 image scaled 2x covers device pixels (20,20) to (119,119).
+	r, g, _, a := result.At(20, 20).RGBA()
+	if a == 0 || g == 0 {
+		t.Errorf("expected green at device (20,20) with 2x scale, got G=%d A=%d", g>>8, a>>8)
+	}
+	_ = r
+
+	// Center of scaled image: device (70, 70).
+	_, g2, _, a2 := result.At(70, 70).RGBA()
+	if a2 == 0 || g2 == 0 {
+		t.Errorf("expected green at device (70,70) with 2x scale, got G=%d A=%d", g2>>8, a2>>8)
+	}
+}
+
+// TestDrawImage_TranslateRotate verifies combined translate + rotate.
+func TestDrawImage_TranslateRotate(t *testing.T) {
+	srcImg := makeTestImage(t, 40, 40, 255, 255, 0, 255)
+
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+	dc.Translate(100, 100)
+	dc.Rotate(math.Pi / 6) // 30 degrees
+	dc.DrawImage(srcImg, -20, -20)
+
+	result := dc.Image()
+
+	// Center of rotation is at (100, 100). The image is centered there.
+	// After rotation, (100, 100) should be yellow (the image center).
+	r, g, _, a := result.At(100, 100).RGBA()
+	if a == 0 || r == 0 || g == 0 {
+		t.Errorf("expected yellow at (100,100) with translate+rotate, got R=%d G=%d A=%d",
+			r>>8, g>>8, a>>8)
+	}
+}
+
+// TestDrawImage_DeviceScale verifies DrawImage with WithDeviceScale(2.0).
+func TestDrawImage_DeviceScale(t *testing.T) {
+	srcImg := makeTestImage(t, 50, 50, 0, 0, 255, 255)
+
+	dc := NewContextWithScale(200, 200, 2.0)
+	dc.Clear()
+	dc.DrawImage(srcImg, 10, 10)
+
+	// Physical pixmap is 400x400. Image at logical (10,10) should map to
+	// device (20,20) with 2x scale. Each source pixel covers 2x2 device pixels
+	// via the deviceMatrix, so the image covers device (20,20) to (119,119).
+	pixel := dc.pixmap.GetPixel(20, 20)
+	if pixel.B < 0.8 {
+		t.Errorf("expected blue at device (20,20) with DeviceScale=2, got B=%.2f", pixel.B)
+	}
+
+	pixel2 := dc.pixmap.GetPixel(60, 60)
+	if pixel2.B < 0.8 {
+		t.Errorf("expected blue at device (60,60) with DeviceScale=2, got B=%.2f", pixel2.B)
+	}
+
+	// Well outside the image region should not be blue.
+	pixel3 := dc.pixmap.GetPixel(200, 20)
+	if pixel3.B > 0.1 {
+		t.Errorf("expected no blue at device (200,20) with DeviceScale=2, got B=%.2f", pixel3.B)
+	}
+}
+
+// TestDrawImageEx_SrcRectWithRotation verifies SrcRect works with rotation.
+func TestDrawImageEx_SrcRectWithRotation(t *testing.T) {
+	// Create 100x100 image: top-left red, top-right green.
+	img, err := NewImageBuf(100, 100, FormatRGBA8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for y := 0; y < 50; y++ {
+		for x := 0; x < 50; x++ {
+			_ = img.SetRGBA(x, y, 255, 0, 0, 255)
+		}
+	}
+	for y := 0; y < 50; y++ {
+		for x := 50; x < 100; x++ {
+			_ = img.SetRGBA(x, y, 0, 255, 0, 255)
+		}
+	}
+
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+
+	// Draw only the red quadrant (top-left 50x50) rotated 90 degrees.
+	srcRect := image.Rect(0, 0, 50, 50)
+	dc.Translate(100, 100)
+	dc.Rotate(math.Pi / 2)
+	dc.DrawImageEx(img, DrawImageOptions{
+		X:       -25,
+		Y:       -25,
+		SrcRect: &srcRect,
+		Opacity: 1.0,
+	})
+
+	result := dc.Image()
+
+	// Center should be red (from the top-left quadrant).
+	r, g, _, a := result.At(100, 100).RGBA()
+	if a == 0 || r == 0 {
+		t.Errorf("expected red at center with SrcRect+rotation, got R=%d G=%d A=%d",
+			r>>8, g>>8, a>>8)
+	}
+	// Should not be green (that's the other quadrant).
+	if g>>8 > 50 {
+		t.Errorf("expected no green at center (wrong quadrant), got G=%d", g>>8)
+	}
+}
+
+// TestCreateImagePattern_Compat verifies backward compatibility of
+// CreateImagePattern after the affine transform refactoring.
+func TestCreateImagePattern_Compat(t *testing.T) {
+	dc := NewContext(200, 200)
+	img := makeTestImage(t, 20, 20, 255, 0, 0, 255)
+
+	pattern := dc.CreateImagePattern(img, 0, 0, 20, 20)
+
+	// Should tile: ColorAt(0,0) = red.
+	col := pattern.ColorAt(0, 0)
+	if col.R < 0.9 || col.A < 0.9 {
+		t.Errorf("expected red at (0,0), got R=%.2f A=%.2f", col.R, col.A)
+	}
+
+	// Tiling: ColorAt(20, 0) wraps to (0, 0) = red.
+	col2 := pattern.ColorAt(20, 0)
+	if col2.R < 0.9 || col2.A < 0.9 {
+		t.Errorf("expected red at (20,0) via tiling, got R=%.2f A=%.2f", col2.R, col2.A)
+	}
+
+	// Use as fill pattern and draw.
+	dc.SetFillPattern(pattern)
+	dc.DrawRectangle(0, 0, 200, 200)
+	_ = dc.Fill()
+
+	// Check some pixels are red.
+	pixel := dc.pixmap.GetPixel(10, 10)
+	if pixel.R < 0.8 {
+		t.Errorf("expected red fill from pattern at (10,10), got R=%.2f", pixel.R)
+	}
+}
+
+// TestImagePattern_SetTransform verifies the new SetTransform method.
+func TestImagePattern_SetTransform(t *testing.T) {
+	img := makeTestImage(t, 10, 10, 255, 0, 0, 255)
+
+	p := &ImagePattern{
+		image:   img,
+		w:       10,
+		h:       10,
+		inverse: Identity(),
+		clamp:   true,
+	}
+
+	// Set a transform that translates (50,50) -> image origin.
+	// Forward: device = Translate(50,50) * imageCoord
+	p.SetTransform(Translate(50, 50))
+
+	// At device (50, 50), should map to image (0, 0) = red.
+	col := p.ColorAt(50, 50)
+	if col.R < 0.9 || col.A < 0.9 {
+		t.Errorf("expected red at (50,50) with SetTransform, got R=%.2f A=%.2f", col.R, col.A)
+	}
+
+	// At device (0, 0), should map to image (-50, -50) = out of bounds.
+	col2 := p.ColorAt(0, 0)
+	if col2.A > 0.01 {
+		t.Errorf("expected transparent at (0,0) with SetTransform, got A=%.2f", col2.A)
 	}
 }
 


### PR DESCRIPTION
Fixes #224. ImagePattern uses pre-computed inverse Matrix for device-to-image mapping (Cairo/Skia pattern). 9 new tests, zero regression.