### PR TITLE
chore(deps): update examples to gg v0.43.1, gogpu v0.29.3

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/blit_only
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.43.0
+	github.com/gogpu/gg v0.43.1
 	github.com/gogpu/gogpu v0.29.3
 )
 

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.0 h1:U7TUFctUeCQeCYZyD56BhT4MrZdaQRMMSFrURkl+l9w=
-github.com/gogpu/gg v0.43.0/go.mod h1:FSx3S3xmpzK5dJh7uQ+khKJqE8rlclcU0uuebLzN7M4=
+github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
+github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
 github.com/gogpu/gogpu v0.29.3 h1:3Vf7/aTeFsB7+ohZhzSTpDTLWwi5p4r2oDio/NONWWM=
 github.com/gogpu/gogpu v0.29.3/go.mod h1:hDM98CVG78BodrdGGyPZAh55mk0PzYri98Sw1Ql3qO4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/clip_demo/README.md
+++ b/examples/clip_demo/README.md
@@ -1,0 +1,17 @@
+# Clip Demo
+
+GPU-accelerated clipping with `ClipRect` and `ClipRoundRect` APIs.
+
+## What it shows
+
+- **Left half:** rotating ring of colored circles — no clip (fully visible)
+- **Right half:** animated shapes inside a pulsing clip region (clipped at edges)
+- Hardware scissor rect (GPU-CLIP-001) + analytic SDF RRect clip (GPU-CLIP-002)
+
+## Run
+
+```bash
+go run .
+```
+
+Press **Escape** to quit.

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.43.0
+	github.com/gogpu/gg v0.43.1
 	github.com/gogpu/gogpu v0.29.3
 	github.com/gogpu/gpucontext v0.15.0
 )

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.0 h1:U7TUFctUeCQeCYZyD56BhT4MrZdaQRMMSFrURkl+l9w=
-github.com/gogpu/gg v0.43.0/go.mod h1:FSx3S3xmpzK5dJh7uQ+khKJqE8rlclcU0uuebLzN7M4=
+github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
+github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
 github.com/gogpu/gogpu v0.29.3 h1:3Vf7/aTeFsB7+ohZhzSTpDTLWwi5p4r2oDio/NONWWM=
 github.com/gogpu/gogpu v0.29.3/go.mod h1:hDM98CVG78BodrdGGyPZAh55mk0PzYri98Sw1Ql3qO4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.43.0
+	github.com/gogpu/gg v0.43.1
 	github.com/gogpu/gogpu v0.29.3
 	github.com/gogpu/gpucontext v0.15.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.0 h1:U7TUFctUeCQeCYZyD56BhT4MrZdaQRMMSFrURkl+l9w=
-github.com/gogpu/gg v0.43.0/go.mod h1:FSx3S3xmpzK5dJh7uQ+khKJqE8rlclcU0uuebLzN7M4=
+github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
+github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
 github.com/gogpu/gogpu v0.29.3 h1:3Vf7/aTeFsB7+ohZhzSTpDTLWwi5p4r2oDio/NONWWM=
 github.com/gogpu/gogpu v0.29.3/go.mod h1:hDM98CVG78BodrdGGyPZAh55mk0PzYri98Sw1Ql3qO4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/lcd_text/README.md
+++ b/examples/lcd_text/README.md
@@ -1,0 +1,17 @@
+# LCD ClearType Text
+
+LCD subpixel text rendering via GPU Tier 6 glyph mask pipeline.
+
+## What it shows
+
+- ClearType LCD subpixel antialiasing (3x horizontal resolution)
+- GPU glyph mask atlas (R8 alpha, hinted at device pixel size)
+- Text at multiple sizes with font hinting
+
+## Run
+
+```bash
+go run .
+```
+
+Press **Escape** to quit.

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/lcd_text
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.43.0
+	github.com/gogpu/gg v0.43.1
 	github.com/gogpu/gogpu v0.29.3
 )
 

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.0 h1:U7TUFctUeCQeCYZyD56BhT4MrZdaQRMMSFrURkl+l9w=
-github.com/gogpu/gg v0.43.0/go.mod h1:FSx3S3xmpzK5dJh7uQ+khKJqE8rlclcU0uuebLzN7M4=
+github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
+github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
 github.com/gogpu/gogpu v0.29.3 h1:3Vf7/aTeFsB7+ohZhzSTpDTLWwi5p4r2oDio/NONWWM=
 github.com/gogpu/gogpu v0.29.3/go.mod h1:hDM98CVG78BodrdGGyPZAh55mk0PzYri98Sw1Ql3qO4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/scene_gpu_visual/README.md
+++ b/examples/scene_gpu_visual/README.md
@@ -1,0 +1,27 @@
+# Scene GPU Visual
+
+Animated scene rendering with GPU acceleration in a gogpu window.
+
+## What it shows
+
+- **GPUSceneRenderer** — scene commands decoded into GPU draw calls
+- Retained-mode scene encoding (built each frame, rendered via canvas)
+- SDF shapes through per-context GPURenderContext
+- Automatic CPU fallback for unsupported operations
+
+## Architecture
+
+```
+scene.Scene (encoded commands)
+    → scene.Renderer (orchestration)
+    → gg.Context GPU accelerator (SDF pipeline)
+    → ggcanvas.Canvas → gogpu window
+```
+
+## Run
+
+```bash
+go run .
+```
+
+Press **Escape** to quit.

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/scene_gpu_visual
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.43.0
+	github.com/gogpu/gg v0.43.1
 	github.com/gogpu/gogpu v0.29.3
 	github.com/gogpu/gpucontext v0.15.0
 )

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.0 h1:U7TUFctUeCQeCYZyD56BhT4MrZdaQRMMSFrURkl+l9w=
-github.com/gogpu/gg v0.43.0/go.mod h1:FSx3S3xmpzK5dJh7uQ+khKJqE8rlclcU0uuebLzN7M4=
+github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
+github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
 github.com/gogpu/gogpu v0.29.3 h1:3Vf7/aTeFsB7+ohZhzSTpDTLWwi5p4r2oDio/NONWWM=
 github.com/gogpu/gogpu v0.29.3/go.mod h1:hDM98CVG78BodrdGGyPZAh55mk0PzYri98Sw1Ql3qO4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/sdf/README.md
+++ b/examples/sdf/README.md
@@ -1,0 +1,18 @@
+# SDF Accelerator Demo
+
+CPU SDF (Signed Distance Field) accelerator for smooth shape rendering.
+
+## What it shows
+
+- CPU SDF smoothstep coverage for circles, ellipses, rounded rectangles
+- Filled and stroked shapes with smooth antialiasing
+- SDF vs standard analytic rasterizer quality comparison
+- No GPU required — pure CPU SDF evaluation per pixel
+
+## Run
+
+```bash
+go run .
+```
+
+Output saved as PNG (no window).

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.43.0
+require github.com/gogpu/gg v0.43.1
 
 require (
 	github.com/go-text/typesetting v0.3.4 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaF
 github.com/go-text/typesetting v0.3.4/go.mod h1:4qZCQphq4KSgGTAeI0uMEkVbROgfah8BuyF5LRYr7XY=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZzMgdYPbmyXqOto4YhhJGrFIQCX94FpR4MzTCsos=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.43.0 h1:U7TUFctUeCQeCYZyD56BhT4MrZdaQRMMSFrURkl+l9w=
-github.com/gogpu/gg v0.43.0/go.mod h1:FSx3S3xmpzK5dJh7uQ+khKJqE8rlclcU0uuebLzN7M4=
+github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
+github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=
 github.com/gogpu/gpucontext v0.15.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.43.0
+	github.com/gogpu/gg v0.43.1
 	github.com/gogpu/gogpu v0.29.3
 )
 

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.0 h1:U7TUFctUeCQeCYZyD56BhT4MrZdaQRMMSFrURkl+l9w=
-github.com/gogpu/gg v0.43.0/go.mod h1:FSx3S3xmpzK5dJh7uQ+khKJqE8rlclcU0uuebLzN7M4=
+github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
+github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
 github.com/gogpu/gogpu v0.29.3 h1:3Vf7/aTeFsB7+ohZhzSTpDTLWwi5p4r2oDio/NONWWM=
 github.com/gogpu/gogpu v0.29.3/go.mod h1:hDM98CVG78BodrdGGyPZAh55mk0PzYri98Sw1Ql3qO4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback_manual
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.43.0
+	github.com/gogpu/gg v0.43.1
 	github.com/gogpu/gogpu v0.29.3
 )
 

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.0 h1:U7TUFctUeCQeCYZyD56BhT4MrZdaQRMMSFrURkl+l9w=
-github.com/gogpu/gg v0.43.0/go.mod h1:FSx3S3xmpzK5dJh7uQ+khKJqE8rlclcU0uuebLzN7M4=
+github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
+github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
 github.com/gogpu/gogpu v0.29.3 h1:3Vf7/aTeFsB7+ohZhzSTpDTLWwi5p4r2oDio/NONWWM=
 github.com/gogpu/gogpu v0.29.3/go.mod h1:hDM98CVG78BodrdGGyPZAh55mk0PzYri98Sw1Ql3qO4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=


### PR DESCRIPTION
Update all 8 examples to gg v0.43.1 + gogpu v0.29.3 (type-safe GPU handles).