### PR TITLE
chore(deps): update examples to gg v0.45.3

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/blit_only
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.45.2
+	github.com/gogpu/gg v0.45.3
 	github.com/gogpu/gogpu v0.32.2
 )
 

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gogpu v0.32.2 h1:tEx3xxNQB2a0Wc+5AAH/PYM+e+IqqYZl4w+UlQqDxvg=
 github.com/gogpu/gogpu v0.32.2/go.mod h1:WrZGmE899hqMQGTeu8PVQIIhD8b6YllsespLuiybgqc=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.2
+	github.com/gogpu/gg v0.45.3
 	github.com/gogpu/gogpu v0.32.2
 	github.com/gogpu/gpucontext v0.17.0
 )

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gogpu v0.32.2 h1:tEx3xxNQB2a0Wc+5AAH/PYM+e+IqqYZl4w+UlQqDxvg=
 github.com/gogpu/gogpu v0.32.2/go.mod h1:WrZGmE899hqMQGTeu8PVQIIhD8b6YllsespLuiybgqc=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_path
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.2
+	github.com/gogpu/gg v0.45.3
 	github.com/gogpu/gogpu v0.32.2
 )
 

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gogpu v0.32.2 h1:tEx3xxNQB2a0Wc+5AAH/PYM+e+IqqYZl4w+UlQqDxvg=
 github.com/gogpu/gogpu v0.32.2/go.mod h1:WrZGmE899hqMQGTeu8PVQIIhD8b6YllsespLuiybgqc=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/damage_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.2
+	github.com/gogpu/gg v0.45.3
 	github.com/gogpu/gogpu v0.32.2
 	github.com/gogpu/gpucontext v0.17.0
 )

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gogpu v0.32.2 h1:tEx3xxNQB2a0Wc+5AAH/PYM+e+IqqYZl4w+UlQqDxvg=
 github.com/gogpu/gogpu v0.32.2/go.mod h1:WrZGmE899hqMQGTeu8PVQIIhD8b6YllsespLuiybgqc=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.2
+	github.com/gogpu/gg v0.45.3
 	github.com/gogpu/gogpu v0.32.2
 	github.com/gogpu/gpucontext v0.17.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gogpu v0.32.2 h1:tEx3xxNQB2a0Wc+5AAH/PYM+e+IqqYZl4w+UlQqDxvg=
 github.com/gogpu/gogpu v0.32.2/go.mod h1:WrZGmE899hqMQGTeu8PVQIIhD8b6YllsespLuiybgqc=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/lcd_text
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.2
+	github.com/gogpu/gg v0.45.3
 	github.com/gogpu/gogpu v0.32.2
 )
 

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gogpu v0.32.2 h1:tEx3xxNQB2a0Wc+5AAH/PYM+e+IqqYZl4w+UlQqDxvg=
 github.com/gogpu/gogpu v0.32.2/go.mod h1:WrZGmE899hqMQGTeu8PVQIIhD8b6YllsespLuiybgqc=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/scene_gpu_visual
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.2
+	github.com/gogpu/gg v0.45.3
 	github.com/gogpu/gogpu v0.32.2
 	github.com/gogpu/gpucontext v0.17.0
 )

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gogpu v0.32.2 h1:tEx3xxNQB2a0Wc+5AAH/PYM+e+IqqYZl4w+UlQqDxvg=
 github.com/gogpu/gogpu v0.32.2/go.mod h1:WrZGmE899hqMQGTeu8PVQIIhD8b6YllsespLuiybgqc=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.45.2
+require github.com/gogpu/gg v0.45.3
 
 require (
 	github.com/go-text/typesetting v0.3.4 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaF
 github.com/go-text/typesetting v0.3.4/go.mod h1:4qZCQphq4KSgGTAeI0uMEkVbROgfah8BuyF5LRYr7XY=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZzMgdYPbmyXqOto4YhhJGrFIQCX94FpR4MzTCsos=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=
 github.com/gogpu/gpucontext v0.17.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.45.2
+	github.com/gogpu/gg v0.45.3
 	github.com/gogpu/gogpu v0.32.2
 )
 

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gogpu v0.32.2 h1:tEx3xxNQB2a0Wc+5AAH/PYM+e+IqqYZl4w+UlQqDxvg=
 github.com/gogpu/gogpu v0.32.2/go.mod h1:WrZGmE899hqMQGTeu8PVQIIhD8b6YllsespLuiybgqc=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback_manual
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.45.2
+	github.com/gogpu/gg v0.45.3
 	github.com/gogpu/gogpu v0.32.2
 )
 

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.2 h1:a1ZrVDI//kpnb9ntDyx5vF2fxARC39IJE+FMUja0QoQ=
-github.com/gogpu/gg v0.45.2/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
+github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
 github.com/gogpu/gogpu v0.32.2 h1:tEx3xxNQB2a0Wc+5AAH/PYM+e+IqqYZl4w+UlQqDxvg=
 github.com/gogpu/gogpu v0.32.2/go.mod h1:WrZGmE899hqMQGTeu8PVQIIhD8b6YllsespLuiybgqc=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=


### PR DESCRIPTION
Update all 10 examples to gg v0.45.3 (TagStroke LineCap/LineJoin fix).