### PR TITLE
fix: v0.41.2 — text kerning, artifact dots, wgpu v0.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.2] - 2026-04-23
+
+### Fixed
+
+- **Text outline kerning** (BUG-TEXT-002, BUG-SCENE-TEXT-001) — `drawStringAsOutlines()` now
+  uses `text.Shape()` for glyph positioning instead of `face.Glyphs()`. Kerning pairs (Te, AV, Wo)
+  work correctly in TextModeVector, rotated, and scaled text.
+
+- **Scene text artifact dots** (BUG-SCENE-TEXT-002) — `outlineToPath()` now skips degenerate
+  contours (consecutive MoveTo without drawing ops) that produced stray dots on T/2 glyphs.
+
+### Changed
+
+- **Dependencies:** wgpu v0.25.3 → v0.25.4, naga v0.17.4 → v0.17.5
+
 ## [0.41.1] - 2026-04-23
 
 ### Fixed

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/go-webgpu/goffi v0.5.0 // indirect
 	github.com/go-webgpu/webgpu v0.4.3 // indirect
 	github.com/gogpu/gputypes v0.5.0 // indirect
-	github.com/gogpu/naga v0.17.4 // indirect
-	github.com/gogpu/wgpu v0.25.3 // indirect
+	github.com/gogpu/naga v0.17.5 // indirect
+	github.com/gogpu/wgpu v0.25.4 // indirect
 	golang.org/x/image v0.39.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -14,10 +14,10 @@ github.com/gogpu/gpucontext v0.14.0 h1:0IAkOwQFW7T5bhRqr8tSgV+bKS4rU9zpDOv5ux1QX
 github.com/gogpu/gpucontext v0.14.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.4 h1:37U/6PP7F+fiyXqJzEAOJUzxZPC5lyyOKxCOnCQIw6k=
-github.com/gogpu/naga v0.17.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.25.3 h1:qeCsEZzQqFtrJo+Ao7BgmY4SWC7mRvOXzTAdTTojqMM=
-github.com/gogpu/wgpu v0.25.3/go.mod h1:8x/k0k8B72PGKR5FJA4o5MM4catYydqZr6a4f9vEx+A=
+github.com/gogpu/naga v0.17.5 h1:FZP7dTDrHVum/4X/mJVNh3PpCirbr9cwvL1gz4qV9T4=
+github.com/gogpu/naga v0.17.5/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.25.4 h1:iXTPaI8bjLWhqBGj62tYrJMPnxtyMlBlGgh2h6qWhYg=
+github.com/gogpu/wgpu v0.25.4/go.mod h1:AJRxpA8vL+ddgEaop3qbcknjdmQOGUnZRXC6RPOpXvc=
 golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
 golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/go-webgpu/goffi v0.5.0 // indirect
 	github.com/go-webgpu/webgpu v0.4.3 // indirect
 	github.com/gogpu/gputypes v0.5.0 // indirect
-	github.com/gogpu/naga v0.17.4 // indirect
-	github.com/gogpu/wgpu v0.25.3 // indirect
+	github.com/gogpu/naga v0.17.5 // indirect
+	github.com/gogpu/wgpu v0.25.4 // indirect
 	golang.org/x/image v0.39.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -14,10 +14,10 @@ github.com/gogpu/gpucontext v0.14.0 h1:0IAkOwQFW7T5bhRqr8tSgV+bKS4rU9zpDOv5ux1QX
 github.com/gogpu/gpucontext v0.14.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.4 h1:37U/6PP7F+fiyXqJzEAOJUzxZPC5lyyOKxCOnCQIw6k=
-github.com/gogpu/naga v0.17.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.25.3 h1:qeCsEZzQqFtrJo+Ao7BgmY4SWC7mRvOXzTAdTTojqMM=
-github.com/gogpu/wgpu v0.25.3/go.mod h1:8x/k0k8B72PGKR5FJA4o5MM4catYydqZr6a4f9vEx+A=
+github.com/gogpu/naga v0.17.5 h1:FZP7dTDrHVum/4X/mJVNh3PpCirbr9cwvL1gz4qV9T4=
+github.com/gogpu/naga v0.17.5/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.25.4 h1:iXTPaI8bjLWhqBGj62tYrJMPnxtyMlBlGgh2h6qWhYg=
+github.com/gogpu/wgpu v0.25.4/go.mod h1:AJRxpA8vL+ddgEaop3qbcknjdmQOGUnZRXC6RPOpXvc=
 golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
 golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/go-webgpu/webgpu v0.4.3 // indirect
 	github.com/gogpu/gpucontext v0.14.0 // indirect
 	github.com/gogpu/gputypes v0.5.0 // indirect
-	github.com/gogpu/naga v0.17.4 // indirect
-	github.com/gogpu/wgpu v0.25.3 // indirect
+	github.com/gogpu/naga v0.17.5 // indirect
+	github.com/gogpu/wgpu v0.25.4 // indirect
 	golang.org/x/image v0.39.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -14,10 +14,10 @@ github.com/gogpu/gpucontext v0.14.0 h1:0IAkOwQFW7T5bhRqr8tSgV+bKS4rU9zpDOv5ux1QX
 github.com/gogpu/gpucontext v0.14.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.4 h1:37U/6PP7F+fiyXqJzEAOJUzxZPC5lyyOKxCOnCQIw6k=
-github.com/gogpu/naga v0.17.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.25.3 h1:qeCsEZzQqFtrJo+Ao7BgmY4SWC7mRvOXzTAdTTojqMM=
-github.com/gogpu/wgpu v0.25.3/go.mod h1:8x/k0k8B72PGKR5FJA4o5MM4catYydqZr6a4f9vEx+A=
+github.com/gogpu/naga v0.17.5 h1:FZP7dTDrHVum/4X/mJVNh3PpCirbr9cwvL1gz4qV9T4=
+github.com/gogpu/naga v0.17.5/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.25.4 h1:iXTPaI8bjLWhqBGj62tYrJMPnxtyMlBlGgh2h6qWhYg=
+github.com/gogpu/wgpu v0.25.4/go.mod h1:AJRxpA8vL+ddgEaop3qbcknjdmQOGUnZRXC6RPOpXvc=
 golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
 golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/go-webgpu/goffi v0.5.0 // indirect
 	github.com/go-webgpu/webgpu v0.4.3 // indirect
 	github.com/gogpu/gputypes v0.5.0 // indirect
-	github.com/gogpu/naga v0.17.4 // indirect
-	github.com/gogpu/wgpu v0.25.3 // indirect
+	github.com/gogpu/naga v0.17.5 // indirect
+	github.com/gogpu/wgpu v0.25.4 // indirect
 	golang.org/x/image v0.39.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -14,10 +14,10 @@ github.com/gogpu/gpucontext v0.14.0 h1:0IAkOwQFW7T5bhRqr8tSgV+bKS4rU9zpDOv5ux1QX
 github.com/gogpu/gpucontext v0.14.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.4 h1:37U/6PP7F+fiyXqJzEAOJUzxZPC5lyyOKxCOnCQIw6k=
-github.com/gogpu/naga v0.17.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.25.3 h1:qeCsEZzQqFtrJo+Ao7BgmY4SWC7mRvOXzTAdTTojqMM=
-github.com/gogpu/wgpu v0.25.3/go.mod h1:8x/k0k8B72PGKR5FJA4o5MM4catYydqZr6a4f9vEx+A=
+github.com/gogpu/naga v0.17.5 h1:FZP7dTDrHVum/4X/mJVNh3PpCirbr9cwvL1gz4qV9T4=
+github.com/gogpu/naga v0.17.5/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.25.4 h1:iXTPaI8bjLWhqBGj62tYrJMPnxtyMlBlGgh2h6qWhYg=
+github.com/gogpu/wgpu v0.25.4/go.mod h1:AJRxpA8vL+ddgEaop3qbcknjdmQOGUnZRXC6RPOpXvc=
 golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
 golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-text/typesetting v0.3.4
 	github.com/gogpu/gpucontext v0.14.0
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/naga v0.17.4
-	github.com/gogpu/wgpu v0.25.3
+	github.com/gogpu/naga v0.17.5
+	github.com/gogpu/wgpu v0.25.4
 	golang.org/x/image v0.39.0
 	golang.org/x/text v0.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/gogpu/gpucontext v0.14.0 h1:0IAkOwQFW7T5bhRqr8tSgV+bKS4rU9zpDOv5ux1QX
 github.com/gogpu/gpucontext v0.14.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.4 h1:37U/6PP7F+fiyXqJzEAOJUzxZPC5lyyOKxCOnCQIw6k=
-github.com/gogpu/naga v0.17.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/wgpu v0.25.3 h1:qeCsEZzQqFtrJo+Ao7BgmY4SWC7mRvOXzTAdTTojqMM=
-github.com/gogpu/wgpu v0.25.3/go.mod h1:8x/k0k8B72PGKR5FJA4o5MM4catYydqZr6a4f9vEx+A=
+github.com/gogpu/naga v0.17.5 h1:FZP7dTDrHVum/4X/mJVNh3PpCirbr9cwvL1gz4qV9T4=
+github.com/gogpu/naga v0.17.5/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/wgpu v0.25.4 h1:iXTPaI8bjLWhqBGj62tYrJMPnxtyMlBlGgh2h6qWhYg=
+github.com/gogpu/wgpu v0.25.4/go.mod h1:AJRxpA8vL+ddgEaop3qbcknjdmQOGUnZRXC6RPOpXvc=
 golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
 golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=

--- a/scene/text.go
+++ b/scene/text.go
@@ -374,9 +374,17 @@ func (r *TextRenderer) outlineToPath(outline *text.GlyphOutline, x, y float32, c
 	}
 
 	segments := outline.Segments
-	for _, seg := range segments {
+	for i, seg := range segments {
 		switch seg.Op {
 		case text.OutlineOpMoveTo:
+			// Skip degenerate contours: MoveTo followed by another MoveTo
+			// or at end of segments produces a dot artifact.
+			if i+1 < len(segments) && segments[i+1].Op == text.OutlineOpMoveTo {
+				continue
+			}
+			if i+1 >= len(segments) {
+				continue
+			}
 			px := x + seg.Points[0].X
 			py := y + seg.Points[0].Y*yMul
 			path.MoveTo(px, py)

--- a/text.go
+++ b/text.go
@@ -470,25 +470,26 @@ func (c *Context) drawStringAsOutlines(s string, x, y float64) {
 	path := NewPath()
 	hasContour := false
 
-	for glyph := range c.face.Glyphs(s) {
+	shaped := text.Shape(s, c.face)
+	for _, sg := range shaped {
 		cacheKey := text.OutlineCacheKey{
 			FontID:  fontID,
-			GID:     glyph.GID,
+			GID:     sg.GID,
 			Size:    sizeKey,
 			Hinting: text.HintingNone,
 		}
 		outline := cache.GetOrCreate(cacheKey, func() *text.GlyphOutline {
-			o, err := extractor.ExtractOutline(parsed, glyph.GID, fontSize)
+			o, err := extractor.ExtractOutline(parsed, sg.GID, fontSize)
 			if err != nil || o == nil || o.IsEmpty() {
 				return nil
 			}
 			return o
 		})
 		if outline == nil {
-			continue // space/missing glyph — advance handled by Glyphs iterator
+			continue
 		}
 
-		gx := x + glyph.X
+		gx := x + sg.X
 
 		for _, seg := range outline.Segments {
 			// sfnt.LoadGlyph returns Y-down coordinates (screen convention):


### PR DESCRIPTION
Patch: text outline kerning via text.Shape(), scene glyph artifact filter, wgpu v0.25.4 + naga v0.17.5.