### PR TITLE
fix: MSDF text overlapping on Retina (v0.39.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.3] - 2026-04-07
+
+### Fixed
+
+- **MSDF text overlapping on Retina** — Large text (28px+) had overlapping letters and
+  rectangular artifacts on HiDPI displays (scale=2). MSDF quad positioning used
+  `fontSize / refSize` which included deviceScale, producing physical-pixel positions
+  in a logical coordinate system. Fixed to `logicalSize / refSize` — CTM handles
+  device scaling. Small text (<48px device) was unaffected (uses Glyph Mask pipeline).
+  (#247, reported by @jdbann)
+
 ## [0.39.2] - 2026-04-07
 
 ### Added

--- a/internal/gpu/gpu_text.go
+++ b/internal/gpu/gpu_text.go
@@ -101,12 +101,8 @@ func (e *GPUTextEngine) LayoutText(
 	defer e.mu.Unlock()
 
 	logicalSize := face.Size()
-	// Apply device scale to get effective physical font size.
-	// On HiDPI displays (deviceScale > 1) this produces higher-quality MSDF
-	// rendering because screenPxRange scales proportionally with physical size.
-	fontSize := logicalSize * deviceScale
-	if fontSize <= 0 {
-		fontSize = logicalSize // fallback: never zero
+	if logicalSize <= 0 {
+		logicalSize = 16 // fallback: never zero
 	}
 	fontSource := face.Source()
 	fontID := computeFontID(fontSource)
@@ -115,10 +111,13 @@ func (e *GPUTextEngine) LayoutText(
 	var quads []TextQuad
 	var glyphCount, outlineSkip, atlasSkip, boundsSkip int
 
-	// Scale ratio: outline is extracted at msdfSize, positions are at fontSize.
-	// All outline-space values are multiplied by ratio to get screen pixels.
+	// Scale ratio: outline is extracted at msdfSize, quad positions are in user space.
+	// All outline-space values are multiplied by ratio to get user-space coordinates.
+	// Use logicalSize (not fontSize which includes deviceScale) because the CTM
+	// already handles device scaling — quads must be in logical user-space coords.
+	// (BUG-MSDF-RETINA-001: was fontSize/refSize which doubled positions on Retina)
 	refSize := float64(e.msdfSize)
-	ratio := fontSize / refSize
+	ratio := logicalSize / refSize
 
 	for glyph := range face.Glyphs(s) {
 		glyphCount++


### PR DESCRIPTION
## Summary

Fixes #247 — MSDF text (28px+) had overlapping letters and rectangular artifacts on Retina (scale=2).

**Root cause:** `ratio = fontSize / refSize` included `deviceScale`, producing physical-pixel positions in a logical coordinate system. Changed to `logicalSize / refSize` — CTM handles device scaling. Matches Glyph Mask pipeline pattern.

## Test plan

- [x] DX12 scale=1: no regression (screenshot verified)
- [x] Lint: 0 issues
- [ ] Retina scale=2: awaiting @jdbann verification