### PR TITLE
fix(gpu): DrawGPUTexture + offscreen GPU text (v0.42.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **DrawGPUTexture invisible** (BUG-GPU-TEXTURE-DEEPCOPY-001) — `GPUTextureCommands` were
+  not deep-copied in `Flush()` scissor group snapshot. After clearing pending state, the
+  owned groups referenced zeroed slice data — GPU texture quads silently dropped every frame.
+
+- **GPU text fallback in offscreen contexts** — `ensureGPU()` was only called in `Flush()`,
+  but `DrawText`/`FillShape` checked `gpuReady` before Flush → `ErrFallbackToCPU` → CPU
+  bitmap text. Fix: lazy GPU init in `NewRenderContext()` + defense-in-depth in draw methods.
+  Glyph mask atlas now propagated to offscreen sessions.
+
 ## [0.42.0] - 2026-04-24
 
 ### Added

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -247,7 +247,12 @@ func (rc *GPURenderContext) DrawText(target gg.GPURenderTarget, face any, s stri
 	rc.sceneStats.TextCount++
 
 	if !rc.shared.gpuReady {
-		return gg.ErrFallbackToCPU
+		rc.shared.mu.Lock()
+		err := rc.shared.ensureGPU()
+		rc.shared.mu.Unlock()
+		if err != nil || !rc.shared.gpuReady {
+			return gg.ErrFallbackToCPU
+		}
 	}
 
 	rc.shared.mu.Lock()
@@ -257,6 +262,7 @@ func (rc *GPURenderContext) DrawText(target gg.GPURenderTarget, face any, s stri
 
 	batch, err := engine.LayoutText(textFace, s, x, y, color, target.Width, target.Height, matrix, deviceScale)
 	if err != nil {
+		slogger().Debug("DrawText: LayoutText failed", "err", err, "text", s)
 		return gg.ErrFallbackToCPU
 	}
 	if len(batch.Quads) == 0 {
@@ -277,7 +283,12 @@ func (rc *GPURenderContext) DrawGlyphMaskText(target gg.GPURenderTarget, face an
 	rc.sceneStats.TextCount++
 
 	if !rc.shared.gpuReady {
-		return gg.ErrFallbackToCPU
+		rc.shared.mu.Lock()
+		err := rc.shared.ensureGPU()
+		rc.shared.mu.Unlock()
+		if err != nil || !rc.shared.gpuReady {
+			return gg.ErrFallbackToCPU
+		}
 	}
 
 	rc.shared.mu.Lock()
@@ -287,6 +298,7 @@ func (rc *GPURenderContext) DrawGlyphMaskText(target gg.GPURenderTarget, face an
 
 	batch, err := engine.LayoutText(textFace, s, x, y, color, target.Width, target.Height, matrix, deviceScale)
 	if err != nil {
+		slogger().Debug("DrawGlyphMaskText: LayoutText failed", "err", err, "text", s, "w", target.Width, "h", target.Height)
 		return gg.ErrFallbackToCPU
 	}
 	if len(batch.Quads) == 0 {
@@ -563,6 +575,17 @@ func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cy
 		rc.session.SetTextAtlasRef(rc.shared.sharedAtlasTex, rc.shared.sharedAtlasView)
 	}
 
+	// Propagate glyph mask atlas page views for offscreen sessions.
+	// Same pattern as MSDF atlas — engine is shared, views must reach each session.
+	if len(allGlyphMaskBatches) > 0 && glyphEng != nil {
+		for i, batch := range allGlyphMaskBatches {
+			view := glyphEng.PageTextureView(batch.AtlasPageIndex)
+			if view != nil {
+				rc.session.SetGlyphMaskAtlasView(i, view, batch.IsLCD)
+			}
+		}
+	}
+
 	err := rc.session.RenderFrameGrouped(target, ownedGroups)
 	if err != nil {
 		total := 0
@@ -611,8 +634,16 @@ func (rc *GPURenderContext) effectivePipelineMode() gg.PipelineMode {
 // The texture has usage flags suitable for both FlushGPUWithView (render to)
 // and DrawGPUTexture (sample from). Returns view + release function.
 func (rc *GPURenderContext) CreateOffscreenTexture(w, h int) (gpucontext.TextureView, func()) {
-	if rc.shared == nil || !rc.shared.gpuReady {
+	if rc.shared == nil {
 		return nil, nil
+	}
+	if !rc.shared.gpuReady {
+		rc.shared.mu.Lock()
+		err := rc.shared.ensureGPU()
+		rc.shared.mu.Unlock()
+		if err != nil || !rc.shared.gpuReady {
+			return nil, nil
+		}
 	}
 	device := rc.shared.Device()
 	if device == nil {

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -513,6 +513,10 @@ func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cy
 			ownedGroups[i].ImageCommands = make([]ImageDrawCommand, len(g.ImageCommands))
 			copy(ownedGroups[i].ImageCommands, g.ImageCommands)
 		}
+		if len(g.GPUTextureCommands) > 0 {
+			ownedGroups[i].GPUTextureCommands = make([]GPUTextureDrawCommand, len(g.GPUTextureCommands))
+			copy(ownedGroups[i].GPUTextureCommands, g.GPUTextureCommands)
+		}
 		if len(g.TextBatches) > 0 {
 			ownedGroups[i].TextBatches = make([]TextBatch, len(g.TextBatches))
 			copy(ownedGroups[i].TextBatches, g.TextBatches)

--- a/internal/gpu/gpu_shared.go
+++ b/internal/gpu/gpu_shared.go
@@ -72,6 +72,15 @@ func NewGPUShared() *GPUShared {
 // this shared resource holder. Each gg.Context should have its own
 // GPURenderContext for isolated pending command queues and frame tracking.
 func (s *GPUShared) NewRenderContext() *GPURenderContext {
+	// Ensure GPU is initialized before creating per-context state.
+	// Without this, standalone GPU (no DeviceProvider) stays uninitialized
+	// until first Flush, causing DrawText/FillShape to fall back to CPU.
+	s.mu.Lock()
+	if err := s.ensureGPU(); err != nil {
+		slogger().Warn("GPU init failed in NewRenderContext", "err", err)
+	}
+	s.mu.Unlock()
+
 	return &GPURenderContext{
 		shared: s,
 	}

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -1946,7 +1946,12 @@ func (s *GPURenderSession) ensureGlyphMaskBatchPools(n int, uniformSize uint64) 
 // the LCD uniform layout (96 bytes with atlas_size) for per-channel alpha
 // compositing. Otherwise, the grayscale layout (80 bytes) is used.
 func (s *GPURenderSession) SetGlyphMaskAtlasView(batchIndex int, atlasView *wgpu.TextureView, isLCD bool) {
-	if s.glyphMaskPipeline == nil || atlasView == nil {
+	if s.glyphMaskPipeline == nil {
+		slogger().Warn("SetGlyphMaskAtlasView: pipeline not initialized", "batchIndex", batchIndex)
+		return
+	}
+	if atlasView == nil {
+		slogger().Warn("SetGlyphMaskAtlasView: nil atlas view", "batchIndex", batchIndex)
 		return
 	}
 	s.ensureGlyphMaskBatchPools(batchIndex+1, glyphMaskLCDUniformSize)


### PR DESCRIPTION
## Summary

- **DrawGPUTexture invisible** (BUG-GPU-TEXTURE-DEEPCOPY-001) — `GPUTextureCommands` not deep-copied in `Flush()` scissor group snapshot. After clearing pending state, owned groups referenced zeroed slice data — GPU texture quads silently dropped every frame. 4-line fix.
- **GPU text fallback in offscreen contexts** — `ensureGPU()` only called in `Flush()`, but `DrawText`/`FillShape` checked `gpuReady` before → `ErrFallbackToCPU`. Fix: lazy GPU init in `NewRenderContext()`, glyph mask atlas propagation.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -tags nogpu ./...` — all tests pass
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt` — clean
- [x] Visual test: `tmp/draw_gpu_tex_test` — both "Direct Text" and "GPU Texture Text" visible