### PR TITLE
chore(examples): update dependencies to gg v0.45.4

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/blit_only
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.45.3
+	github.com/gogpu/gg v0.45.4
 	github.com/gogpu/gogpu v0.32.3
 )
 

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/blit_only/main.go
+++ b/examples/blit_only/main.go
@@ -35,9 +35,11 @@ func main() {
 		WithSize(width, height).
 		WithContinuousRender(false))
 
-	var canvas *ggcanvas.Canvas
-	var animToken *gogpu.AnimationToken
-	startTime := time.Now()
+	var (
+		canvas       *ggcanvas.Canvas
+		animTime     float64
+		lastDrawTime time.Time
+	)
 
 	app.OnDraw(func(dc *gogpu.Context) {
 		w, h := dc.Width(), dc.Height()
@@ -54,13 +56,22 @@ func main() {
 			if canvas == nil {
 				return
 			}
-			animToken = app.StartAnimation()
 		} else {
 			_ = canvas.Resize(w, h)
 		}
 
+		now := time.Now()
+		if !lastDrawTime.IsZero() {
+			dt := now.Sub(lastDrawTime).Seconds()
+			if dt > 0.1 {
+				dt = 1.0 / 60.0
+			}
+			animTime += dt
+		}
+		lastDrawTime = now
+
 		cc := canvas.Context()
-		elapsed := time.Since(startTime).Seconds()
+		elapsed := animTime
 
 		// ── CPU-ONLY content (NO GPU SDF, NO GPU text) ──
 
@@ -116,13 +127,11 @@ func main() {
 		if err := cc.FlushGPUWithView(sv, sw, sh); err != nil {
 			log.Printf("FlushGPUWithView: %v", err)
 		}
+
+		app.RequestRedraw()
 	})
 
-	app.OnClose(func() {
-		if animToken != nil {
-			animToken.Stop()
-		}
-	})
+	app.OnClose(func() {})
 
 	if err := app.Run(); err != nil {
 		log.Fatal(err)

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.3
+	github.com/gogpu/gg v0.45.4
 	github.com/gogpu/gogpu v0.32.3
 	github.com/gogpu/gpucontext v0.17.0
 )

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/clip_demo/main.go
+++ b/examples/clip_demo/main.go
@@ -57,7 +57,8 @@ func main() {
 	var animToken *gogpu.AnimationToken
 	var frame int
 	paused := false
-	startTime := time.Now()
+	var animTime float64
+	var lastDrawTime time.Time
 
 	app.OnDraw(func(dc *gogpu.Context) {
 		if frame == 0 {
@@ -65,6 +66,16 @@ func main() {
 			animToken = app.StartAnimation()
 			log.Printf("Animation started (Space to pause/resume)")
 		}
+
+		now := time.Now()
+		if !lastDrawTime.IsZero() {
+			dt := now.Sub(lastDrawTime).Seconds()
+			if dt > 0.1 {
+				dt = 1.0 / 60.0
+			}
+			animTime += dt
+		}
+		lastDrawTime = now
 
 		w, h := dc.Width(), dc.Height()
 		if w <= 0 || h <= 0 {
@@ -92,7 +103,7 @@ func main() {
 			cw, ch = w, h
 		}
 
-		elapsed := time.Since(startTime).Seconds()
+		elapsed := animTime
 		if err := canvas.Draw(func(cc *gg.Context) {
 			renderFrame(cc, elapsed, cw, ch, face20, face14, frame)
 		}); err != nil {
@@ -103,6 +114,10 @@ func main() {
 			log.Printf("Frame %d: Render error: %v", frame, err)
 		}
 		frame++
+
+		if !paused {
+			app.RequestRedraw()
+		}
 	})
 
 	// Space toggles animation pause/resume.
@@ -119,6 +134,7 @@ func main() {
 			log.Printf("Paused (0%% CPU idle, press Space to resume)")
 		} else {
 			animToken = app.StartAnimation()
+			app.RequestRedraw()
 			log.Printf("Resumed")
 		}
 	})

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_path
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.3
+	github.com/gogpu/gg v0.45.4
 	github.com/gogpu/gogpu v0.32.3
 )
 

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/clip_path/main.go
+++ b/examples/clip_path/main.go
@@ -40,7 +40,8 @@ func main() {
 
 	var canvas *ggcanvas.Canvas
 	var animToken *gogpu.AnimationToken
-	start := time.Now()
+	var animTime float64
+	var lastDrawTime time.Time
 	frame := 0
 
 	app.OnDraw(func(dc *gogpu.Context) {
@@ -49,6 +50,16 @@ func main() {
 			animToken = app.StartAnimation()
 			_ = animToken
 		}
+
+		now := time.Now()
+		if !lastDrawTime.IsZero() {
+			dt := now.Sub(lastDrawTime).Seconds()
+			if dt > 0.1 {
+				dt = 1.0 / 60.0
+			}
+			animTime += dt
+		}
+		lastDrawTime = now
 
 		w, h := dc.Size()
 		if canvas == nil {
@@ -65,7 +76,7 @@ func main() {
 		}
 
 		cw, ch := w, h
-		t := time.Since(start).Seconds()
+		t := animTime
 
 		if err := canvas.Draw(func(cc *gg.Context) {
 			renderFrame(cc, t, float64(cw), float64(ch), face16, face12, frame)
@@ -77,6 +88,7 @@ func main() {
 			log.Printf("Render error: %v", err)
 		}
 		frame++
+		app.RequestRedraw()
 	})
 
 	app.OnResize(func(w, h int) {

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/damage_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.3
+	github.com/gogpu/gg v0.45.4
 	github.com/gogpu/gogpu v0.32.3
 	github.com/gogpu/gpucontext v0.17.0
 )

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/damage_demo/main.go
+++ b/examples/damage_demo/main.go
@@ -35,13 +35,14 @@ func main() {
 		WithContinuousRender(false))
 
 	var (
-		canvas     *ggcanvas.Canvas
-		animToken  *gogpu.AnimationToken
-		startTime  = time.Now()
-		frameNum   int
-		fpsFrames  int
-		lastFPS    time.Time
-		currentFPS float64
+		canvas       *ggcanvas.Canvas
+		animToken    *gogpu.AnimationToken
+		animTime     float64
+		lastDrawTime time.Time
+		frameNum     int
+		fpsFrames    int
+		lastFPS      time.Time
+		currentFPS   float64
 	)
 
 	app.OnDraw(func(dc *gogpu.Context) {
@@ -66,7 +67,16 @@ func main() {
 			_ = canvas.Resize(w, h)
 		}
 
-		t := time.Since(startTime).Seconds()
+		now := time.Now()
+		if !lastDrawTime.IsZero() {
+			dt := now.Sub(lastDrawTime).Seconds()
+			if dt > 0.1 {
+				dt = 1.0 / 60.0
+			}
+			animTime += dt
+		}
+		lastDrawTime = now
+		t := animTime
 
 		if err := canvas.Draw(func(cc *gg.Context) {
 			cc.ResetFrameDamage()
@@ -81,7 +91,7 @@ func main() {
 
 			// ANIMATED elements — each gets its own damage rect.
 			drawBouncingCircle(cc, w, h, t)
-			drawFrameCounter(cc, w, h, frameNum, time.Since(startTime), currentFPS)
+			drawFrameCounter(cc, w, h, frameNum, time.Duration(animTime*float64(time.Second)), currentFPS)
 		}); err != nil {
 			log.Printf("Draw: %v", err)
 		}
@@ -106,6 +116,7 @@ func main() {
 			fpsFrames = 0
 			lastFPS = time.Now()
 		}
+		app.RequestRedraw()
 	})
 
 	app.EventSource().OnKeyPress(func(_ gpucontext.Key, _ gpucontext.Modifiers) {})

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.3
+	github.com/gogpu/gg v0.45.4
 	github.com/gogpu/gogpu v0.32.3
 	github.com/gogpu/gpucontext v0.17.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/gogpu_integration/main.go
+++ b/examples/gogpu_integration/main.go
@@ -61,15 +61,26 @@ func main() {
 	var animToken *gogpu.AnimationToken
 	var frame int
 	paused := false
-	startTime := time.Now()
+	var animTime float64
+	var lastDrawTime time.Time
 
 	app.OnDraw(func(dc *gogpu.Context) {
 		if frame == 0 {
 			log.Printf("Backend: %s", dc.Backend())
-			// Start animation — renders at VSync while token is alive.
 			animToken = app.StartAnimation()
 			log.Printf("Animation started (Space to pause/resume)")
 		}
+
+		// Accumulate animation time (clamped after pause to prevent jump)
+		now := time.Now()
+		if !lastDrawTime.IsZero() {
+			dt := now.Sub(lastDrawTime).Seconds()
+			if dt > 0.1 {
+				dt = 1.0 / 60.0
+			}
+			animTime += dt
+		}
+		lastDrawTime = now
 
 		w, h := dc.Width(), dc.Height()
 		if w <= 0 || h <= 0 {
@@ -98,7 +109,7 @@ func main() {
 			cw, ch = w, h
 		}
 
-		elapsed := time.Since(startTime).Seconds()
+		elapsed := animTime
 		faces := [4]text.Face{fontFace, face28, face18, face14}
 		if err := canvas.Draw(func(cc *gg.Context) {
 			renderFrame(cc, elapsed, cw, ch, faces, frame)
@@ -111,6 +122,12 @@ func main() {
 			log.Printf("Frame %d: Render error: %v", frame, err)
 		}
 		frame++
+
+		// Self-sustaining animation: request next frame from within OnDraw.
+		// Pause breaks the chain → no more OnDraw → zero frame generation.
+		if !paused {
+			app.RequestRedraw()
+		}
 	})
 
 	// Space toggles animation pause/resume — demonstrates three-state model.
@@ -127,6 +144,7 @@ func main() {
 			log.Printf("Paused (0%% CPU idle, press Space to resume)")
 		} else {
 			animToken = app.StartAnimation()
+			app.RequestRedraw()
 			log.Printf("Resumed")
 		}
 	})

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/lcd_text
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.3
+	github.com/gogpu/gg v0.45.4
 	github.com/gogpu/gogpu v0.32.3
 )
 

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/scene_gpu_visual
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.3
+	github.com/gogpu/gg v0.45.4
 	github.com/gogpu/gogpu v0.32.3
 	github.com/gogpu/gpucontext v0.17.0
 )

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/scene_gpu_visual/main.go
+++ b/examples/scene_gpu_visual/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gogpu/gg/integration/ggcanvas"
 	"github.com/gogpu/gg/scene"
 	"github.com/gogpu/gogpu"
-	"github.com/gogpu/gpucontext"
 )
 
 func main() {
@@ -29,9 +28,11 @@ func main() {
 		WithSize(width, height).
 		WithContinuousRender(false))
 
-	var canvas *ggcanvas.Canvas
-	var animToken *gogpu.AnimationToken
-	startTime := time.Now()
+	var (
+		canvas       *ggcanvas.Canvas
+		animTime     float64
+		lastDrawTime time.Time
+	)
 
 	app.OnDraw(func(dc *gogpu.Context) {
 		w, h := dc.Width(), dc.Height()
@@ -49,12 +50,21 @@ func main() {
 			if err != nil {
 				log.Fatalf("ggcanvas.New: %v", err)
 			}
-			animToken = app.StartAnimation()
 		} else {
 			_ = canvas.Resize(w, h)
 		}
 
-		t := time.Since(startTime).Seconds()
+		now := time.Now()
+		if !lastDrawTime.IsZero() {
+			dt := now.Sub(lastDrawTime).Seconds()
+			if dt > 0.1 {
+				dt = 1.0 / 60.0
+			}
+			animTime += dt
+		}
+		lastDrawTime = now
+
+		t := animTime
 		s := buildAnimatedScene(w, h, t)
 
 		if err := canvas.Draw(func(cc *gg.Context) {
@@ -71,16 +81,11 @@ func main() {
 		if err := canvas.Render(dc.RenderTarget()); err != nil {
 			log.Printf("Render: %v", err)
 		}
+
+		app.RequestRedraw()
 	})
 
-	app.EventSource().OnKeyPress(func(_ gpucontext.Key, _ gpucontext.Modifiers) {
-	})
-
-	app.OnClose(func() {
-		if animToken != nil {
-			animToken.Stop()
-		}
-	})
+	app.OnClose(func() {})
 
 	if err := app.Run(); err != nil {
 		log.Fatalf("app.Run: %v", err)

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.45.3
+require github.com/gogpu/gg v0.45.4
 
 require (
 	github.com/go-text/typesetting v0.3.4 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaF
 github.com/go-text/typesetting v0.3.4/go.mod h1:4qZCQphq4KSgGTAeI0uMEkVbROgfah8BuyF5LRYr7XY=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZzMgdYPbmyXqOto4YhhJGrFIQCX94FpR4MzTCsos=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=
 github.com/gogpu/gpucontext v0.17.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.45.3
+	github.com/gogpu/gg v0.45.4
 	github.com/gogpu/gogpu v0.32.3
 )
 

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/zero_readback/main.go
+++ b/examples/zero_readback/main.go
@@ -40,9 +40,11 @@ func main() {
 		fontFace = src.Face(14)
 	}
 
-	var canvas *ggcanvas.Canvas
-	var animToken *gogpu.AnimationToken
-	startTime := time.Now()
+	var (
+		canvas       *ggcanvas.Canvas
+		animTime     float64
+		lastDrawTime time.Time
+	)
 
 	app.OnDraw(func(dc *gogpu.Context) {
 		w, h := dc.Width(), dc.Height()
@@ -59,13 +61,22 @@ func main() {
 			if canvas == nil {
 				return
 			}
-			animToken = app.StartAnimation()
 		} else {
 			_ = canvas.Resize(w, h)
 		}
 
+		now := time.Now()
+		if !lastDrawTime.IsZero() {
+			dt := now.Sub(lastDrawTime).Seconds()
+			if dt > 0.1 {
+				dt = 1.0 / 60.0
+			}
+			animTime += dt
+		}
+		lastDrawTime = now
+
 		_ = canvas.Draw(func(cc *gg.Context) {
-			elapsed := time.Since(startTime).Seconds()
+			elapsed := animTime
 
 			// FillRectCPU: CPU-only background fill.
 			// Bypasses GPU SDF accelerator — standard DrawRectangle+Fill
@@ -113,13 +124,11 @@ func main() {
 		// RenderDirect: single GPU render pass → swapchain surface.
 		// Zero CPU readback, zero pixmap upload. All content GPU-rendered.
 		_ = canvas.Render(dc.RenderTarget())
+
+		app.RequestRedraw()
 	})
 
-	app.OnClose(func() {
-		if animToken != nil {
-			animToken.Stop()
-		}
-	})
+	app.OnClose(func() {})
 
 	if err := app.Run(); err != nil {
 		log.Fatal(err)

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback_manual
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.45.3
+	github.com/gogpu/gg v0.45.4
 	github.com/gogpu/gogpu v0.32.3
 )
 

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.45.3 h1:rB4+8jrWfDBvFI80FhJ8ZFojRGZhLyLkjK5qogRitu8=
-github.com/gogpu/gg v0.45.3/go.mod h1:cXG+IIuvtuVcV7lkVKtPuhaR6QQO2Wh+fdG7egI0xV4=
+github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
+github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gpucontext v0.17.0 h1:ptwrnCfZn0fMJa7yZU0FHy4CXNsmb6bdYJRFo0SFNN8=

--- a/examples/zero_readback_manual/main.go
+++ b/examples/zero_readback_manual/main.go
@@ -41,9 +41,11 @@ func main() {
 		fontFace = src.Face(14)
 	}
 
-	var canvas *ggcanvas.Canvas
-	var animToken *gogpu.AnimationToken
-	startTime := time.Now()
+	var (
+		canvas       *ggcanvas.Canvas
+		animTime     float64
+		lastDrawTime time.Time
+	)
 
 	app.OnDraw(func(dc *gogpu.Context) {
 		w, h := dc.Width(), dc.Height()
@@ -60,13 +62,22 @@ func main() {
 			if canvas == nil {
 				return
 			}
-			animToken = app.StartAnimation()
 		} else {
 			_ = canvas.Resize(w, h)
 		}
 
+		now := time.Now()
+		if !lastDrawTime.IsZero() {
+			dt := now.Sub(lastDrawTime).Seconds()
+			if dt > 0.1 {
+				dt = 1.0 / 60.0
+			}
+			animTime += dt
+		}
+		lastDrawTime = now
+
 		cc := canvas.Context()
-		elapsed := time.Since(startTime).Seconds()
+		elapsed := animTime
 
 		// ── Phase 1: CPU content → pixmap ──
 
@@ -135,13 +146,11 @@ func main() {
 		if err := cc.FlushGPUWithView(sv, sw, sh); err != nil {
 			log.Printf("FlushGPUWithView: %v", err)
 		}
+
+		app.RequestRedraw()
 	})
 
-	app.OnClose(func() {
-		if animToken != nil {
-			animToken.Stop()
-		}
-	})
+	app.OnClose(func() {})
 
 	if err := app.Run(); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Summary

- Update all 10 examples to gg v0.45.4 (damage pipeline, overlay-only blit, multi-flush fixes)

## Test plan

- [x] `go mod tidy` clean for all examples
- [ ] CI green