### PR TITLE
chore(deps): update examples to gg v0.39.1

### DIFF
--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.39.0
+	github.com/gogpu/gg v0.39.1
 	github.com/gogpu/gogpu v0.26.3
 	github.com/gogpu/gpucontext v0.11.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.39.0 h1:LFp3pBJUcmYbVDKIaMbVlmDugIaY4UAYiDkSU5DEP5c=
-github.com/gogpu/gg v0.39.0/go.mod h1:wHZZ3Slq2U/3FIKgYX35tBiKwM3QdMIKWshxBpRM4gc=
+github.com/gogpu/gg v0.39.1 h1:IG9XVJBaWoSGwfJDIkDg6umcljvpMTCZjiFm36HjTac=
+github.com/gogpu/gg v0.39.1/go.mod h1:5iHARXWF8rx1Q99A4w4kDJdKvSuq+h8jslnFWkgUmX4=
 github.com/gogpu/gogpu v0.26.3 h1:ZS940Aqk5R2ne8wTAQ6C0Fv5tG8Sbwlj9o9f80IFBZ4=
 github.com/gogpu/gogpu v0.26.3/go.mod h1:lDChqAtXl9GFIdOd0iBRnoz5DS3BweeUOa81npFu25E=
 github.com/gogpu/gpucontext v0.11.0 h1:dm+u3+Sl0Xgh7iZiRRUb36GDpSi8RpNk8n3NPmd5sGw=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/lcd_text
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.39.0
+	github.com/gogpu/gg v0.39.1
 	github.com/gogpu/gogpu v0.26.3
 )
 

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.39.0 h1:LFp3pBJUcmYbVDKIaMbVlmDugIaY4UAYiDkSU5DEP5c=
-github.com/gogpu/gg v0.39.0/go.mod h1:wHZZ3Slq2U/3FIKgYX35tBiKwM3QdMIKWshxBpRM4gc=
+github.com/gogpu/gg v0.39.1 h1:IG9XVJBaWoSGwfJDIkDg6umcljvpMTCZjiFm36HjTac=
+github.com/gogpu/gg v0.39.1/go.mod h1:5iHARXWF8rx1Q99A4w4kDJdKvSuq+h8jslnFWkgUmX4=
 github.com/gogpu/gogpu v0.26.3 h1:ZS940Aqk5R2ne8wTAQ6C0Fv5tG8Sbwlj9o9f80IFBZ4=
 github.com/gogpu/gogpu v0.26.3/go.mod h1:lDChqAtXl9GFIdOd0iBRnoz5DS3BweeUOa81npFu25E=
 github.com/gogpu/gpucontext v0.11.0 h1:dm+u3+Sl0Xgh7iZiRRUb36GDpSi8RpNk8n3NPmd5sGw=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.39.0
+require github.com/gogpu/gg v0.39.1
 
 require (
 	github.com/go-text/typesetting v0.3.4 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaF
 github.com/go-text/typesetting v0.3.4/go.mod h1:4qZCQphq4KSgGTAeI0uMEkVbROgfah8BuyF5LRYr7XY=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZzMgdYPbmyXqOto4YhhJGrFIQCX94FpR4MzTCsos=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.39.0 h1:LFp3pBJUcmYbVDKIaMbVlmDugIaY4UAYiDkSU5DEP5c=
-github.com/gogpu/gg v0.39.0/go.mod h1:wHZZ3Slq2U/3FIKgYX35tBiKwM3QdMIKWshxBpRM4gc=
+github.com/gogpu/gg v0.39.1 h1:IG9XVJBaWoSGwfJDIkDg6umcljvpMTCZjiFm36HjTac=
+github.com/gogpu/gg v0.39.1/go.mod h1:5iHARXWF8rx1Q99A4w4kDJdKvSuq+h8jslnFWkgUmX4=
 github.com/gogpu/gpucontext v0.11.0 h1:dm+u3+Sl0Xgh7iZiRRUb36GDpSi8RpNk8n3NPmd5sGw=
 github.com/gogpu/gpucontext v0.11.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.4.0 h1:nPFn77na71K4gkyObbXgpYywy9lIKz/U1x/2+4EAZ3Y=


### PR DESCRIPTION
Update all examples to gg v0.39.1 (wgpu v0.24.2, gogpu v0.26.3, naga v0.17.0).