### PR TITLE
refactor: per-pass GPU render target via GPURenderTarget.View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **GPU render target: per-pass routing** (TASK-GG-OFFSCREEN-001) — `GPURenderTarget.View` (`gpucontext.TextureView`) enables per-render-pass target selection per WebGPU spec. Eliminates session-level `surfaceView` override that forced all rendering to surface. Enables multi-context GPU rendering (RepaintBoundary, offscreen export, multi-window).
+- **`SurfaceTargetAware` deprecated** — surface view now travels in `GPURenderTarget.View`, not as side-band session state.
+- **`Context.FlushGPUWithView()`** — new method for GPU-direct rendering to a specific texture view.
+- **Dependencies:** gpucontext v0.12.0 → v0.14.0 (TextureView type token), gputypes v0.4.0 → v0.5.0 (PrimitiveState zero value)
+
 ## [0.40.1] - 2026-04-11
 
 ### Fixed

--- a/accelerator.go
+++ b/accelerator.go
@@ -41,9 +41,28 @@ const (
 )
 
 // GPURenderTarget provides pixel buffer access for GPU output.
-// The Data slice must be in premultiplied RGBA format, 4 bytes per pixel,
-// laid out row by row with the given Stride.
+//
+// Two mutually exclusive modes:
+//
+// GPU-direct mode: when View is non-nil, the render pass resolves directly
+// to this texture view. Data/Stride are ignored and no CPU readback occurs.
+// ViewWidth and ViewHeight specify the view dimensions in device pixels.
+//
+// CPU readback mode: when View is nil, rendering goes to an internal resolve
+// texture and pixels are copied back into Data. Width, Height, and Stride
+// describe the destination pixel buffer layout.
+//
+// The Data slice (when used) must be in premultiplied RGBA format, 4 bytes
+// per pixel, laid out row by row with the given Stride.
 type GPURenderTarget struct {
+	// GPU-direct path: resolve directly to this view.
+	// When non-nil, Data/Stride are ignored -- no CPU readback.
+	// Type-assert to *wgpu.TextureView in internal/gpu consumers.
+	View       gpucontext.TextureView
+	ViewWidth  uint32
+	ViewHeight uint32
+
+	// CPU readback path.
 	Data          []uint8
 	Width, Height int
 	Stride        int // bytes per row
@@ -112,10 +131,12 @@ type DeviceProviderAware interface {
 }
 
 // SurfaceTargetAware is an optional interface for accelerators that support
-// direct surface rendering. When SetSurfaceTarget is called with a non-nil
-// view, the accelerator renders directly to the surface texture instead of
-// reading back pixels to CPU. This eliminates the GPU->CPU->GPU round-trip
-// for windowed rendering (ggcanvas + gogpu).
+// direct surface rendering.
+//
+// Deprecated: use GPURenderTarget.View instead. New code should pass the
+// texture view via GPURenderTarget.View on each Flush call. This interface
+// is retained for backward compatibility with existing ggcanvas code paths
+// and is translated internally to GPURenderTarget.View.
 //
 // Call SetSurfaceTarget with nil to return to offscreen (readback) mode.
 // The caller retains ownership of the surface view.

--- a/context.go
+++ b/context.go
@@ -1088,6 +1088,33 @@ func (c *Context) FlushGPU() error {
 	return a.Flush(t)
 }
 
+// FlushGPUWithView flushes pending GPU operations, resolving directly to the
+// given texture view instead of reading back to CPU. The view is passed
+// through GPURenderTarget.View so the render session uses it as the per-pass
+// resolve target, enabling multiple Contexts to render to different views
+// without cross-contamination.
+//
+// This is the per-pass render target path for ggcanvas.RenderDirect.
+// When view is nil, behaves identically to FlushGPU (CPU readback).
+func (c *Context) FlushGPUWithView(view any, width, height uint32) error {
+	a := Accelerator()
+	if a == nil {
+		return nil
+	}
+	t := c.gpuRenderTarget()
+	if view != nil {
+		t.View = view
+		t.ViewWidth = width
+		t.ViewHeight = height
+	}
+	Logger().Debug("FlushGPUWithView",
+		"target_w", t.Width, "target_h", t.Height,
+		"view", view != nil,
+		"viewW", width, "viewH", height,
+	)
+	return a.Flush(t)
+}
+
 // gpuRenderTarget returns the current context's pixel buffer as a GPU render target.
 func (c *Context) gpuRenderTarget() GPURenderTarget {
 	return GPURenderTarget{

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ import _ "github.com/gogpu/gg/gpu"  // enables GPU acceleration
 Optional extension interfaces for gogpu integration:
 
 - **DeviceProviderAware** -- share GPU device with an external provider (e.g., gogpu window)
-- **SurfaceTargetAware** -- render directly to a surface texture view (zero-copy windowed rendering)
+- **Per-pass render target** -- `GPURenderTarget.View` (`gpucontext.TextureView`) enables GPU-direct rendering to any texture view (surface or offscreen). Follows WebGPU spec per-render-pass target pattern. ~~SurfaceTargetAware~~ (deprecated, use GPURenderTarget.View)
 
 ### Six-Tier GPU Rendering
 
@@ -710,8 +710,9 @@ Key implementation details:
   `defer canvas.Close()` or `OnClose` wiring needed.
 
 When used with gogpu, the accelerator shares the gogpu GPU device via `DeviceProviderAware`,
-and can render directly to the window surface via `SurfaceTargetAware`, eliminating the
-GPU->CPU->GPU round-trip.
+and can render directly to any texture view (surface or offscreen) via `GPURenderTarget.View`
+(`gpucontext.TextureView`), eliminating the GPU->CPU->GPU round-trip. Target is per-pass
+(WebGPU spec pattern), enabling multi-context rendering (RepaintBoundary, offscreen export).
 
 ## Recording System (v0.23.0)
 
@@ -793,7 +794,7 @@ gg and gogpu are **independent libraries** that can interoperate via gpucontext:
 | **Command Pattern** | Cairo/Skia | Recording system for vector export |
 | **Driver Pattern** | database/sql | Backend registration via blank import |
 | **Device Sharing** | Skia Graphite | DeviceProviderAware for gogpu integration |
-| **Zero-Copy Surface** | Flutter Impeller | SurfaceTargetAware for direct window rendering |
+| **Per-Pass Render Target** | WebGPU spec, Skia GrContext | GPURenderTarget.View for per-pass target (surface or offscreen) |
 
 ## See Also
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/go-text/typesetting v0.3.4
-	github.com/gogpu/gpucontext v0.12.0
-	github.com/gogpu/gputypes v0.4.0
+	github.com/gogpu/gpucontext v0.14.0
+	github.com/gogpu/gputypes v0.5.0
 	github.com/gogpu/naga v0.17.4
 	github.com/gogpu/wgpu v0.25.1
 	golang.org/x/image v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZz
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
 github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE=
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/gogpu/gpucontext v0.12.0 h1:9stgEAuNDhqHkHUx76SRxxYsSvLA4aDFwTb8zcwLlHw=
-github.com/gogpu/gpucontext v0.12.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
-github.com/gogpu/gputypes v0.4.0 h1:nPFn77na71K4gkyObbXgpYywy9lIKz/U1x/2+4EAZ3Y=
-github.com/gogpu/gputypes v0.4.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+github.com/gogpu/gpucontext v0.14.0 h1:0IAkOwQFW7T5bhRqr8tSgV+bKS4rU9zpDOv5ux1QXr0=
+github.com/gogpu/gpucontext v0.14.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
+github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
+github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.4 h1:37U/6PP7F+fiyXqJzEAOJUzxZPC5lyyOKxCOnCQIw6k=
 github.com/gogpu/naga v0.17.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 github.com/gogpu/wgpu v0.25.1 h1:F852wgqxhYdvpCWRa2WCW8+B+V3qiEVUQ++QvIbPOnw=

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -334,12 +334,12 @@ func (c *Canvas) Flush() (any, error) {
 }
 
 // RenderDirect renders canvas content directly to the given surface view,
-// bypassing the GPU→CPU→GPU readback. This is the zero-copy rendering path
+// bypassing the GPU->CPU->GPU readback. This is the zero-copy rendering path
 // for use with gogpu's surface texture view.
 //
 // When the GPU accelerator supports direct surface rendering, shapes are
 // rendered directly to the provided surface view via MSAA resolve. No
-// staging buffers, no ReadBuffer, no texture upload — pure GPU-to-GPU.
+// staging buffers, no ReadBuffer, no texture upload -- pure GPU-to-GPU.
 //
 // If the accelerator doesn't support surface rendering, or if no GPU
 // accelerator is registered, this method falls back to the readback path
@@ -371,20 +371,27 @@ func (c *Canvas) RenderDirect(surfaceView any, width, height uint32) error {
 		"hasSurfaceView", surfaceView != nil,
 	)
 
-	// Configure GPU accelerator for direct surface rendering.
-	// The surface target stays set between frames to avoid destroying
-	// and recreating MSAA/stencil textures on every frame. The target
-	// is only cleared on Close() or when switching to offscreen mode.
+	// Pass the surface view via GPURenderTarget.View so the render session
+	// uses it as the per-pass resolve target. This replaces the old
+	// session-level SetSurfaceTarget approach, enabling multiple Contexts
+	// to render to different targets without interfering.
+	//
+	// We still call SetAcceleratorSurfaceTarget for backward compatibility
+	// with the session-level path (e.g., EnsureTextures surface mode).
 	gg.SetAcceleratorSurfaceTarget(surfaceView, width, height)
 
 	// Flush GPU shapes directly to the surface view (no readback).
-	// NOTE: BeginAcceleratorFrame is NOT called here — it must be called
+	// FlushGPUWithView passes the view through GPURenderTarget.View,
+	// which takes priority over session-level surfaceView in the
+	// render session's routing logic.
+	//
+	// NOTE: BeginAcceleratorFrame is NOT called here -- it must be called
 	// BEFORE canvas.Draw(), not after. If Draw triggers a mid-frame CPU
 	// fallback (bitmap text, gradient fill), flushGPUAccelerator submits
 	// GPU commands with LoadOpClear. Calling BeginFrame here would reset
 	// frameRendered=false, causing the final FlushGPU to wipe that content
 	// with a second LoadOpClear. See RENDER-DIRECT-003.
-	err := c.ctx.FlushGPU()
+	err := c.ctx.FlushGPUWithView(surfaceView, width, height)
 
 	c.dirty = false
 	return err

--- a/internal/gpu/pipeline_wiring_test.go
+++ b/internal/gpu/pipeline_wiring_test.go
@@ -305,7 +305,7 @@ func TestSDFAccelerator_Interfaces(t *testing.T) {
 	var _ gg.GPUAccelerator = a
 
 	// Extension interfaces.
-	var _ gg.SurfaceTargetAware = a
+	var _ gg.SurfaceTargetAware = a //nolint:staticcheck // backward compat, SetSurfaceTarget still supported
 	var _ gg.GPUTextAccelerator = a
 	var _ gg.PipelineModeAware = a
 	var _ gg.ComputePipelineAware = a

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -161,10 +161,17 @@ type GPURenderSession struct {
 	// previously drawn content. This handles mid-frame flushes caused by
 	// CPU fallback operations (e.g., DrawImage between GPU draws).
 	//
-	// Reset by BeginFrame() at the start of each frame.
+	// Reset by BeginFrame() at the start of each frame, or when the
+	// active view changes (different Context targets different view).
 	// Only relevant in surface mode — offscreen mode composites via
 	// Porter-Duff "over" during readback, so LoadOpClear is always safe.
 	frameRendered bool
+
+	// lastView tracks the most recent per-pass view used for rendering.
+	// When the view changes between Flush calls (e.g., two gg.Context
+	// instances rendering to different targets), frameRendered is reset
+	// so the new view gets a LoadOpClear on its first render pass.
+	lastView *wgpu.TextureView
 
 	// scissorRect holds the current scissor rect in device pixels.
 	// When non-nil, all draw commands are clipped to this rectangle.
@@ -253,6 +260,67 @@ func (s *GPURenderSession) SetSurfaceTarget(view *wgpu.TextureView, width, heigh
 // Porter-Duff "over", so LoadOpClear is always safe there.
 func (s *GPURenderSession) BeginFrame() {
 	s.frameRendered = false
+	s.lastView = nil
+}
+
+// resolveActiveView returns the per-pass texture view to use for surface
+// rendering. The per-pass target.View takes priority over the session-level
+// surfaceView (which is retained for backward compatibility with callers
+// that still use SetSurfaceTarget).
+//
+// Returns nil when rendering should use the CPU readback path.
+func (s *GPURenderSession) resolveActiveView(target gg.GPURenderTarget) *wgpu.TextureView {
+	if target.View != nil {
+		if v := extractTextureView(target.View); v != nil {
+			return v
+		}
+	}
+	// Fall back to session-level surfaceView for backward compat.
+	return s.surfaceView
+}
+
+// extractTextureView type-asserts a gpucontext.TextureView to
+// *wgpu.TextureView, trying the direct assertion first and then the
+// HalTextureView() accessor pattern used by gogpu wrappers.
+func extractTextureView(view any) *wgpu.TextureView {
+	if halView, ok := view.(*wgpu.TextureView); ok && halView != nil {
+		return halView
+	}
+	type halTextureViewAccessor interface {
+		HalTextureView() *wgpu.TextureView
+	}
+	if hva, ok := view.(halTextureViewAccessor); ok {
+		return hva.HalTextureView()
+	}
+	return nil
+}
+
+// effectiveDimensions returns the width and height to use for MSAA textures
+// and viewport. When rendering to a view, uses the view dimensions; otherwise
+// uses the CPU readback target dimensions.
+func (s *GPURenderSession) effectiveDimensions(target gg.GPURenderTarget, activeView *wgpu.TextureView) (uint32, uint32) {
+	if activeView != nil {
+		// Per-pass view dimensions from target take priority.
+		if target.View != nil && target.ViewWidth > 0 && target.ViewHeight > 0 {
+			return target.ViewWidth, target.ViewHeight
+		}
+		// Fall back to session-level surface dimensions (backward compat).
+		if s.surfaceWidth > 0 && s.surfaceHeight > 0 {
+			return s.surfaceWidth, s.surfaceHeight
+		}
+	}
+	return uint32(target.Width), uint32(target.Height) //nolint:gosec // dimensions always fit uint32
+}
+
+// ensureTexturesForView creates or ensures MSAA/stencil textures sized for
+// the active render target. In surface/view mode only MSAA and stencil are
+// created (the view itself is the resolve target). In offscreen mode a
+// resolve texture is also created for CPU readback.
+func (s *GPURenderSession) ensureTexturesForView(activeView *wgpu.TextureView, w, h uint32) error {
+	if activeView != nil {
+		return s.textures.ensureSurfaceTextures(s.device, w, h, "session")
+	}
+	return s.textures.ensureTextures(s.device, w, h, "session")
 }
 
 // SetScissorRect sets the scissor rect for subsequent GPU draw commands.
@@ -322,25 +390,23 @@ func (s *GPURenderSession) RenderFrame(
 		return nil
 	}
 
+	// Determine render target view: per-pass target.View takes priority
+	// over session-level surfaceView (backward compat).
+	activeView := s.resolveActiveView(target)
+
 	slogger().Debug("RenderFrame",
 		"sdf", len(sdfShapes), "convex", len(convexCommands),
 		"stencil", len(stencilPaths), "text", len(textBatches),
 		"glyphMask", len(glyphMaskBatches),
-		"surface", s.surfaceView != nil)
+		"surface", activeView != nil)
 
-	w, h := uint32(target.Width), uint32(target.Height) //nolint:gosec // dimensions always fit uint32
-	// In surface mode, use surface dimensions for MSAA textures and viewport.
-	// The target (gg pixmap) may differ from the surface; the MSAA resolve
-	// target must match the surface view dimensions.
-	if s.surfaceView != nil && s.surfaceWidth > 0 && s.surfaceHeight > 0 {
-		w, h = s.surfaceWidth, s.surfaceHeight
-	}
+	w, h := s.effectiveDimensions(target, activeView)
 	slogger().Debug("RenderFrame dimensions",
 		"target_w", target.Width, "target_h", target.Height,
 		"effective_w", w, "effective_h", h,
-		"surface", s.surfaceView != nil,
+		"surface", activeView != nil,
 	)
-	if err := s.EnsureTextures(w, h); err != nil {
+	if err := s.ensureTexturesForView(activeView, w, h); err != nil {
 		return fmt.Errorf("ensure textures: %w", err)
 	}
 
@@ -387,8 +453,8 @@ func (s *GPURenderSession) RenderFrame(
 		return err
 	}
 
-	if s.surfaceView != nil {
-		return s.encodeSubmitSurface(w, h, sdfResources, sdfShapes, convexRes, stencilResources, stencilPaths, textRes, glyphMaskRes)
+	if activeView != nil {
+		return s.encodeSubmitSurface(activeView, w, h, sdfResources, sdfShapes, convexRes, stencilResources, stencilPaths, textRes, glyphMaskRes)
 	}
 	return s.encodeSubmitReadback(w, h, sdfResources, sdfShapes, convexRes, stencilResources, stencilPaths, textRes, glyphMaskRes, target)
 }
@@ -428,11 +494,12 @@ func (s *GPURenderSession) RenderFrameGrouped(target gg.GPURenderTarget, groups 
 		return nil
 	}
 
-	w, h := uint32(target.Width), uint32(target.Height) //nolint:gosec // dimensions always fit uint32
-	if s.surfaceView != nil && s.surfaceWidth > 0 && s.surfaceHeight > 0 {
-		w, h = s.surfaceWidth, s.surfaceHeight
-	}
-	if err := s.EnsureTextures(w, h); err != nil {
+	// Determine render target view: per-pass target.View takes priority
+	// over session-level surfaceView (backward compat).
+	activeView := s.resolveActiveView(target)
+
+	w, h := s.effectiveDimensions(target, activeView)
+	if err := s.ensureTexturesForView(activeView, w, h); err != nil {
 		return fmt.Errorf("ensure textures: %w", err)
 	}
 	// Clip bind layout must be created BEFORE pipelines, because pipeline
@@ -578,8 +645,8 @@ func (s *GPURenderSession) RenderFrameGrouped(target gg.GPURenderTarget, groups 
 		}
 	}
 
-	if s.surfaceView != nil {
-		return s.encodeSubmitSurfaceGrouped(w, h, grpRes)
+	if activeView != nil {
+		return s.encodeSubmitSurfaceGrouped(activeView, w, h, grpRes)
 	}
 	return s.encodeSubmitReadbackGrouped(w, h, grpRes, target)
 }
@@ -623,6 +690,7 @@ func (s *GPURenderSession) Destroy() {
 	s.surfaceView = nil
 	s.surfaceWidth = 0
 	s.surfaceHeight = 0
+	s.lastView = nil
 	// Do not destroy pipelines -- they are owned by the caller.
 }
 
@@ -1784,14 +1852,15 @@ func (s *GPURenderSession) copySubmitAndReadback(
 	return nil
 }
 
-// encodeSubmitSurface encodes the unified render pass with the surface view
+// encodeSubmitSurface encodes the unified render pass with the given view
 // as the resolve target, then submits without readback. The MSAA color
-// attachment resolves directly to the caller-provided surface texture view.
+// attachment resolves directly to the provided texture view.
 //
 // This is the zero-copy path for windowed rendering: no staging buffer, no
 // CopyTextureToBuffer, no ReadBuffer, no fence wait (presentation handles
 // synchronization).
 func (s *GPURenderSession) encodeSubmitSurface(
+	view *wgpu.TextureView,
 	w, h uint32,
 	sdfRes *sdfFrameResources,
 	sdfShapes []SDFRenderShape,
@@ -1807,6 +1876,15 @@ func (s *GPURenderSession) encodeSubmitSurface(
 	if err != nil {
 		return fmt.Errorf("create command encoder: %w", err)
 	}
+	// Per-view frame tracking: when the view changes between flushes
+	// (e.g., two gg.Context instances rendering to different targets),
+	// reset frameRendered so the new view gets LoadOpClear on its first
+	// pass. This prevents shapes from one Context leaking into another.
+	if view != s.lastView {
+		s.frameRendered = false
+		s.lastView = view
+	}
+
 	// Surface render pass LoadOp: first pass clears, subsequent passes
 	// preserve existing content. This handles mid-frame flushes caused by
 	// CPU fallback operations (e.g., DrawImage between GPU draw calls).
@@ -1824,7 +1902,7 @@ func (s *GPURenderSession) encodeSubmitSurface(
 		Label: "session_surface_pass",
 		ColorAttachments: []wgpu.RenderPassColorAttachment{{
 			View:          s.textures.msaaView,
-			ResolveTarget: s.surfaceView,
+			ResolveTarget: view,
 			LoadOp:        colorLoadOp,
 			StoreOp:       gputypes.StoreOpStore,
 			ClearValue:    gputypes.Color{R: 0, G: 0, B: 0, A: 0},
@@ -2100,9 +2178,10 @@ func (s *GPURenderSession) encodeSubmitReadbackGrouped(
 }
 
 // encodeSubmitSurfaceGrouped encodes a single render pass with per-group
-// scissor state changes, resolving directly to the surface view. No readback
+// scissor state changes, resolving directly to the given view. No readback
 // occurs. This is the grouped version of encodeSubmitSurface.
 func (s *GPURenderSession) encodeSubmitSurfaceGrouped(
+	view *wgpu.TextureView,
 	w, h uint32,
 	grpRes []groupResources,
 ) error {
@@ -2112,6 +2191,12 @@ func (s *GPURenderSession) encodeSubmitSurfaceGrouped(
 	if err != nil {
 		return fmt.Errorf("create command encoder: %w", err)
 	}
+	// Per-view frame tracking (same as encodeSubmitSurface).
+	if view != s.lastView {
+		s.frameRendered = false
+		s.lastView = view
+	}
+
 	// Surface render pass LoadOp: first pass clears, subsequent passes
 	// preserve existing content. This handles mid-frame flushes caused by
 	// CPU fallback operations (e.g., DrawImage between GPU draw calls).
@@ -2128,7 +2213,7 @@ func (s *GPURenderSession) encodeSubmitSurfaceGrouped(
 		Label: "session_surface_pass",
 		ColorAttachments: []wgpu.RenderPassColorAttachment{{
 			View:          s.textures.msaaView,
-			ResolveTarget: s.surfaceView,
+			ResolveTarget: view,
 			LoadOp:        colorLoadOp,
 			StoreOp:       gputypes.StoreOpStore,
 			ClearValue:    gputypes.Color{R: 0, G: 0, B: 0, A: 0},

--- a/internal/gpu/sdf_gpu.go
+++ b/internal/gpu/sdf_gpu.go
@@ -99,7 +99,7 @@ type SDFAccelerator struct {
 }
 
 var _ gg.GPUAccelerator = (*SDFAccelerator)(nil)
-var _ gg.SurfaceTargetAware = (*SDFAccelerator)(nil)
+var _ gg.SurfaceTargetAware = (*SDFAccelerator)(nil) //nolint:staticcheck // backward compat, SetSurfaceTarget still supported
 var _ gg.DirectRenderCapable = (*SDFAccelerator)(nil)
 var _ gg.GPUTextAccelerator = (*SDFAccelerator)(nil)
 var _ gg.GPUGlyphMaskAccelerator = (*SDFAccelerator)(nil)
@@ -1180,6 +1180,11 @@ func (a *SDFAccelerator) queueShape(target gg.GPURenderTarget, shape gg.Detected
 }
 
 func sameTarget(a *gg.GPURenderTarget, b *gg.GPURenderTarget) bool {
+	// GPU-direct mode: compare View identity.
+	if a.View != nil || b.View != nil {
+		return a.View == b.View
+	}
+	// CPU readback mode: compare data buffer identity.
 	return a.Width == b.Width && a.Height == b.Height &&
 		len(a.Data) == len(b.Data) && len(a.Data) > 0 && &a.Data[0] == &b.Data[0]
 }


### PR DESCRIPTION
## Summary

Refactor GPURenderSession to use per-pass render target instead of session-level `surfaceView`. Follows WebGPU spec, Skia GrContext, Vello patterns.

Closes TASK-GG-OFFSCREEN-001. Enables multi-context GPU rendering for ui RepaintBoundary, offscreen export, multi-window.

### Changed

- **`GPURenderTarget.View`** (`gpucontext.TextureView`) — per-pass target selection. When set, GPU renders directly to this view instead of session's surfaceView.
- **`resolveActiveView(target)`** — target.View priority, fallback to session surfaceView (backward compat).
- **Per-view `lastView` tracking** — `frameRendered` reset on view change for LoadOp correctness.
- **`Context.FlushGPUWithView()`** — public API for GPU-direct rendering to specific texture view.
- **`SurfaceTargetAware` deprecated** — view travels in GPURenderTarget, not session state.
- **`ggcanvas.RenderDirect`** — migrated to `FlushGPUWithView`.
- **ARCHITECTURE.md** — updated 3 references from SurfaceTargetAware to per-pass pattern.
- **Dependencies:** gpucontext v0.14.0 (TextureView type token), gputypes v0.5.0.

## Root cause (what was broken)

`render_session.go:390`: `if s.surfaceView != nil` forced ALL GPU rendering to surface, ignoring offscreen targets. Offscreen `gg.Context` (for ui RepaintBoundary) couldn't use GPU — text appeared as vertical strips on wrong surface.

## Enterprise references

Per-pass render target is the WebGPU spec pattern (`RenderPassDescriptor.colorAttachments[].view`). Verified against Rust wgpu, Vello `render_to_texture()`, Skia GrContext + GrRenderTarget, Qt Quick QRhi.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all pass including `internal/gpu` (1.3s GPU tests)
- [x] `go vet ./...`
- [x] `golangci-lint` — 0 issues
- [x] Downstream builds: gogpu + ui clean
- [ ] CI