### PR TITLE
v0.43.4: Scene.AppendWithTranslation for compositor scene composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.4] - 2026-04-27
+
+### Added
+
+- **`Scene.AppendWithTranslation()`** — merges a child scene into a parent with
+  (dx, dy) coordinate offset. All pathData coordinates (MoveTo, LineTo, QuadTo,
+  CubicTo, FillRoundRect) are offset at append time. Transform stream copied
+  verbatim (our architecture pre-bakes coordinates, unlike Vello which uses
+  transform composition). Panic on unknown tags for exhaustiveness safety.
+  8 tests covering all coordinate tags, bounds, transforms, nil/empty.
+
+- **`Encoding.AppendWithTranslation()`** — encoding-level merge with coordinate
+  offset + brush/image index adjustment. Enables ADR-007 Phase 5 scene
+  composition in ui (RepaintBoundary at local coordinates → parent scene at offset).
+
 ## [0.43.3] - 2026-04-27
 
 ### Added

--- a/scene/append_translation_test.go
+++ b/scene/append_translation_test.go
@@ -1,0 +1,218 @@
+package scene
+
+import (
+	"testing"
+
+	"github.com/gogpu/gg"
+)
+
+func buildChildScene(t *testing.T) *Scene {
+	t.Helper()
+	s := NewScene()
+	brush := SolidBrush(gg.RGBA{R: 1, A: 1})
+	shape := NewRectShape(0, 0, 100, 50)
+	s.Fill(FillNonZero, IdentityAffine(), brush, shape)
+	return s
+}
+
+func TestSceneAppendWithTranslation_ZeroOffset(t *testing.T) {
+	child := buildChildScene(t)
+
+	withZero := NewScene()
+	withZero.AppendWithTranslation(child, 0, 0)
+
+	withAppend := NewScene()
+	withAppend.Append(child)
+
+	encZ := withZero.Encoding()
+	encA := withAppend.Encoding()
+
+	if len(encZ.pathData) != len(encA.pathData) {
+		t.Fatalf("pathData len: zero=%d, append=%d", len(encZ.pathData), len(encA.pathData))
+	}
+	for i := range encZ.pathData {
+		if encZ.pathData[i] != encA.pathData[i] {
+			t.Errorf("pathData[%d]: zero=%v, append=%v", i, encZ.pathData[i], encA.pathData[i])
+		}
+	}
+}
+
+func TestSceneAppendWithTranslation_RectOffset(t *testing.T) {
+	child := NewScene()
+	brush := SolidBrush(gg.RGBA{R: 1, A: 1})
+	shape := NewRoundedRectShape(0, 0, 100, 50, 5)
+	child.Fill(FillNonZero, IdentityAffine(), brush, shape)
+
+	parent := NewScene()
+	parent.AppendWithTranslation(child, 30, 40)
+
+	enc := parent.Encoding()
+
+	// Find FillRoundRect pathData: minX, minY, maxX, maxY, rx, ry
+	pathIdx := 0
+	for _, tag := range enc.tags {
+		switch tag {
+		case TagFillRoundRect:
+			if enc.pathData[pathIdx] != 30 {
+				t.Errorf("minX = %v, want 30", enc.pathData[pathIdx])
+			}
+			if enc.pathData[pathIdx+1] != 40 {
+				t.Errorf("minY = %v, want 40", enc.pathData[pathIdx+1])
+			}
+			if enc.pathData[pathIdx+2] != 130 {
+				t.Errorf("maxX = %v, want 130", enc.pathData[pathIdx+2])
+			}
+			if enc.pathData[pathIdx+3] != 90 {
+				t.Errorf("maxY = %v, want 90", enc.pathData[pathIdx+3])
+			}
+			if enc.pathData[pathIdx+4] != 5 {
+				t.Errorf("rx = %v, want 5 (no offset)", enc.pathData[pathIdx+4])
+			}
+			if enc.pathData[pathIdx+5] != 5 {
+				t.Errorf("ry = %v, want 5 (no offset)", enc.pathData[pathIdx+5])
+			}
+			pathIdx += 6
+		case TagMoveTo, TagLineTo:
+			pathIdx += 2
+		case TagQuadTo:
+			pathIdx += 4
+		case TagCubicTo:
+			pathIdx += 6
+		case TagBrush:
+			pathIdx += 4
+		}
+	}
+}
+
+func TestSceneAppendWithTranslation_PathCoordinates(t *testing.T) {
+	child := NewScene()
+	path := NewPath()
+	path.MoveTo(0, 0)
+	path.LineTo(10, 0)
+	path.QuadTo(15, 5, 10, 10)
+	path.CubicTo(5, 15, 0, 15, 0, 10)
+	path.Close()
+
+	brush := SolidBrush(gg.RGBA{R: 0, G: 1, A: 1})
+	child.Fill(FillNonZero, IdentityAffine(), brush, NewPathShape(path))
+
+	parent := NewScene()
+	parent.AppendWithTranslation(child, 50, 100)
+
+	enc := parent.Encoding()
+	pathIdx := 0
+	for _, tag := range enc.tags {
+		switch tag {
+		case TagMoveTo:
+			x, y := enc.pathData[pathIdx], enc.pathData[pathIdx+1]
+			if x != 50 || y != 100 {
+				t.Errorf("MoveTo = (%v,%v), want (50,100)", x, y)
+			}
+			pathIdx += 2
+		case TagLineTo:
+			x, y := enc.pathData[pathIdx], enc.pathData[pathIdx+1]
+			if x != 60 || y != 100 {
+				t.Errorf("LineTo = (%v,%v), want (60,100)", x, y)
+			}
+			pathIdx += 2
+		case TagQuadTo:
+			cx, cy := enc.pathData[pathIdx], enc.pathData[pathIdx+1]
+			x, y := enc.pathData[pathIdx+2], enc.pathData[pathIdx+3]
+			if cx != 65 || cy != 105 {
+				t.Errorf("QuadTo.cp = (%v,%v), want (65,105)", cx, cy)
+			}
+			if x != 60 || y != 110 {
+				t.Errorf("QuadTo.end = (%v,%v), want (60,110)", x, y)
+			}
+			pathIdx += 4
+		case TagCubicTo:
+			c1x, c1y := enc.pathData[pathIdx], enc.pathData[pathIdx+1]
+			if c1x != 55 || c1y != 115 {
+				t.Errorf("CubicTo.c1 = (%v,%v), want (55,115)", c1x, c1y)
+			}
+			pathIdx += 6
+		case TagBrush:
+			pathIdx += 4
+		case TagFillRoundRect:
+			pathIdx += 6
+		}
+	}
+}
+
+func TestSceneAppendWithTranslation_TransformsVerbatim(t *testing.T) {
+	child := NewScene()
+	child.PushTransform(TranslateAffine(5, 10))
+	brush := SolidBrush(gg.RGBA{A: 1})
+	child.Fill(FillNonZero, IdentityAffine(), brush, NewRectShape(0, 0, 10, 10))
+	child.PopTransform()
+
+	parent := NewScene()
+	parent.AppendWithTranslation(child, 100, 200)
+
+	enc := parent.Encoding()
+	for i, tr := range enc.transforms {
+		if tr.C == 105 || tr.F == 210 {
+			t.Errorf("transform[%d].C=%v, F=%v — should NOT be offset (verbatim copy)", i, tr.C, tr.F)
+		}
+	}
+}
+
+func TestSceneAppendWithTranslation_BrushNotOffset(t *testing.T) {
+	child := NewScene()
+	brush := SolidBrush(gg.RGBA{R: 0.25, G: 0.5, B: 0.75, A: 1.0})
+	child.Fill(FillNonZero, IdentityAffine(), brush, NewRectShape(0, 0, 10, 10))
+
+	parent := NewScene()
+	parent.AppendWithTranslation(child, 999, 999)
+
+	enc := parent.Encoding()
+	pathIdx := 0
+	for _, tag := range enc.tags {
+		switch tag {
+		case TagBrush:
+			r, g, b, a := enc.pathData[pathIdx], enc.pathData[pathIdx+1], enc.pathData[pathIdx+2], enc.pathData[pathIdx+3]
+			if r != 0.25 || g != 0.5 || b != 0.75 || a != 1.0 {
+				t.Errorf("Brush RGBA = (%v,%v,%v,%v), want (0.25,0.5,0.75,1) — NOT offset", r, g, b, a)
+			}
+			pathIdx += 4
+		case TagMoveTo, TagLineTo:
+			pathIdx += 2
+		case TagQuadTo:
+			pathIdx += 4
+		case TagCubicTo:
+			pathIdx += 6
+		case TagFillRoundRect:
+			pathIdx += 6
+		}
+	}
+}
+
+func TestSceneAppendWithTranslation_BoundsOffset(t *testing.T) {
+	child := NewScene()
+	brush := SolidBrush(gg.RGBA{A: 1})
+	child.Fill(FillNonZero, IdentityAffine(), brush, NewRectShape(0, 0, 100, 50))
+
+	parent := NewScene()
+	parent.AppendWithTranslation(child, 30, 40)
+
+	b := parent.Bounds()
+	if b.MinX > 30 || b.MinY > 40 || b.MaxX < 130 || b.MaxY < 90 {
+		t.Errorf("bounds = {%v,%v,%v,%v}, want to contain {30,40,130,90}", b.MinX, b.MinY, b.MaxX, b.MaxY)
+	}
+}
+
+func TestSceneAppendWithTranslation_Nil(t *testing.T) {
+	parent := NewScene()
+	parent.AppendWithTranslation(nil, 100, 200)
+	if !parent.IsEmpty() {
+		t.Error("nil append should be no-op")
+	}
+}
+
+func TestSceneAppendWithTranslation_Empty(t *testing.T) {
+	parent := NewScene()
+	parent.AppendWithTranslation(NewScene(), 100, 200)
+	if !parent.IsEmpty() {
+		t.Error("empty append should be no-op")
+	}
+}

--- a/scene/encoding.go
+++ b/scene/encoding.go
@@ -1,6 +1,7 @@
 package scene
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/gogpu/gg"
@@ -716,6 +717,160 @@ func (e *Encoding) AppendWithImages(other *Encoding, imageOffset uint32) {
 	e.bounds = e.bounds.Union(other.bounds)
 
 	// Update statistics
+	e.pathCount += other.pathCount
+	e.shapeCount += other.shapeCount
+}
+
+// AppendWithTranslation merges another encoding with a translation offset
+// applied to all path coordinates.
+//
+// Architecture: pathData coordinate offset approach.
+//
+// Our SceneCanvas pre-bakes absolute coordinates via applyTransform() and
+// records Identity transforms in the encoding. This differs from Vello where
+// paths stay in local coordinates and the transform stream carries the full
+// transformation (Vello composes transforms at append: parent * child).
+//
+// Because our pathData already contains absolute coordinates with Identity
+// transforms, the correct offset strategy is:
+//
+//   - pathData: offset all coordinate float32 values by (dx, dy)
+//   - transforms: copy VERBATIM (they are Identity; composing translation
+//     would cause double-offset since the renderer applies transforms to
+//     already-offset pathData coordinates)
+//
+// Alternative approaches considered:
+//
+//   - Vello pattern (transform composition only): multiply each child
+//     transform by TranslateAffine(dx, dy). Does NOT work with our
+//     pre-baked coordinate architecture — coordinates would stay at (0,0)
+//     since transforms are Identity.
+//
+//   - Skia/Flutter pattern (replay-time canvas transform): wrap replay in
+//     Push/Translate/Pop on the target canvas. Works with render.Canvas
+//     (used by current desktop compositor) but NOT with SceneCanvas
+//     (Scene.Append has no canvas context).
+//
+//   - Migrate to Vello architecture: stop pre-baking coordinates, record
+//     transforms in encoding, compose at append. Correct long-term but
+//     requires rewriting SceneCanvas coordinate handling.
+//
+// Tag exhaustiveness: every Tag that consumes pathData floats MUST have a
+// case in the switch below. Adding a new tag with pathData without updating
+// this switch will cause silent coordinate corruption. The default case
+// handles tags with zero pathData/drawData (markers, clip, pop).
+func (e *Encoding) AppendWithTranslation(other *Encoding, dx, dy float32, imageOffset uint32) {
+	if other == nil || len(other.tags) == 0 {
+		return
+	}
+	if dx == 0 && dy == 0 {
+		e.AppendWithImages(other, imageOffset)
+		return
+	}
+
+	//nolint:gosec // brush slice length is bounded
+	brushOffset := uint32(len(e.brushes))
+
+	e.tags = append(e.tags, other.tags...)
+
+	pathStart := len(e.pathData)
+	e.pathData = append(e.pathData, other.pathData...)
+
+	drawDataStart := len(e.drawData)
+	e.drawData = append(e.drawData, other.drawData...)
+
+	pathIdx := 0
+	drawIdx := 0
+	for _, tag := range other.tags {
+		switch tag {
+		// --- Coordinate tags: offset pathData by (dx, dy) ---
+
+		case TagMoveTo, TagLineTo:
+			e.pathData[pathStart+pathIdx] += dx
+			e.pathData[pathStart+pathIdx+1] += dy
+			pathIdx += 2
+
+		case TagQuadTo:
+			for i := 0; i < 4; i += 2 {
+				e.pathData[pathStart+pathIdx+i] += dx
+				e.pathData[pathStart+pathIdx+i+1] += dy
+			}
+			pathIdx += 4
+
+		case TagCubicTo:
+			for i := 0; i < 6; i += 2 {
+				e.pathData[pathStart+pathIdx+i] += dx
+				e.pathData[pathStart+pathIdx+i+1] += dy
+			}
+			pathIdx += 6
+
+		case TagFillRoundRect:
+			// 6 floats: minX, minY, maxX, maxY (offset), radiusX, radiusY (no offset).
+			e.pathData[pathStart+pathIdx] += dx
+			e.pathData[pathStart+pathIdx+1] += dy
+			e.pathData[pathStart+pathIdx+2] += dx
+			e.pathData[pathStart+pathIdx+3] += dy
+			pathIdx += 6
+			if drawIdx < len(other.drawData) {
+				e.drawData[drawDataStart+drawIdx] += brushOffset
+			}
+			drawIdx += 2
+
+		// --- Non-coordinate pathData: skip without offset ---
+
+		case TagBrush:
+			pathIdx += 4 // 4 float32: R, G, B, A — not coordinates
+
+		// --- Draw data only (no pathData) ---
+
+		case TagFill:
+			if drawIdx < len(other.drawData) {
+				e.drawData[drawDataStart+drawIdx] += brushOffset
+			}
+			drawIdx += 2
+
+		case TagStroke:
+			if drawIdx < len(other.drawData) {
+				e.drawData[drawDataStart+drawIdx] += brushOffset
+			}
+			drawIdx += 5 // brush + width + miterLimit + cap + join
+
+		case TagPushLayer:
+			drawIdx += 2 // blend mode + alpha
+
+		case TagImage:
+			if imageOffset > 0 && drawIdx < len(other.drawData) {
+				e.drawData[drawDataStart+drawIdx] += imageOffset
+			}
+			drawIdx++ // image index only; transform is in transforms stream
+
+		// --- Marker/structural tags: zero pathData, zero drawData ---
+
+		case TagTransform:
+			// Transform data is in the separate transforms stream, not pathData.
+			// Handled below (copied verbatim).
+
+		case TagBeginPath, TagEndPath, TagClosePath,
+			TagPopLayer, TagBeginClip, TagEndClip:
+			// Pure markers — no data in any stream.
+
+		default:
+			panic(fmt.Sprintf("scene.AppendWithTranslation: unhandled tag 0x%02X (%s) — update switch to handle pathData/drawData layout for this tag", byte(tag), tag))
+		}
+	}
+
+	// Transforms copied verbatim — see architecture note above.
+	e.transforms = append(e.transforms, other.transforms...)
+
+	e.brushes = append(e.brushes, other.brushes...)
+
+	ob := other.bounds
+	ob.MinX += dx
+	ob.MinY += dy
+	ob.MaxX += dx
+	ob.MaxY += dy
+	e.bounds = e.bounds.Union(ob)
+
 	e.pathCount += other.pathCount
 	e.shapeCount += other.shapeCount
 }

--- a/scene/scene.go
+++ b/scene/scene.go
@@ -467,6 +467,31 @@ func (s *Scene) Append(other *Scene) {
 	s.version++
 }
 
+// AppendWithTranslation merges another scene into this one, offsetting all
+// coordinates by (dx, dy). Image indices are adjusted to avoid conflicts.
+//
+// This is the Vello-derived pattern for composing child scenes recorded at
+// local (0,0) into a parent at a specific position. Used by RepaintBoundary
+// scene composition (ADR-007 Phase 5).
+func (s *Scene) AppendWithTranslation(other *Scene, dx, dy float32) {
+	if other == nil || other.IsEmpty() {
+		return
+	}
+	otherEnc := other.Encoding()
+	//nolint:gosec // image registry length is bounded
+	imageOffset := uint32(len(s.imageRegistry))
+	s.encoding.AppendWithTranslation(otherEnc, dx, dy, imageOffset)
+	s.imageRegistry = append(s.imageRegistry, other.imageRegistry...)
+
+	ob := other.Bounds()
+	ob.MinX += dx
+	ob.MinY += dy
+	ob.MaxX += dx
+	ob.MaxY += dy
+	s.bounds = s.bounds.Union(ob)
+	s.version++
+}
+
 // LayerDepth returns the current layer stack depth.
 func (s *Scene) LayerDepth() int {
 	return s.layerStack.Depth()


### PR DESCRIPTION
## Summary
- `Scene.AppendWithTranslation()` — merge child scene at (dx, dy) offset
- `Encoding.AppendWithTranslation()` — pathData coordinate offset + index adjustment
- Panic on unknown tags for exhaustiveness safety
- 8 tests covering all coordinate tags, bounds, transforms, nil/empty

Enables ADR-007 Phase 5 scene composition in ui (RepaintBoundary → parent scene).

## Test plan
- [x] `go build ./...` — pass
- [x] `go test ./scene/` — all pass (8 new + existing)
- [x] `golangci-lint` — 0 issues