### PR TITLE
chore(examples): update dependencies to gg v0.46.2

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/blit_only
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.45.4
+	github.com/gogpu/gg v0.46.2
 	github.com/gogpu/gogpu v0.33.0
 )
 

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
 github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
+github.com/gogpu/gg v0.46.2 h1:TPPTOo9Cw5nUIhkkxrtcLMAEWIke/o1WgIcH1hs/liI=
+github.com/gogpu/gg v0.46.2/go.mod h1:Og2JvPiWLUuGwWMrfXYbJZcXO8wD6nHZqtA6M9FmmYU=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gogpu v0.33.0 h1:rzINLS0HxX9jIvD/fNbwPch53qzuK01ul1B4eIAGr+8=

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.4
+	github.com/gogpu/gg v0.46.2
 	github.com/gogpu/gogpu v0.33.0
 	github.com/gogpu/gpucontext v0.18.0
 )

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
 github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
+github.com/gogpu/gg v0.46.2 h1:TPPTOo9Cw5nUIhkkxrtcLMAEWIke/o1WgIcH1hs/liI=
+github.com/gogpu/gg v0.46.2/go.mod h1:Og2JvPiWLUuGwWMrfXYbJZcXO8wD6nHZqtA6M9FmmYU=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gogpu v0.33.0 h1:rzINLS0HxX9jIvD/fNbwPch53qzuK01ul1B4eIAGr+8=

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_path
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.4
+	github.com/gogpu/gg v0.46.2
 	github.com/gogpu/gogpu v0.33.0
 )
 

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
 github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
+github.com/gogpu/gg v0.46.2 h1:TPPTOo9Cw5nUIhkkxrtcLMAEWIke/o1WgIcH1hs/liI=
+github.com/gogpu/gg v0.46.2/go.mod h1:Og2JvPiWLUuGwWMrfXYbJZcXO8wD6nHZqtA6M9FmmYU=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gogpu v0.33.0 h1:rzINLS0HxX9jIvD/fNbwPch53qzuK01ul1B4eIAGr+8=

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/damage_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.4
+	github.com/gogpu/gg v0.46.2
 	github.com/gogpu/gogpu v0.33.0
 	github.com/gogpu/gpucontext v0.18.0
 )

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
 github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
+github.com/gogpu/gg v0.46.2 h1:TPPTOo9Cw5nUIhkkxrtcLMAEWIke/o1WgIcH1hs/liI=
+github.com/gogpu/gg v0.46.2/go.mod h1:Og2JvPiWLUuGwWMrfXYbJZcXO8wD6nHZqtA6M9FmmYU=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gogpu v0.33.0 h1:rzINLS0HxX9jIvD/fNbwPch53qzuK01ul1B4eIAGr+8=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.4
+	github.com/gogpu/gg v0.46.2
 	github.com/gogpu/gogpu v0.33.0
 	github.com/gogpu/gpucontext v0.18.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
 github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
+github.com/gogpu/gg v0.46.2 h1:TPPTOo9Cw5nUIhkkxrtcLMAEWIke/o1WgIcH1hs/liI=
+github.com/gogpu/gg v0.46.2/go.mod h1:Og2JvPiWLUuGwWMrfXYbJZcXO8wD6nHZqtA6M9FmmYU=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gogpu v0.33.0 h1:rzINLS0HxX9jIvD/fNbwPch53qzuK01ul1B4eIAGr+8=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/lcd_text
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.4
+	github.com/gogpu/gg v0.46.2
 	github.com/gogpu/gogpu v0.33.0
 )
 

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
 github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
+github.com/gogpu/gg v0.46.2 h1:TPPTOo9Cw5nUIhkkxrtcLMAEWIke/o1WgIcH1hs/liI=
+github.com/gogpu/gg v0.46.2/go.mod h1:Og2JvPiWLUuGwWMrfXYbJZcXO8wD6nHZqtA6M9FmmYU=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gogpu v0.33.0 h1:rzINLS0HxX9jIvD/fNbwPch53qzuK01ul1B4eIAGr+8=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/scene_gpu_visual
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.45.4
+	github.com/gogpu/gg v0.46.2
 	github.com/gogpu/gogpu v0.33.0
 	github.com/gogpu/gpucontext v0.18.0
 )

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
 github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
+github.com/gogpu/gg v0.46.2 h1:TPPTOo9Cw5nUIhkkxrtcLMAEWIke/o1WgIcH1hs/liI=
+github.com/gogpu/gg v0.46.2/go.mod h1:Og2JvPiWLUuGwWMrfXYbJZcXO8wD6nHZqtA6M9FmmYU=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gogpu v0.33.0 h1:rzINLS0HxX9jIvD/fNbwPch53qzuK01ul1B4eIAGr+8=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.45.4
+	github.com/gogpu/gg v0.46.2
 	github.com/gogpu/gogpu v0.33.0
 )
 

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
 github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
+github.com/gogpu/gg v0.46.2 h1:TPPTOo9Cw5nUIhkkxrtcLMAEWIke/o1WgIcH1hs/liI=
+github.com/gogpu/gg v0.46.2/go.mod h1:Og2JvPiWLUuGwWMrfXYbJZcXO8wD6nHZqtA6M9FmmYU=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gogpu v0.33.0 h1:rzINLS0HxX9jIvD/fNbwPch53qzuK01ul1B4eIAGr+8=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback_manual
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.45.4
+	github.com/gogpu/gg v0.46.2
 	github.com/gogpu/gogpu v0.33.0
 )
 

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -8,6 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.45.4 h1:Q5saa+cQcZkewSxIPDDsFVg5+eNmLx7FqN27HD3ISHo=
 github.com/gogpu/gg v0.45.4/go.mod h1:wZ/coZqj2bS2eT5DOTz4QWraKCamHJ7F36VpvUCXi5o=
+github.com/gogpu/gg v0.46.2 h1:TPPTOo9Cw5nUIhkkxrtcLMAEWIke/o1WgIcH1hs/liI=
+github.com/gogpu/gg v0.46.2/go.mod h1:Og2JvPiWLUuGwWMrfXYbJZcXO8wD6nHZqtA6M9FmmYU=
 github.com/gogpu/gogpu v0.32.3 h1:M5baNrwR+wB9CiH0RFyWIflx49DBFRNqhJYKZffBgsQ=
 github.com/gogpu/gogpu v0.32.3/go.mod h1:JtsAjxYk7SG8LmvxBQH+AiiY2fXowK5Nfz4MYGSdwls=
 github.com/gogpu/gogpu v0.33.0 h1:rzINLS0HxX9jIvD/fNbwPch53qzuK01ul1B4eIAGr+8=


### PR DESCRIPTION
Update all 9 examples to gg v0.46.2 (ClearType LCD auto-detection + GPU-direct examples fix).