### PR TITLE
chore(deps): update examples to gg v0.43.0

### DIFF
--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.41.1
+	github.com/gogpu/gg v0.43.0
 	github.com/gogpu/gogpu v0.28.3
 	github.com/gogpu/gpucontext v0.14.0
 )

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.41.1
+	github.com/gogpu/gg v0.43.0
 	github.com/gogpu/gogpu v0.29.0
 	github.com/gogpu/gpucontext v0.14.0
 )

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/lcd_text
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.41.1
+	github.com/gogpu/gg v0.43.0
 	github.com/gogpu/gogpu v0.28.3
 )
 

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/scene_gpu_visual
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.41.1
+	github.com/gogpu/gg v0.43.0
 	github.com/gogpu/gogpu v0.28.3
 	github.com/gogpu/gpucontext v0.14.0
 )

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.41.1
+require github.com/gogpu/gg v0.43.0
 
 require (
 	github.com/go-text/typesetting v0.3.4 // indirect

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.42.1
+	github.com/gogpu/gg v0.43.0
 	github.com/gogpu/gogpu v0.29.0
 )
 

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback_manual
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.42.1
+	github.com/gogpu/gg v0.43.0
 	github.com/gogpu/gogpu v0.29.0
 )
 


### PR DESCRIPTION
## Summary

- Update all examples go.mod: gg v0.41.1/v0.42.1 → v0.43.0

## Test plan

- [x] All examples build successfully via go.work