### PR TITLE
feat: alpha mask API — per-shape, per-layer, luminance, GPU interface (v0.40.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.0] - 2026-04-08
+
+### Added
+
+- **Alpha mask API** — complete enterprise-level masking system following Vello/tiny-skia patterns.
+  Fixes #238 (SetMask ignored during Fill) and #236 (AsMask documentation). (@Rider21)
+
+  **Per-shape masking** (`SetMask`/`ClearMask`):
+  - `SetMask(mask)` modulates each Fill/Stroke individually — mask value (0-255) multiplies pixel coverage
+  - Mask and clip compose multiplicatively when both active
+  - Saved/restored with Push/Pop
+
+  **Per-layer masking** (`PushMaskLayer`/`PopLayer`):
+  - `PushMaskLayer(mask)` creates isolated layer; all drawing goes to layer unmasked
+  - `PopLayer()` applies mask to entire layer before compositing back
+  - Nested layers compose correctly; `PushMaskLayer(nil)` = regular `PushLayer`
+
+  **Post-processing** (`ApplyMask`):
+  - `ApplyMask(mask)` applies DestinationIn blend to already-drawn content
+  - All premultiplied channels scaled by mask value
+
+  **Mask constructors:**
+  - `NewLuminanceMask(img)` — CSS Masking Level 1 formula (Y = 0.2126R + 0.7152G + 0.0722B)
+  - `NewMaskFromData(data, w, h)` — raw byte constructor with copy semantics
+
+  **GPU integration:**
+  - `MaskAware` interface for GPU accelerators to support mask textures
+  - GPU path uploads mask as R8Unorm texture when accelerator supports it
+  - Falls back to CPU when accelerator does not implement `MaskAware`
+
+### Improved
+
+- **AsMask documentation** — clarified that it works with the current unfilled path,
+  added three correct usage patterns and documented the common mistake of calling
+  AsMask after Fill (which clears the path)
+
 ## [0.39.4] - 2026-04-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 | **Rendering** | Immediate and retained mode, six-tier GPU acceleration (SDF, Convex, Stencil+Cover, MSDF Text, Compute, Glyph Mask), Vello analytic AA, GPU scissor rect clipping, CPU fallback |
 | **Shapes** | Rectangles, circles, ellipses, arcs, bezier curves, polygons, stars |
 | **Text** | TrueType fonts, MSDF + glyph mask dual-strategy rendering, TextMode auto-selection, DPI-aware HiDPI text, ClearType LCD subpixel rendering, font hinting (auto-hinter), transform-aware CPU text (scale/rotate/shear), glyph outline caching, emoji support, bidirectional text, HarfBuzz shaping |
-| **Compositing** | 29 blend modes (Porter-Duff, Advanced, HSL), layer isolation |
+| **Compositing** | 29 blend modes (Porter-Duff, Advanced, HSL), layer isolation, alpha masks (per-shape, per-layer, luminance, post-process) |
 | **Images** | 7 pixel formats, PNG/JPEG/WebP I/O, mipmaps, affine transforms |
 | **SVG** | Full SVG renderer (`gg/svg`): parse + render SVG XML with color override for theming, SVG path data parser (`ParseSVGPath`), transform-aware `FillPath`/`StrokePath` |
 | **Vector Export** | Recording system with PDF and SVG backends |
@@ -389,17 +389,33 @@ dc.PopLayer()
 
 ### Alpha Masks
 
-Sophisticated compositing with masks:
+Per-shape masking — each draw individually masked:
 
 ```go
+// Create a circular mask
 dc.DrawCircle(200, 200, 100)
-dc.Fill()
-mask := dc.AsMask()
+mask := dc.AsMask() // capture path as mask (before Fill!)
+dc.ClearPath()
 
-dc2 := gg.NewContext(400, 400)
-dc2.SetMask(mask)
-dc2.DrawRectangle(0, 0, 400, 400)
-dc2.Fill() // Only visible through mask
+// Apply mask: only the circle area is visible
+dc.SetMask(mask)
+dc.SetRGB(0, 0, 1)
+dc.DrawRectangle(0, 0, 400, 400)
+dc.Fill() // blue only inside the circle
+```
+
+Per-layer masking — mask an entire group of draws:
+
+```go
+mask := gg.NewMask(400, 400)
+// ... fill mask with desired shape ...
+
+dc.PushMaskLayer(mask)
+dc.DrawCircle(100, 100, 50)
+dc.Fill()
+dc.DrawRectangle(200, 200, 80, 80)
+dc.Fill()
+dc.PopLayer() // entire layer masked, then composited
 ```
 
 ### Recording & Vector Export

--- a/accelerator.go
+++ b/accelerator.go
@@ -415,6 +415,26 @@ type LCDLayoutAware interface {
 	SetLCDLayout(layout LCDLayout)
 }
 
+// MaskAware is an optional interface for accelerators that support
+// GPU-accelerated alpha masking. When the Context has an active mask,
+// it uploads the mask data to the accelerator as a texture. The fragment
+// shader multiplies output alpha by the mask texel, eliminating the need
+// to fall back to CPU rendering for masked shapes.
+//
+// SetMaskTexture uploads the mask data (8-bit per pixel, row-major).
+// Pass nil data to clear the mask texture.
+// ClearMaskTexture removes the mask, restoring unmasked rendering.
+type MaskAware interface {
+	// SetMaskTexture uploads an alpha mask for GPU rendering.
+	// data is an 8-bit grayscale buffer (width*height bytes).
+	// The accelerator creates an R8Unorm texture and samples it in the
+	// fragment shader to modulate output alpha.
+	SetMaskTexture(data []byte, width, height int)
+
+	// ClearMaskTexture removes the GPU mask texture.
+	ClearMaskTexture()
+}
+
 // SceneStatsTracker is an optional interface for accelerators that track
 // per-frame scene statistics for auto pipeline selection. The Context
 // does not call these methods directly — the accelerator uses them internally.

--- a/context.go
+++ b/context.go
@@ -1108,27 +1108,39 @@ func (c *Context) flushGPUAccelerator() {
 }
 
 // tryGPUFill attempts to fill the current path using the GPU accelerator.
-// Falls back to CPU when an alpha mask is active (GPU mask support is Phase 2).
+// When a mask is active and the accelerator implements MaskAware, the mask
+// is uploaded as a GPU texture. Otherwise, falls back to CPU.
 func (c *Context) tryGPUFill() error {
-	if c.mask != nil {
-		return ErrFallbackToCPU
-	}
 	a := Accelerator()
 	if a == nil {
 		return ErrFallbackToCPU
+	}
+	if c.mask != nil {
+		if ma, ok := a.(MaskAware); ok {
+			ma.SetMaskTexture(c.mask.Data(), c.mask.Width(), c.mask.Height())
+			defer ma.ClearMaskTexture()
+		} else {
+			return ErrFallbackToCPU
+		}
 	}
 	return c.tryGPUOp(a, a.FillShape, a.FillPath, AccelFill)
 }
 
 // tryGPUStroke attempts to stroke the current path using the GPU accelerator.
-// Falls back to CPU when an alpha mask is active (GPU mask support is Phase 2).
+// When a mask is active and the accelerator implements MaskAware, the mask
+// is uploaded as a GPU texture. Otherwise, falls back to CPU.
 func (c *Context) tryGPUStroke() error {
-	if c.mask != nil {
-		return ErrFallbackToCPU
-	}
 	a := Accelerator()
 	if a == nil {
 		return ErrFallbackToCPU
+	}
+	if c.mask != nil {
+		if ma, ok := a.(MaskAware); ok {
+			ma.SetMaskTexture(c.mask.Data(), c.mask.Width(), c.mask.Height())
+			defer ma.ClearMaskTexture()
+		} else {
+			return ErrFallbackToCPU
+		}
 	}
 	return c.tryGPUOp(a, a.StrokeShape, a.StrokePath, AccelStroke)
 }

--- a/context.go
+++ b/context.go
@@ -1108,7 +1108,11 @@ func (c *Context) flushGPUAccelerator() {
 }
 
 // tryGPUFill attempts to fill the current path using the GPU accelerator.
+// Falls back to CPU when an alpha mask is active (GPU mask support is Phase 2).
 func (c *Context) tryGPUFill() error {
+	if c.mask != nil {
+		return ErrFallbackToCPU
+	}
 	a := Accelerator()
 	if a == nil {
 		return ErrFallbackToCPU
@@ -1117,7 +1121,11 @@ func (c *Context) tryGPUFill() error {
 }
 
 // tryGPUStroke attempts to stroke the current path using the GPU accelerator.
+// Falls back to CPU when an alpha mask is active (GPU mask support is Phase 2).
 func (c *Context) tryGPUStroke() error {
+	if c.mask != nil {
+		return ErrFallbackToCPU
+	}
 	a := Accelerator()
 	if a == nil {
 		return ErrFallbackToCPU
@@ -1214,6 +1222,10 @@ func (c *Context) doFill() error {
 	c.applyClipToPaint()
 	defer func() { c.paint.ClipCoverage = nil }()
 
+	// Set mask coverage function on paint so the renderer can apply alpha masking.
+	c.applyMaskToPaint()
+	defer func() { c.paint.MaskCoverage = nil }()
+
 	return c.renderer.Fill(c.pixmap, devicePath, c.paint)
 }
 
@@ -1247,6 +1259,10 @@ func (c *Context) doStroke() error {
 	c.applyClipToPaint()
 	defer func() { c.paint.ClipCoverage = nil }()
 
+	// Set mask coverage function on paint so the renderer can apply alpha masking.
+	c.applyMaskToPaint()
+	defer func() { c.paint.MaskCoverage = nil }()
+
 	return c.renderer.Stroke(c.pixmap, devicePath, c.paint)
 }
 
@@ -1260,6 +1276,19 @@ func (c *Context) applyClipToPaint() {
 	cs := c.clipStack
 	c.paint.ClipCoverage = func(x, y float64) byte {
 		return cs.Coverage(x, y)
+	}
+}
+
+// applyMaskToPaint sets the MaskCoverage function on the paint when an alpha
+// mask is active. This allows the renderer to apply per-pixel mask modulation
+// during compositing. Mask and clip compose multiplicatively.
+func (c *Context) applyMaskToPaint() {
+	if c.mask == nil {
+		return
+	}
+	m := c.mask
+	c.paint.MaskCoverage = func(x, y int) uint8 {
+		return m.At(x, y)
 	}
 }
 

--- a/context_layer.go
+++ b/context_layer.go
@@ -12,6 +12,7 @@ type Layer struct {
 	pixmap    *Pixmap
 	blendMode BlendMode
 	opacity   float64
+	mask      *Mask // optional alpha mask, applied on PopLayer (nil = no mask)
 }
 
 // layerStack manages the layer hierarchy for the context.
@@ -113,11 +114,75 @@ func (c *Context) PopLayer() {
 		c.basePixmap = nil
 	}
 
+	// Apply mask to layer content before compositing (PushMaskLayer).
+	if layer.mask != nil {
+		c.applyMaskToPixmap(layer.pixmap, layer.mask)
+	}
+
 	// Composite layer onto parent
 	c.compositeLayer(layer, parentPixmap)
 
 	// Restore parent pixmap as current drawing target
 	c.pixmap = parentPixmap
+}
+
+// PushMaskLayer creates an isolated layer with an associated alpha mask.
+// All subsequent drawing operations render to this layer normally (without masking).
+// When PopLayer is called, the ENTIRE layer is masked by the mask and then
+// composited onto the parent using source-over blending with full opacity.
+//
+// This produces different results from SetMask: PushMaskLayer masks the
+// composited group, while SetMask masks each shape individually.
+//
+// Matches Vello push_mask_layer() semantics (research §4).
+//
+// Example:
+//
+//	mask := gg.NewMaskFromAlpha(maskImage)
+//	dc.PushMaskLayer(mask)
+//	dc.DrawCircle(100, 100, 50)
+//	dc.Fill()
+//	dc.DrawRect(80, 80, 40, 40)
+//	dc.Fill()
+//	dc.PopLayer() // entire layer content masked, then composited
+func (c *Context) PushMaskLayer(mask *Mask) {
+	// Clamp: nil mask means no masking (equivalent to PushLayer).
+	if mask == nil {
+		c.PushLayer(BlendNormal, 1.0)
+		return
+	}
+
+	// Initialize layer stack if needed.
+	if c.layerStack == nil {
+		c.layerStack = newLayerStack()
+	}
+
+	// Save base pixmap on first push.
+	if len(c.layerStack.layers) == 0 && c.basePixmap == nil {
+		c.basePixmap = c.pixmap
+	}
+
+	// Create new pixmap for the layer (same size as context).
+	layerPixmap := NewPixmap(c.width, c.height)
+	layerPixmap.Clear(Transparent)
+
+	// Create layer with mask.
+	layer := &Layer{
+		pixmap:    layerPixmap,
+		blendMode: BlendNormal,
+		opacity:   1.0,
+		mask:      mask,
+	}
+
+	// Switch to layer pixmap.
+	c.layerStack.layers = append(c.layerStack.layers, layer)
+	c.pixmap = layerPixmap
+}
+
+// applyMaskToPixmap applies a DestinationIn mask to a pixmap's pixel data.
+// For each pixel: all channels are scaled by mask.At(x,y) / 255.
+func (c *Context) applyMaskToPixmap(pm *Pixmap, mask *Mask) {
+	applyMaskToPixmapData(pm, mask)
 }
 
 // SetBlendMode sets the blend mode for subsequent fill and stroke operations.

--- a/context_mask.go
+++ b/context_mask.go
@@ -1,7 +1,13 @@
 package gg
 
 // SetMask sets an alpha mask for subsequent drawing operations.
-// The mask modulates the alpha of all drawing operations.
+// The mask modulates the alpha of all Fill and Stroke operations —
+// each pixel's coverage is multiplied by the mask value at that pixel.
+// A mask value of 255 means fully visible, 0 means fully transparent.
+//
+// When both a mask and a clip are active, they compose multiplicatively:
+// finalCoverage = shapeCoverage * clipCoverage * maskCoverage / (255*255).
+//
 // Pass nil to clear the mask.
 func (c *Context) SetMask(mask *Mask) {
 	c.mask = mask
@@ -25,9 +31,37 @@ func (c *Context) ClearMask() {
 	c.mask = nil
 }
 
-// AsMask creates a mask from the current path.
-// The mask is filled according to the current fill rule.
-// The path is NOT cleared after this operation.
+// AsMask creates a mask from the current unfilled path.
+// The current path is rasterized (filled with white on a transparent background)
+// and the alpha channel is extracted into a Mask. The fill rule from the context
+// is used for rasterization. The path is NOT cleared after this operation.
+//
+// IMPORTANT: AsMask works with the current path, which is cleared by [Context.Fill].
+// Call AsMask BEFORE Fill, or use [Context.FillPreserve] to keep the path.
+//
+// Correct usage patterns:
+//
+//	// Pattern 1: AsMask before Fill
+//	dc.DrawCircle(50, 50, 30)
+//	mask := dc.AsMask()    // captures the circle path as a mask
+//	dc.Fill()              // fills the circle (clears the path)
+//
+//	// Pattern 2: FillPreserve + AsMask
+//	dc.DrawCircle(50, 50, 30)
+//	dc.FillPreserve()      // fills but keeps the path
+//	mask := dc.AsMask()    // still has the circle path
+//	dc.ClearPath()
+//
+//	// Pattern 3: Capture rendered output as mask
+//	dc.DrawCircle(50, 50, 30)
+//	dc.Fill()              // path is now cleared
+//	mask := NewMaskFromAlpha(dc.Image()) // capture from rendered pixels
+//
+// Common mistake (returns empty mask):
+//
+//	dc.DrawCircle(50, 50, 30)
+//	dc.Fill()              // clears the path!
+//	mask := dc.AsMask()    // path is empty → mask is all zeros
 func (c *Context) AsMask() *Mask {
 	mask := NewMask(c.Width(), c.Height())
 

--- a/context_mask.go
+++ b/context_mask.go
@@ -31,6 +31,23 @@ func (c *Context) ClearMask() {
 	c.mask = nil
 }
 
+// ApplyMask applies a mask to already-drawn content using DestinationIn blending.
+// For each pixel, the alpha is modulated by the mask value:
+//
+//	pixel.A = pixel.A * mask.At(x,y) / 255
+//
+// RGB channels are also scaled proportionally (premultiplied alpha).
+// This is a post-processing operation — it modifies existing pixel content,
+// not future draws. Pass nil to no-op.
+//
+// Matches tiny-skia apply_mask() with DestinationIn blend (research §3).
+func (c *Context) ApplyMask(mask *Mask) {
+	if mask == nil {
+		return
+	}
+	applyMaskToPixmapData(c.pixmap, mask)
+}
+
 // AsMask creates a mask from the current unfilled path.
 // The current path is rasterized (filled with white on a transparent background)
 // and the alpha channel is extracted into a Mask. The fill rule from the context

--- a/mask.go
+++ b/mask.go
@@ -100,3 +100,110 @@ func (m *Mask) Clone() *Mask {
 func (m *Mask) Data() []uint8 {
 	return m.data
 }
+
+// applyMaskToPixmapData applies DestinationIn blending to a pixmap using a mask.
+// For each pixel: all premultiplied channels are scaled by mask.At(x,y) / 255.
+// Pixels outside the mask bounds are cleared to transparent.
+func applyMaskToPixmapData(pm *Pixmap, mask *Mask) {
+	data := pm.Data()
+	pw, ph := pm.Width(), pm.Height()
+	mw, mh := mask.Width(), mask.Height()
+
+	maxX := pw
+	if mw < maxX {
+		maxX = mw
+	}
+	maxY := ph
+	if mh < maxY {
+		maxY = mh
+	}
+
+	for y := 0; y < maxY; y++ {
+		for x := 0; x < maxX; x++ {
+			mv := uint16(mask.At(x, y))
+			if mv == 255 {
+				continue // fully visible, no change
+			}
+			idx := (y*pw + x) * 4
+			if mv == 0 {
+				// Fully masked out: clear pixel.
+				data[idx+0] = 0
+				data[idx+1] = 0
+				data[idx+2] = 0
+				data[idx+3] = 0
+				continue
+			}
+			// DestinationIn: dst = dst * maskAlpha / 255
+			data[idx+0] = uint8(uint16(data[idx+0]) * mv / 255)
+			data[idx+1] = uint8(uint16(data[idx+1]) * mv / 255)
+			data[idx+2] = uint8(uint16(data[idx+2]) * mv / 255)
+			data[idx+3] = uint8(uint16(data[idx+3]) * mv / 255)
+		}
+	}
+
+	// Clear pixels outside mask bounds.
+	if mw < pw {
+		for y := 0; y < maxY; y++ {
+			for x := mw; x < pw; x++ {
+				idx := (y*pw + x) * 4
+				data[idx+0] = 0
+				data[idx+1] = 0
+				data[idx+2] = 0
+				data[idx+3] = 0
+			}
+		}
+	}
+	if mh < ph {
+		for y := mh; y < ph; y++ {
+			for x := 0; x < pw; x++ {
+				idx := (y*pw + x) * 4
+				data[idx+0] = 0
+				data[idx+1] = 0
+				data[idx+2] = 0
+				data[idx+3] = 0
+			}
+		}
+	}
+}
+
+// NewLuminanceMask creates a mask from an image using the CSS Masking Level 1
+// luminance formula: Y = 0.2126*R + 0.7152*G + 0.0722*B. The luminance
+// value is used directly as the mask alpha (brighter = more visible).
+//
+// This matches tiny-skia MaskType::Luminance and Vello Mask::new_luminance().
+func NewLuminanceMask(img image.Image) *Mask {
+	bounds := img.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	mask := NewMask(w, h)
+
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			r, g, b, _ := img.At(x+bounds.Min.X, y+bounds.Min.Y).RGBA()
+			// r, g, b are 0-65535. Compute luminance using CSS formula.
+			// Y = 0.2126*R + 0.7152*G + 0.0722*B
+			lum := 0.2126*float64(r) + 0.7152*float64(g) + 0.0722*float64(b)
+			// Scale from 0-65535 to 0-255.
+			// #nosec G115 -- safe: lum/257 is always in range [0, 255]
+			mask.data[y*w+x] = uint8(lum/257.0 + 0.5)
+		}
+	}
+
+	return mask
+}
+
+// NewMaskFromData creates a mask from a raw byte slice.
+// The data must contain exactly width*height bytes, where each byte
+// represents the mask alpha at that pixel (row-major order).
+// Returns nil if the data length does not match width*height.
+func NewMaskFromData(data []byte, width, height int) *Mask {
+	if len(data) != width*height {
+		return nil
+	}
+	m := &Mask{
+		width:  width,
+		height: height,
+		data:   make([]uint8, width*height),
+	}
+	copy(m.data, data)
+	return m
+}

--- a/mask_test.go
+++ b/mask_test.go
@@ -557,6 +557,377 @@ func TestSetMask_NoMask(t *testing.T) {
 	}
 }
 
+// --- Phase 2 tests ---
+
+func TestNewLuminanceMask(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 3, 1))
+	// Pure red: Y = 0.2126*255 = 54.2 → 54
+	img.Set(0, 0, color.RGBA{255, 0, 0, 255})
+	// Pure green: Y = 0.7152*255 = 182.4 → 182
+	img.Set(1, 0, color.RGBA{0, 255, 0, 255})
+	// Pure blue: Y = 0.0722*255 = 18.4 → 18
+	img.Set(2, 0, color.RGBA{0, 0, 255, 255})
+
+	mask := NewLuminanceMask(img)
+	if mask == nil {
+		t.Fatal("expected non-nil mask")
+	}
+	if mask.Width() != 3 || mask.Height() != 1 {
+		t.Fatalf("expected 3x1, got %dx%d", mask.Width(), mask.Height())
+	}
+
+	// Allow ±1 tolerance for rounding.
+	tests := []struct {
+		x    int
+		want uint8
+		name string
+	}{
+		{0, 54, "red luminance"},
+		{1, 182, "green luminance"},
+		{2, 18, "blue luminance"},
+	}
+	for _, tt := range tests {
+		got := mask.At(tt.x, 0)
+		diff := int(got) - int(tt.want)
+		if diff < -1 || diff > 1 {
+			t.Errorf("%s: got %d, want %d (±1)", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestNewLuminanceMask_White(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{255, 255, 255, 255})
+
+	mask := NewLuminanceMask(img)
+	got := mask.At(0, 0)
+	// White luminance should be ~255.
+	if got < 254 {
+		t.Errorf("white luminance should be ~255, got %d", got)
+	}
+}
+
+func TestNewLuminanceMask_Black(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{0, 0, 0, 255})
+
+	mask := NewLuminanceMask(img)
+	if mask.At(0, 0) != 0 {
+		t.Errorf("black luminance should be 0, got %d", mask.At(0, 0))
+	}
+}
+
+func TestNewMaskFromData(t *testing.T) {
+	data := []byte{0, 64, 128, 192, 255, 0, 0, 0, 0, 0, 0, 0}
+	mask := NewMaskFromData(data, 4, 3)
+	if mask == nil {
+		t.Fatal("expected non-nil mask")
+	}
+	if mask.Width() != 4 || mask.Height() != 3 {
+		t.Fatalf("expected 4x3, got %dx%d", mask.Width(), mask.Height())
+	}
+	if mask.At(0, 0) != 0 {
+		t.Errorf("expected 0, got %d", mask.At(0, 0))
+	}
+	if mask.At(1, 0) != 64 {
+		t.Errorf("expected 64, got %d", mask.At(1, 0))
+	}
+	if mask.At(2, 0) != 128 {
+		t.Errorf("expected 128, got %d", mask.At(2, 0))
+	}
+
+	// Verify independence: modifying original data doesn't affect mask.
+	data[0] = 99
+	if mask.At(0, 0) != 0 {
+		t.Error("mask should be independent of original data")
+	}
+}
+
+func TestNewMaskFromData_InvalidLength(t *testing.T) {
+	data := []byte{1, 2, 3}
+	mask := NewMaskFromData(data, 2, 2) // needs 4 bytes, got 3
+	if mask != nil {
+		t.Error("expected nil mask for invalid data length")
+	}
+}
+
+func TestNewMaskFromData_RoundTrip(t *testing.T) {
+	original := NewMask(10, 10)
+	original.Fill(42)
+	original.Set(5, 5, 200)
+
+	reconstructed := NewMaskFromData(original.Data(), 10, 10)
+	if reconstructed == nil {
+		t.Fatal("expected non-nil mask")
+	}
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 10; x++ {
+			if reconstructed.At(x, y) != original.At(x, y) {
+				t.Fatalf("mismatch at (%d,%d): got %d, want %d",
+					x, y, reconstructed.At(x, y), original.At(x, y))
+			}
+		}
+	}
+}
+
+func TestApplyMask_Basic(t *testing.T) {
+	const size = 100
+	dc := NewContext(size, size)
+
+	// Fill entire canvas with opaque red.
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	// Create a mask: left half = 255, right half = 0.
+	mask := NewMask(size, size)
+	for y := 0; y < size; y++ {
+		for x := 0; x < size/2; x++ {
+			mask.Set(x, y, 255)
+		}
+	}
+
+	dc.ApplyMask(mask)
+	img := dc.Image()
+
+	// Left half should still have red.
+	r25, _, _, a25 := pixelRGBA(img, 25, 50)
+	if r25 == 0 || a25 == 0 {
+		t.Errorf("left half should have color after mask, got r=%d a=%d", r25, a25)
+	}
+
+	// Right half should be transparent (mask=0).
+	a75 := pixelAlpha(img, 75, 50)
+	if a75 != 0 {
+		t.Errorf("right half should be transparent after mask, got a=%d", a75)
+	}
+}
+
+func TestApplyMask_NilMask(t *testing.T) {
+	dc := NewContext(50, 50)
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, 50, 50)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	aBefore := pixelAlpha(dc.Image(), 25, 25)
+
+	// ApplyMask(nil) should be a no-op.
+	dc.ApplyMask(nil)
+
+	aAfter := pixelAlpha(dc.Image(), 25, 25)
+	if aBefore != aAfter {
+		t.Errorf("nil mask should be no-op, alpha changed from %d to %d", aBefore, aAfter)
+	}
+}
+
+func TestApplyMask_PartialAlpha(t *testing.T) {
+	const size = 50
+	dc := NewContext(size, size)
+
+	// Fill with opaque red.
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	// Apply mask with 128 everywhere.
+	mask := NewMask(size, size)
+	mask.Fill(128)
+	dc.ApplyMask(mask)
+
+	img := dc.Image()
+	a := pixelAlpha(img, 25, 25)
+	// Alpha should be roughly 128/255 * 65535 ≈ 32896. Allow tolerance.
+	if a > 40000 || a < 25000 {
+		t.Errorf("expected roughly half alpha (~32896), got %d", a)
+	}
+}
+
+// --- Phase 3 tests ---
+
+func TestPushMaskLayer_Basic(t *testing.T) {
+	const size = 100
+	dc := NewContext(size, size)
+
+	// Create mask: circle in center.
+	circleMask := NewMask(size, size)
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			dx := float64(x) - 50
+			dy := float64(y) - 50
+			if dx*dx+dy*dy <= 30*30 {
+				circleMask.Set(x, y, 255)
+			}
+		}
+	}
+
+	dc.PushMaskLayer(circleMask)
+
+	// Draw full-screen red rect into the layer.
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	dc.PopLayer()
+
+	img := dc.Image()
+
+	// Center should have red.
+	rCenter, _, _, aCenter := pixelRGBA(img, 50, 50)
+	if rCenter == 0 || aCenter == 0 {
+		t.Errorf("center should have color, got r=%d a=%d", rCenter, aCenter)
+	}
+
+	// Corner should be transparent.
+	aCorner := pixelAlpha(img, 5, 5)
+	if aCorner != 0 {
+		t.Errorf("corner should be transparent, got a=%d", aCorner)
+	}
+}
+
+func TestPushMaskLayer_Nested(t *testing.T) {
+	const size = 100
+	dc := NewContext(size, size)
+
+	// Outer mask: left half.
+	outerMask := NewMask(size, size)
+	for y := 0; y < size; y++ {
+		for x := 0; x < size/2; x++ {
+			outerMask.Set(x, y, 255)
+		}
+	}
+
+	// Inner mask: top half.
+	innerMask := NewMask(size, size)
+	for y := 0; y < size/2; y++ {
+		for x := 0; x < size; x++ {
+			innerMask.Set(x, y, 255)
+		}
+	}
+
+	dc.PushMaskLayer(outerMask)
+	dc.PushMaskLayer(innerMask)
+
+	// Fill everything red.
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	dc.PopLayer() // inner mask applied: only top half visible in inner layer
+	dc.PopLayer() // outer mask applied: only left half visible in outer layer
+
+	img := dc.Image()
+
+	// Top-left quadrant: should have color (both masks allow).
+	aTL := pixelAlpha(img, 25, 25)
+	if aTL == 0 {
+		t.Error("top-left should have color")
+	}
+
+	// Top-right: inner allows, outer blocks.
+	aTR := pixelAlpha(img, 75, 25)
+	if aTR != 0 {
+		t.Errorf("top-right should be transparent, got a=%d", aTR)
+	}
+
+	// Bottom-left: inner blocks.
+	aBL := pixelAlpha(img, 25, 75)
+	if aBL != 0 {
+		t.Errorf("bottom-left should be transparent, got a=%d", aBL)
+	}
+
+	// Bottom-right: both block.
+	aBR := pixelAlpha(img, 75, 75)
+	if aBR != 0 {
+		t.Errorf("bottom-right should be transparent, got a=%d", aBR)
+	}
+}
+
+func TestPushMaskLayer_NilMask(t *testing.T) {
+	const size = 50
+	dc := NewContext(size, size)
+
+	dc.PushMaskLayer(nil) // nil mask = PushLayer(Normal, 1.0)
+
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	dc.PopLayer()
+
+	// Everything should be visible (no mask applied).
+	a := pixelAlpha(dc.Image(), 25, 25)
+	if a == 0 {
+		t.Error("nil mask should not block content")
+	}
+}
+
+func TestPushMaskLayer_WithSetMask(t *testing.T) {
+	// PushMaskLayer + SetMask should compose: SetMask applies per-shape,
+	// PushMaskLayer applies to the entire layer on pop.
+	const size = 100
+	dc := NewContext(size, size)
+
+	// Layer mask: left half.
+	layerMask := NewMask(size, size)
+	for y := 0; y < size; y++ {
+		for x := 0; x < size/2; x++ {
+			layerMask.Set(x, y, 255)
+		}
+	}
+
+	// Per-shape mask: top half.
+	shapeMask := NewMask(size, size)
+	for y := 0; y < size/2; y++ {
+		for x := 0; x < size; x++ {
+			shapeMask.Set(x, y, 255)
+		}
+	}
+
+	dc.PushMaskLayer(layerMask)
+	dc.SetMask(shapeMask)
+
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	dc.ClearMask()
+	dc.PopLayer()
+
+	img := dc.Image()
+
+	// Top-left: both allow → visible.
+	aTL := pixelAlpha(img, 25, 25)
+	if aTL == 0 {
+		t.Error("top-left should have color (both masks allow)")
+	}
+
+	// Top-right: shape allows, layer blocks → transparent.
+	aTR := pixelAlpha(img, 75, 25)
+	if aTR != 0 {
+		t.Errorf("top-right should be transparent (layer mask blocks), got a=%d", aTR)
+	}
+
+	// Bottom-left: shape blocks drawing into layer → transparent.
+	aBL := pixelAlpha(img, 25, 75)
+	if aBL != 0 {
+		t.Errorf("bottom-left should be transparent (shape mask blocks), got a=%d", aBL)
+	}
+}
+
 func TestMaskNestedPushPop(t *testing.T) {
 	dc := NewContext(100, 100)
 

--- a/mask_test.go
+++ b/mask_test.go
@@ -6,6 +6,19 @@ import (
 	"testing"
 )
 
+// pixelAlpha returns the alpha component (0-65535) of the pixel at (x, y).
+func pixelAlpha(img image.Image, x, y int) uint32 {
+	c := img.At(x, y)
+	//nolint:dogsled // we only need the alpha channel
+	_, _, _, a := c.RGBA()
+	return a
+}
+
+// pixelRGBA returns all four components (0-65535) of the pixel at (x, y).
+func pixelRGBA(img image.Image, x, y int) (r, g, b, a uint32) {
+	return img.At(x, y).RGBA()
+}
+
 func TestNewMask(t *testing.T) {
 	mask := NewMask(100, 100)
 	if mask.Width() != 100 || mask.Height() != 100 {
@@ -242,6 +255,305 @@ func TestMaskPushPopNil(t *testing.T) {
 	dc.Pop()
 	if dc.GetMask() != nil {
 		t.Error("expected nil mask after pop")
+	}
+}
+
+// TestSetMask_Fill verifies that SetMask modulates Fill output.
+// A full-coverage rect is drawn with a half-opaque mask.
+func TestSetMask_Fill(t *testing.T) {
+	const size = 100
+	dc := NewContext(size, size)
+
+	// Create a mask: left half = 255 (opaque), right half = 0 (transparent).
+	mask := NewMask(size, size)
+	for y := 0; y < size; y++ {
+		for x := 0; x < size/2; x++ {
+			mask.Set(x, y, 255)
+		}
+	}
+	dc.SetMask(mask)
+
+	// Fill the entire canvas with red.
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	img := dc.Image()
+
+	// Left half should have red pixels.
+	r25, _, _, a25 := pixelRGBA(img, 25, 50)
+	if r25 == 0 || a25 == 0 {
+		t.Errorf("left half should have color, got r=%d a=%d", r25, a25)
+	}
+
+	// Right half should be transparent (mask=0).
+	a75 := pixelAlpha(img, 75, 50)
+	if a75 != 0 {
+		t.Errorf("right half should be transparent, got a=%d", a75)
+	}
+}
+
+// TestSetMask_Fill_PartialAlpha verifies that mask values between 0 and 255
+// produce proportionally modulated output.
+func TestSetMask_Fill_PartialAlpha(t *testing.T) {
+	const size = 100
+	dc := NewContext(size, size)
+
+	// Create a mask with 128 (half) coverage everywhere.
+	mask := NewMask(size, size)
+	mask.Fill(128)
+	dc.SetMask(mask)
+
+	// Fill with opaque red.
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	img := dc.Image()
+	a := pixelAlpha(img, 50, 50)
+	// Alpha should be roughly 128/255 * 65535 ≈ 32896. Allow tolerance.
+	if a > 40000 || a < 25000 {
+		t.Errorf("expected roughly half alpha (~32896), got %d", a)
+	}
+}
+
+// TestSetMask_Stroke verifies that SetMask modulates Stroke output.
+func TestSetMask_Stroke(t *testing.T) {
+	const size = 100
+	dc := NewContext(size, size)
+
+	// Mask: top half = 255, bottom half = 0.
+	mask := NewMask(size, size)
+	for y := 0; y < size/2; y++ {
+		for x := 0; x < size; x++ {
+			mask.Set(x, y, 255)
+		}
+	}
+	dc.SetMask(mask)
+
+	// Draw a horizontal line through the middle (y=50 border, with stroke width).
+	dc.SetRGBA(0, 0, 1, 1)
+	dc.SetLineWidth(10)
+	dc.MoveTo(0, 25)
+	dc.LineTo(100, 25)
+	if err := dc.Stroke(); err != nil {
+		t.Fatalf("Stroke failed: %v", err)
+	}
+
+	// Also stroke in the masked-out area.
+	dc.MoveTo(0, 75)
+	dc.LineTo(100, 75)
+	if err := dc.Stroke(); err != nil {
+		t.Fatalf("Stroke failed: %v", err)
+	}
+
+	img := dc.Image()
+
+	// Top line should be visible (mask = 255).
+	_, _, b25, a25 := pixelRGBA(img, 50, 25)
+	if b25 == 0 || a25 == 0 {
+		t.Errorf("top stroke should be visible, got b=%d a=%d", b25, a25)
+	}
+
+	// Bottom line should be invisible (mask = 0).
+	a75 := pixelAlpha(img, 50, 75)
+	if a75 != 0 {
+		t.Errorf("bottom stroke should be transparent, got a=%d", a75)
+	}
+}
+
+// TestSetMask_WithClip verifies that mask and clip compose multiplicatively.
+func TestSetMask_WithClip(t *testing.T) {
+	const size = 100
+	dc := NewContext(size, size)
+
+	// Clip to right half.
+	dc.DrawRectangle(50, 0, 50, 100)
+	dc.Clip()
+
+	// Mask: full canvas at half coverage.
+	mask := NewMask(size, size)
+	mask.Fill(128)
+	dc.SetMask(mask)
+
+	// Fill entire canvas with opaque green.
+	dc.SetRGBA(0, 1, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	img := dc.Image()
+
+	// Left half: clipped out entirely.
+	aLeft := pixelAlpha(img, 25, 50)
+	if aLeft != 0 {
+		t.Errorf("left half (clipped) should be transparent, got a=%d", aLeft)
+	}
+
+	// Right half: visible but at reduced alpha (mask=128).
+	_, g, _, aRight := pixelRGBA(img, 75, 50)
+	if g == 0 || aRight == 0 {
+		t.Errorf("right half should have color, got g=%d a=%d", g, aRight)
+	}
+	// Alpha should be roughly 128/255 of full.
+	if aRight > 40000 {
+		t.Errorf("right half alpha should be reduced by mask, got a=%d", aRight)
+	}
+}
+
+// TestSetMask_PushPop verifies mask is saved and restored by Push/Pop.
+func TestSetMask_PushPop(t *testing.T) {
+	const size = 50
+	dc := NewContext(size, size)
+
+	// Set mask.
+	mask1 := NewMask(size, size)
+	mask1.Fill(100)
+	dc.SetMask(mask1)
+
+	dc.Push()
+
+	// Change mask.
+	mask2 := NewMask(size, size)
+	mask2.Fill(200)
+	dc.SetMask(mask2)
+
+	// Fill with mask2.
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+	img1 := dc.Image()
+	a1 := pixelAlpha(img1, 25, 25)
+
+	dc.Pop()
+
+	// Now mask1 should be restored. Draw again on fresh context.
+	dc2 := NewContext(size, size)
+	dc2.SetMask(dc.GetMask())
+	dc2.SetRGBA(1, 0, 0, 1)
+	dc2.DrawRectangle(0, 0, size, size)
+	if err := dc2.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+	img2 := dc2.Image()
+	a2 := pixelAlpha(img2, 25, 25)
+
+	// mask2 (200) should produce more alpha than mask1 (100).
+	if a1 <= a2 {
+		t.Errorf("mask2 (200) should produce more alpha than mask1 (100): a1=%d a2=%d", a1, a2)
+	}
+}
+
+// TestAsMask_BeforeFill verifies AsMask returns valid data before Fill.
+func TestAsMask_BeforeFill(t *testing.T) {
+	dc := NewContext(100, 100)
+	dc.DrawCircle(50, 50, 30)
+
+	mask := dc.AsMask()
+	if mask == nil {
+		t.Fatal("AsMask should return non-nil mask")
+	}
+
+	// Center of the circle should have high alpha.
+	center := mask.At(50, 50)
+	if center < 200 {
+		t.Errorf("expected high alpha at center, got %d", center)
+	}
+
+	// Far corner should have zero alpha.
+	corner := mask.At(0, 0)
+	if corner > 10 {
+		t.Errorf("expected near-zero alpha at corner, got %d", corner)
+	}
+}
+
+// TestAsMask_AfterFill verifies AsMask returns empty mask after Fill (path cleared).
+func TestAsMask_AfterFill(t *testing.T) {
+	dc := NewContext(100, 100)
+	dc.DrawCircle(50, 50, 30)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	// Path was cleared by Fill, so AsMask should produce an empty mask.
+	mask := dc.AsMask()
+	if mask == nil {
+		t.Fatal("AsMask should return non-nil mask")
+	}
+
+	center := mask.At(50, 50)
+	if center != 0 {
+		t.Errorf("expected 0 at center after Fill cleared path, got %d", center)
+	}
+}
+
+// TestSetMask_Rider21Reproduction reproduces the exact scenario from gg#238.
+// User creates a mask from a circle, sets it, then fills a rectangle.
+// Without the fix, the mask was ignored and the full rectangle was drawn.
+func TestSetMask_Rider21Reproduction(t *testing.T) {
+	const size = 100
+	dc := NewContext(size, size)
+
+	// Step 1: Create a circular mask.
+	dc.DrawCircle(50, 50, 30)
+	mask := dc.AsMask()
+
+	// Step 2: Set the mask and fill a full-screen rectangle.
+	dc.SetMask(mask)
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	img := dc.Image()
+
+	// Inside the circle (center) should have color.
+	rCenter, _, _, aCenter := pixelRGBA(img, 50, 50)
+	if rCenter == 0 || aCenter == 0 {
+		t.Errorf("center of circle should have color, got r=%d a=%d", rCenter, aCenter)
+	}
+
+	// Outside the circle (corners) should be transparent.
+	aCorner := pixelAlpha(img, 5, 5)
+	if aCorner != 0 {
+		t.Errorf("corner (outside circle mask) should be transparent, got a=%d", aCorner)
+	}
+
+	aTopRight := pixelAlpha(img, 95, 5)
+	if aTopRight != 0 {
+		t.Errorf("top-right (outside circle mask) should be transparent, got a=%d", aTopRight)
+	}
+
+	aBottomRight := pixelAlpha(img, 95, 95)
+	if aBottomRight != 0 {
+		t.Errorf("bottom-right (outside circle mask) should be transparent, got a=%d", aBottomRight)
+	}
+}
+
+// TestSetMask_NoMask verifies that without mask, Fill works as before.
+func TestSetMask_NoMask(t *testing.T) {
+	const size = 50
+	dc := NewContext(size, size)
+
+	// No mask set — fill should work normally.
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, size, size)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+
+	img := dc.Image()
+	r, _, _, a := pixelRGBA(img, 25, 25)
+	if r == 0 || a == 0 {
+		t.Errorf("fill without mask should produce color, got r=%d a=%d", r, a)
 	}
 }
 

--- a/paint.go
+++ b/paint.go
@@ -88,6 +88,13 @@ type Paint struct {
 	// pixel alpha by this coverage to apply the clip mask.
 	// Set automatically by Context before rendering when a clip is active.
 	ClipCoverage func(x, y float64) byte
+
+	// MaskCoverage is a function that returns the alpha mask coverage (0-255)
+	// at a given pixel coordinate. When non-nil, the renderer multiplies
+	// pixel alpha by this coverage to apply the alpha mask.
+	// Uses int coords because masks are pixel-aligned (no sub-pixel sampling).
+	// Set automatically by Context before rendering when a mask is active.
+	MaskCoverage func(x, y int) uint8
 }
 
 // NewPaint creates a new Paint with default values.

--- a/software.go
+++ b/software.go
@@ -232,22 +232,24 @@ func (r *SoftwareRenderer) fillWithCoverageFiller(
 		fillRule = FillRuleEvenOdd
 	}
 	clipFn := paint.ClipCoverage
+	maskFn := paint.MaskCoverage
 	if color, ok := solidColorFromPaint(paint); ok {
-		r.fillCoverageSolidPath(pixmap, p, filler, fillRule, color, clipFn)
+		r.fillCoverageSolidPath(pixmap, p, filler, fillRule, color, clipFn, maskFn)
 	} else {
-		r.fillCoveragePaintPath(pixmap, p, filler, fillRule, paint, clipFn)
+		r.fillCoveragePaintPath(pixmap, p, filler, fillRule, paint, clipFn, maskFn)
 	}
 }
 
 // fillCoverageSolidPath fills using the CoverageFiller with a solid color,
-// applying optional clip coverage.
+// applying optional clip and mask coverage.
 func (r *SoftwareRenderer) fillCoverageSolidPath(
 	pixmap *Pixmap, p *Path, filler CoverageFiller,
-	fillRule FillRule, color RGBA, clipFn func(x, y float64) byte,
+	fillRule FillRule, color RGBA, clipFn func(x, y float64) byte, maskFn func(x, y int) uint8,
 ) {
 	filler.FillCoverage(p, r.width, r.height, fillRule,
 		func(x, y int, coverage uint8) {
 			coverage = applyClipCoverage(clipFn, x, y, coverage)
+			coverage = applyMaskCoverage(maskFn, x, y, coverage)
 			if coverage == 0 {
 				return
 			}
@@ -256,14 +258,15 @@ func (r *SoftwareRenderer) fillCoverageSolidPath(
 }
 
 // fillCoveragePaintPath fills using the CoverageFiller with a paint pattern,
-// applying optional clip coverage.
+// applying optional clip and mask coverage.
 func (r *SoftwareRenderer) fillCoveragePaintPath(
 	pixmap *Pixmap, p *Path, filler CoverageFiller,
-	fillRule FillRule, paint *Paint, clipFn func(x, y float64) byte,
+	fillRule FillRule, paint *Paint, clipFn func(x, y float64) byte, maskFn func(x, y int) uint8,
 ) {
 	filler.FillCoverage(p, r.width, r.height, fillRule,
 		func(x, y int, coverage uint8) {
 			coverage = applyClipCoverage(clipFn, x, y, coverage)
+			coverage = applyMaskCoverage(maskFn, x, y, coverage)
 			if coverage == 0 {
 				return
 			}
@@ -283,6 +286,23 @@ func applyClipCoverage(clipFn func(x, y float64) byte, px, py int, coverage uint
 		return 0
 	}
 	return uint8(uint16(coverage) * uint16(cc) / 255)
+}
+
+// applyMaskCoverage multiplies pixel coverage by the alpha mask coverage.
+// Returns 0 if the pixel is fully masked out. When maskFn is nil, returns the
+// original coverage unchanged. Uses int coords because masks are pixel-aligned.
+func applyMaskCoverage(maskFn func(x, y int) uint8, px, py int, coverage uint8) uint8 {
+	if maskFn == nil {
+		return coverage
+	}
+	mc := maskFn(px, py)
+	if mc == 0 {
+		return 0
+	}
+	if mc == 255 {
+		return coverage
+	}
+	return uint8(uint16(coverage) * uint16(mc) / 255)
 }
 
 // Fill implements Renderer.Fill using analytic anti-aliasing.
@@ -368,14 +388,16 @@ func (r *SoftwareRenderer) Fill(pixmap *Pixmap, p *Path, paint *Paint) error {
 	if color, ok := solidColorFromPaint(paint); ok {
 		// Fast path: solid color
 		clipFn := paint.ClipCoverage
+		maskFn := paint.MaskCoverage
 		r.analyticFiller.Fill(r.edgeBuilder, coreFillRule, func(y int, runs *raster.AlphaRuns) {
-			r.blendAlphaRunsFromCoreRuns(pixmap, y, runs, color, clipFn)
+			r.blendAlphaRunsFromCoreRuns(pixmap, y, runs, color, clipFn, maskFn)
 		})
 	} else {
 		// Pattern/gradient path: per-pixel color sampling
 		clipFn := paint.ClipCoverage
+		maskFn := paint.MaskCoverage
 		r.analyticFiller.Fill(r.edgeBuilder, coreFillRule, func(y int, runs *raster.AlphaRuns) {
-			r.blendAlphaRunsFromCoreRunsPaint(pixmap, y, runs, paint, clipFn)
+			r.blendAlphaRunsFromCoreRunsPaint(pixmap, y, runs, paint, clipFn, maskFn)
 		})
 	}
 
@@ -484,7 +506,8 @@ func solidColorFromPaint(paint *Paint) (RGBA, bool) {
 // blendAlphaRunsFromCoreRuns blends alpha values from raster.AlphaRuns to the pixmap.
 // Uses source-over compositing for proper alpha blending.
 // When clipFn is non-nil, each pixel's alpha is multiplied by the clip coverage.
-func (r *SoftwareRenderer) blendAlphaRunsFromCoreRuns(pixmap *Pixmap, y int, runs *raster.AlphaRuns, color RGBA, clipFn func(x, y float64) byte) {
+// When maskFn is non-nil, each pixel's alpha is multiplied by the mask coverage.
+func (r *SoftwareRenderer) blendAlphaRunsFromCoreRuns(pixmap *Pixmap, y int, runs *raster.AlphaRuns, color RGBA, clipFn func(x, y float64) byte, maskFn func(x, y int) uint8) {
 	if y < 0 || y >= pixmap.Height() {
 		return
 	}
@@ -509,6 +532,12 @@ func (r *SoftwareRenderer) blendAlphaRunsFromCoreRuns(pixmap *Pixmap, y int, run
 			if alpha == 0 {
 				continue
 			}
+		}
+
+		// Apply mask coverage if active.
+		alpha = applyMaskCoverage(maskFn, x, y, alpha)
+		if alpha == 0 {
+			continue
 		}
 
 		// Full coverage - just set the pixel
@@ -539,7 +568,8 @@ func (r *SoftwareRenderer) blendAlphaRunsFromCoreRuns(pixmap *Pixmap, y int, run
 // blendAlphaRunsFromCoreRunsPaint is like blendAlphaRunsFromCoreRuns but samples
 // the paint color at each pixel instead of using a single constant color.
 // When clipFn is non-nil, each pixel's alpha is multiplied by the clip coverage.
-func (r *SoftwareRenderer) blendAlphaRunsFromCoreRunsPaint(pixmap *Pixmap, y int, runs *raster.AlphaRuns, paint *Paint, clipFn func(x, y float64) byte) {
+// When maskFn is non-nil, each pixel's alpha is multiplied by the mask coverage.
+func (r *SoftwareRenderer) blendAlphaRunsFromCoreRunsPaint(pixmap *Pixmap, y int, runs *raster.AlphaRuns, paint *Paint, clipFn func(x, y float64) byte, maskFn func(x, y int) uint8) {
 	if y < 0 || y >= pixmap.Height() {
 		return
 	}
@@ -566,6 +596,12 @@ func (r *SoftwareRenderer) blendAlphaRunsFromCoreRunsPaint(pixmap *Pixmap, y int
 			if alpha == 0 {
 				continue
 			}
+		}
+
+		// Apply mask coverage if active.
+		alpha = applyMaskCoverage(maskFn, x, y, alpha)
+		if alpha == 0 {
+			continue
 		}
 
 		// Sample color from paint at pixel center

--- a/software_coverage_test.go
+++ b/software_coverage_test.go
@@ -310,6 +310,50 @@ func TestApplyClipCoverage(t *testing.T) {
 	}
 }
 
+// --- applyMaskCoverage tests ---
+
+func TestApplyMaskCoverage(t *testing.T) {
+	tests := []struct {
+		name     string
+		maskFn   func(x, y int) uint8
+		coverage uint8
+		want     uint8
+	}{
+		{
+			name:     "nil mask returns unchanged",
+			maskFn:   nil,
+			coverage: 200,
+			want:     200,
+		},
+		{
+			name:     "mask returns zero",
+			maskFn:   func(_, _ int) uint8 { return 0 },
+			coverage: 200,
+			want:     0,
+		},
+		{
+			name:     "mask returns full",
+			maskFn:   func(_, _ int) uint8 { return 255 },
+			coverage: 200,
+			want:     200,
+		},
+		{
+			name:     "mask returns half",
+			maskFn:   func(_, _ int) uint8 { return 128 },
+			coverage: 200,
+			want:     uint8(uint16(200) * 128 / 255),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyMaskCoverage(tt.maskFn, 5, 5, tt.coverage)
+			if got != tt.want {
+				t.Errorf("applyMaskCoverage() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 // --- SoftwareRenderer Fill integration tests ---
 
 func TestSoftwareRendererFillSimplePath(t *testing.T) {


### PR DESCRIPTION
## Summary

Complete enterprise-level alpha mask API following Vello/tiny-skia patterns. Fixes #238 (SetMask ignored during Fill) and #236 (AsMask documentation).

**Per-shape masking** (`SetMask`/`ClearMask`):
- Each Fill/Stroke individually masked — mask value (0-255) multiplies pixel coverage
- Mask and clip compose multiplicatively when both active

**Per-layer masking** (`PushMaskLayer`/`PopLayer`):
- Isolated layer with mask applied on pop before compositing
- Matches Vello `push_mask_layer()` semantics
- Nested layers compose correctly

**Post-processing** (`ApplyMask`):
- DestinationIn blend on already-drawn content

**Constructors:**
- `NewLuminanceMask(img)` — CSS Masking Level 1 (Y = 0.2126R + 0.7152G + 0.0722B)
- `NewMaskFromData(data, w, h)` — raw byte constructor

**GPU integration:**
- `MaskAware` interface for GPU accelerators to support mask textures
- Falls back to CPU when accelerator does not implement `MaskAware`

### Research

Enterprise references analyzed: Cairo (`cairo_mask()`), Skia (`saveLayer` + `SkMaskFilter`), tiny-skia (`Mask` param + `apply_mask()`), Vello (`push_mask_layer` + `Cmd::Mask`).

## Test plan

- [x] 25 mask-related tests covering all phases
- [x] `TestSetMask_Rider21Reproduction` — exact gg#238 scenario
- [x] `TestPushMaskLayer_Nested` — nested layers with different masks
- [x] `TestPushMaskLayer_WithSetMask` — per-shape + per-layer compose
- [x] `TestNewLuminanceMask` — CSS formula verification (R/G/B primaries)
- [x] `TestApplyMask_PartialAlpha` — 128/255 alpha modulation
- [x] All existing tests pass
- [x] `golangci-lint` 0 issues
