### PR TITLE
chore(deps): update examples to gg v0.43.2

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/blit_only
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.43.1
+	github.com/gogpu/gg v0.43.2
 	github.com/gogpu/gogpu v0.29.4
 )
 

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
-github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
+github.com/gogpu/gg v0.43.2 h1:2iysbQk4ovoibdlguzh6/8bHqWY+oD1cWfNs5WWRQU0=
+github.com/gogpu/gg v0.43.2/go.mod h1:qM9ZxRJcxRajh6mz+oOQd1DCpvzdbe4eu0sEQqSt0rM=
 github.com/gogpu/gogpu v0.29.4 h1:DNu+JK3dKyqV1ed9zlZzgmHEQdG+0qbMJAk/1AKVc1Q=
 github.com/gogpu/gogpu v0.29.4/go.mod h1:sNTQaGFgsiViixkRr7Cigu1toticVg54r0V1OW8nVH4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.43.1
+	github.com/gogpu/gg v0.43.2
 	github.com/gogpu/gogpu v0.29.4
 	github.com/gogpu/gpucontext v0.15.0
 )

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
-github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
+github.com/gogpu/gg v0.43.2 h1:2iysbQk4ovoibdlguzh6/8bHqWY+oD1cWfNs5WWRQU0=
+github.com/gogpu/gg v0.43.2/go.mod h1:qM9ZxRJcxRajh6mz+oOQd1DCpvzdbe4eu0sEQqSt0rM=
 github.com/gogpu/gogpu v0.29.4 h1:DNu+JK3dKyqV1ed9zlZzgmHEQdG+0qbMJAk/1AKVc1Q=
 github.com/gogpu/gogpu v0.29.4/go.mod h1:sNTQaGFgsiViixkRr7Cigu1toticVg54r0V1OW8nVH4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.43.1
+	github.com/gogpu/gg v0.43.2
 	github.com/gogpu/gogpu v0.29.4
 	github.com/gogpu/gpucontext v0.15.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
-github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
+github.com/gogpu/gg v0.43.2 h1:2iysbQk4ovoibdlguzh6/8bHqWY+oD1cWfNs5WWRQU0=
+github.com/gogpu/gg v0.43.2/go.mod h1:qM9ZxRJcxRajh6mz+oOQd1DCpvzdbe4eu0sEQqSt0rM=
 github.com/gogpu/gogpu v0.29.4 h1:DNu+JK3dKyqV1ed9zlZzgmHEQdG+0qbMJAk/1AKVc1Q=
 github.com/gogpu/gogpu v0.29.4/go.mod h1:sNTQaGFgsiViixkRr7Cigu1toticVg54r0V1OW8nVH4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/lcd_text
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.43.1
+	github.com/gogpu/gg v0.43.2
 	github.com/gogpu/gogpu v0.29.4
 )
 

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
-github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
+github.com/gogpu/gg v0.43.2 h1:2iysbQk4ovoibdlguzh6/8bHqWY+oD1cWfNs5WWRQU0=
+github.com/gogpu/gg v0.43.2/go.mod h1:qM9ZxRJcxRajh6mz+oOQd1DCpvzdbe4eu0sEQqSt0rM=
 github.com/gogpu/gogpu v0.29.4 h1:DNu+JK3dKyqV1ed9zlZzgmHEQdG+0qbMJAk/1AKVc1Q=
 github.com/gogpu/gogpu v0.29.4/go.mod h1:sNTQaGFgsiViixkRr7Cigu1toticVg54r0V1OW8nVH4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/scene_gpu_visual
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.43.1
+	github.com/gogpu/gg v0.43.2
 	github.com/gogpu/gogpu v0.29.4
 	github.com/gogpu/gpucontext v0.15.0
 )

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
-github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
+github.com/gogpu/gg v0.43.2 h1:2iysbQk4ovoibdlguzh6/8bHqWY+oD1cWfNs5WWRQU0=
+github.com/gogpu/gg v0.43.2/go.mod h1:qM9ZxRJcxRajh6mz+oOQd1DCpvzdbe4eu0sEQqSt0rM=
 github.com/gogpu/gogpu v0.29.4 h1:DNu+JK3dKyqV1ed9zlZzgmHEQdG+0qbMJAk/1AKVc1Q=
 github.com/gogpu/gogpu v0.29.4/go.mod h1:sNTQaGFgsiViixkRr7Cigu1toticVg54r0V1OW8nVH4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.43.1
+require github.com/gogpu/gg v0.43.2
 
 require (
 	github.com/go-text/typesetting v0.3.4 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaF
 github.com/go-text/typesetting v0.3.4/go.mod h1:4qZCQphq4KSgGTAeI0uMEkVbROgfah8BuyF5LRYr7XY=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZzMgdYPbmyXqOto4YhhJGrFIQCX94FpR4MzTCsos=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
-github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
+github.com/gogpu/gg v0.43.2 h1:2iysbQk4ovoibdlguzh6/8bHqWY+oD1cWfNs5WWRQU0=
+github.com/gogpu/gg v0.43.2/go.mod h1:qM9ZxRJcxRajh6mz+oOQd1DCpvzdbe4eu0sEQqSt0rM=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=
 github.com/gogpu/gpucontext v0.15.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.43.1
+	github.com/gogpu/gg v0.43.2
 	github.com/gogpu/gogpu v0.29.4
 )
 

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
-github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
+github.com/gogpu/gg v0.43.2 h1:2iysbQk4ovoibdlguzh6/8bHqWY+oD1cWfNs5WWRQU0=
+github.com/gogpu/gg v0.43.2/go.mod h1:qM9ZxRJcxRajh6mz+oOQd1DCpvzdbe4eu0sEQqSt0rM=
 github.com/gogpu/gogpu v0.29.4 h1:DNu+JK3dKyqV1ed9zlZzgmHEQdG+0qbMJAk/1AKVc1Q=
 github.com/gogpu/gogpu v0.29.4/go.mod h1:sNTQaGFgsiViixkRr7Cigu1toticVg54r0V1OW8nVH4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback_manual
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.43.1
+	github.com/gogpu/gg v0.43.2
 	github.com/gogpu/gogpu v0.29.4
 )
 

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.43.1 h1:34vEBprMSo2g4NTPgycBBC0QbmWmiakTA9iJYVGDtWk=
-github.com/gogpu/gg v0.43.1/go.mod h1:2+tTF+ZefkzJSfRc7dl/qhl+YgedD2hfNWnj+24vGb8=
+github.com/gogpu/gg v0.43.2 h1:2iysbQk4ovoibdlguzh6/8bHqWY+oD1cWfNs5WWRQU0=
+github.com/gogpu/gg v0.43.2/go.mod h1:qM9ZxRJcxRajh6mz+oOQd1DCpvzdbe4eu0sEQqSt0rM=
 github.com/gogpu/gogpu v0.29.4 h1:DNu+JK3dKyqV1ed9zlZzgmHEQdG+0qbMJAk/1AKVc1Q=
 github.com/gogpu/gogpu v0.29.4/go.mod h1:sNTQaGFgsiViixkRr7Cigu1toticVg54r0V1OW8nVH4=
 github.com/gogpu/gpucontext v0.15.0 h1:LV1Ztvi14FD5FCQy9A+XP7OWRXtZNA/c8y201x7E70w=


### PR DESCRIPTION
Update all 8 examples to gg v0.43.2 (wgpu v0.26.6).