### PR TITLE
v0.45.3: GPUSceneRenderer TagStroke LineCap/LineJoin fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.3] - 2026-05-07
+
+### Fixed
+
+- **GPUSceneRenderer TagStroke missing LineCap/LineJoin/MiterLimit** — only
+  `SetLineWidth` was applied from scene StrokeStyle. Arc strokes (spinner)
+  rendered as filled wedges instead of rounded arcs because LineCap defaulted
+  to Butt instead of Round.
+
 ## [0.45.2] - 2026-05-07
 
 ### Added

--- a/scene/gpu_renderer.go
+++ b/scene/gpu_renderer.go
@@ -43,7 +43,7 @@ func NewGPUSceneRenderer(dc *gg.Context) *GPUSceneRenderer {
 // not accidentally pop the clip's saved state.
 //
 // Returns nil if the scene is empty.
-func (r *GPUSceneRenderer) RenderScene(scene *Scene) error { //nolint:gocyclo,cyclop,funlen // tag dispatch across all scene command types
+func (r *GPUSceneRenderer) RenderScene(scene *Scene) error { //nolint:gocyclo,cyclop,funlen,gocognit // tag dispatch across all scene command types
 	if scene == nil {
 		return nil
 	}
@@ -145,8 +145,15 @@ func (r *GPUSceneRenderer) RenderScene(scene *Scene) error { //nolint:gocyclo,cy
 		case TagStroke:
 			brush, style := dec.Stroke()
 			applySceneBrush(dc, brush)
-			if style != nil && style.Width > 0 {
-				dc.SetLineWidth(float64(style.Width))
+			if style != nil {
+				if style.Width > 0 {
+					dc.SetLineWidth(float64(style.Width))
+				}
+				dc.SetLineCap(gg.LineCap(style.Cap))
+				dc.SetLineJoin(gg.LineJoin(style.Join))
+				if style.MiterLimit > 0 {
+					dc.SetMiterLimit(float64(style.MiterLimit))
+				}
 			}
 			_ = dc.StrokePath(path)
 			path.Clear()


### PR DESCRIPTION
### Fixed
- GPUSceneRenderer TagStroke: apply LineCap, LineJoin, MiterLimit from StrokeStyle (was only Width). Spinner arc rendered as filled wedge instead of rounded arc.