### PR TITLE
v0.46.4: deferred ortho projection + scissor blit-only fix (ADR-025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from `effectiveDimensions()`, matching SDF/Convex/Stencil/Image tiers and Skia/Vello
   enterprise pattern. CPU-side fix, zero shader changes.
 
+- **Scissor groups applied to GPU texture overlays in blit-only path** — `encodeBlitOnlyPass`
+  had scissor group infrastructure but was not applying it to GPU texture overlay draws.
+  RepaintBoundary textures (e.g., ListView items) rendered outside their parent viewport
+  when composited via the non-MSAA blit path.
+
 ## [0.46.3] - 2026-05-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.46.4] - 2026-05-09
+
+### Fixed
+
+- **Text ortho projection deferred to flush time** (ADR-025, Skia `sk_RTAdjust` pattern) —
+  Tier 4 (MSDF) and Tier 6 (GlyphMask) previously baked ortho projection at draw time
+  using context pixmap dimensions. When `FlushGPUWithView` rendered to offscreen textures
+  (RepaintBoundary), text was squished/mispositioned. Now ortho is computed at flush time
+  from `effectiveDimensions()`, matching SDF/Convex/Stencil/Image tiers and Skia/Vello
+  enterprise pattern. CPU-side fix, zero shader changes.
+
 ## [0.46.3] - 2026-05-09
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,15 +19,19 @@
 
 ---
 
-## Current State: v0.45.2
+## Current State: v0.46.4
 
 ✅ **Production-ready** with GPU-accelerated rendering:
-- **Four-level damage pipeline** (ADR-021) — Object Diff → Tile Dirty → GPU Scissor → OS Present. Per-rect damage tracking, debug overlay (`GOGPU_DEBUG_DAMAGE=1`), incremental Path.Bounds (Skia pattern)
-- **Adapter-aware render mode** (`GOGPU_RENDER_MODE=auto|cpu|gpu`, ADR-020) — CPU rasterizer on software adapter, GPU on real hardware
-- **GPU depth clipping** — `dc.Clip()` with arbitrary paths routes to GPU depth buffer (ADR-019)
+- **Scene text TagText** (ADR-022) — glyph references, shape-once, DrawShapedGlyphs (Skia drawTextBlob)
+- **Atlas zoom resilience** — Skia size buckets, page reclamation, frame-based compact (ui#94)
+- **ClearType LCD auto-detection** (ADR-024) — Windows SPI, macOS None, Linux Xft/Wayland
+- **Deferred ortho projection** (ADR-025) — Skia sk_RTAdjust, correct offscreen text
+- **Four-level damage pipeline** (ADR-021) — Object Diff → Tile Dirty → GPU Scissor → OS Present
+- **Adapter-aware render mode** (`GOGPU_RENDER_MODE=auto|cpu|gpu`, ADR-020)
 - Canvas API, Text, Images, Clipping, Layers
 - **Seven-tier GPU render pipeline** (SDF + Convex + Stencil-then-Cover + Textured Quad + GPU Texture Composite + MSDF Text + Compute + Glyph Mask)
-- **Zero-readback compositor pipeline** (ADR-015/016) — FlushPixmap, DrawGPUTextureBase, BeginGPUFrame, FillRectCPU, non-MSAA blit path (93% bandwidth reduction)
+- **Zero-readback compositor pipeline** (ADR-015/016)
+- All 5 backends: Vulkan, DX12, DX12+DXIL, GLES, Software
 - **Single command buffer compositor** (ADR-017, Flutter Impeller pattern) — CreateSharedEncoder + SetSharedEncoder + SubmitSharedEncoder for multi-context frames
 - **GPU-to-GPU texture compositing** — DrawGPUTexture + CreateOffscreenTexture (Flutter pattern, zero readback)
 - **Bullet-proof encoder lifecycle** — defer-based safety, no silently swallowed errors

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,6 +89,10 @@ Auto-selection routes horizontal text ≤48px to Tier 6 (pixel-perfect with font
 
 This mirrors enterprise engines (Skia Ganesh/Graphite, Flutter Impeller, Gio).
 
+All tiers compute ortho projection at **flush time** from actual render target dimensions
+(ADR-025, Skia `sk_RTAdjust` pattern). This enables correct rendering to offscreen
+textures of any size (RepaintBoundary compositing).
+
 Key design:
 - `RegisterAccelerator()` for opt-in GPU
 - `ErrFallbackToCPU` sentinel error for graceful degradation
@@ -869,6 +873,7 @@ gg and gogpu are **independent libraries** that can interoperate via gpucontext:
 | **Device Sharing** | Skia Graphite | DeviceProviderAware for gogpu integration |
 | **Per-Pass Render Target** | WebGPU spec, Skia GrContext | GPURenderTarget.View for per-pass target (surface or offscreen) |
 | **LCD Auto-Detection** | Skia/Chrome, Qt6 | Platform subpixel detection (ADR-024): Windows SPI+registry, macOS None, Linux Xft/Wayland. Auto-enabled via PlatformProvider. |
+| **Deferred Ortho Projection** | Skia `sk_RTAdjust`, Vello | Ortho computed at flush time from render target dimensions, not draw time (ADR-025). Enables correct offscreen rendering. |
 
 ## See Also
 

--- a/internal/gpu/glyph_mask_engine.go
+++ b/internal/gpu/glyph_mask_engine.go
@@ -102,7 +102,6 @@ func (e *GlyphMaskEngine) LayoutText(
 	s string,
 	x, y float64,
 	color gg.RGBA,
-	viewportW, viewportH int,
 	matrix gg.Matrix,
 	deviceScale float64,
 ) (GlyphMaskBatch, error) {
@@ -145,7 +144,7 @@ func (e *GlyphMaskEngine) LayoutText(
 		shaped = append(shaped, text.ShapedGlyph{GID: glyph.GID, X: glyph.X, Y: glyph.Y})
 	}
 
-	return e.layoutGlyphs(shaped, x, y, fontSize, fontID, parsed, hinting, useLCD, lcdLayout, &lcdFilter, batchColor, viewportW, viewportH, matrix, deviceScale), nil
+	return e.layoutGlyphs(shaped, x, y, fontSize, fontID, parsed, hinting, useLCD, lcdLayout, &lcdFilter, batchColor, matrix, deviceScale), nil
 }
 
 // LayoutShapedGlyphs lays out pre-shaped glyphs into a GlyphMaskBatch.
@@ -156,7 +155,6 @@ func (e *GlyphMaskEngine) LayoutShapedGlyphs(
 	glyphs []text.ShapedGlyph,
 	x, y float64,
 	color gg.RGBA,
-	viewportW, viewportH int,
 	matrix gg.Matrix,
 	deviceScale float64,
 ) (GlyphMaskBatch, error) {
@@ -184,7 +182,7 @@ func (e *GlyphMaskEngine) LayoutShapedGlyphs(
 	}
 
 	lcdFilter := e.lcdFilter
-	return e.layoutGlyphs(glyphs, x, y, fontSize, fontID, parsed, hinting, useLCD, e.lcdLayout, &lcdFilter, batchColor, viewportW, viewportH, matrix, deviceScale), nil
+	return e.layoutGlyphs(glyphs, x, y, fontSize, fontID, parsed, hinting, useLCD, e.lcdLayout, &lcdFilter, batchColor, matrix, deviceScale), nil
 }
 
 // layoutGlyphs is the common implementation for LayoutText and LayoutShapedGlyphs.
@@ -200,7 +198,6 @@ func (e *GlyphMaskEngine) layoutGlyphs(
 	lcdLayout text.LCDLayout,
 	lcdFilter *text.LCDFilter,
 	batchColor [4]float32,
-	viewportW, viewportH int,
 	matrix gg.Matrix,
 	deviceScale float64,
 ) GlyphMaskBatch {
@@ -296,17 +293,9 @@ func (e *GlyphMaskEngine) layoutGlyphs(
 		return GlyphMaskBatch{}
 	}
 
-	// Build the composed transform: CTM x ortho_projection.
-	// The ortho projection maps pixel coordinates to NDC [-1, 1]:
-	//   ndc_x = x / w * 2 - 1
-	//   ndc_y = 1 - y / h * 2
-	vw := float64(viewportW)
-	vh := float64(viewportH)
-	ortho := gg.Matrix{
-		A: 2.0 / vw, B: 0, C: -1.0,
-		D: 0, E: -2.0 / vh, F: 1.0,
-	}
-	transform := ortho.Multiply(matrix)
+	// Store device-space CTM only — ortho projection is deferred to flush time
+	// when the actual render target dimensions are known (ADR-025, Skia sk_RTAdjust pattern).
+	// This enables correct rendering to offscreen textures of any size.
 
 	// Atlas dimensions for the LCD shader's texel stepping.
 	atlasConfig := e.atlas.Config()
@@ -314,7 +303,7 @@ func (e *GlyphMaskEngine) layoutGlyphs(
 
 	return GlyphMaskBatch{
 		Quads:          quads,
-		Transform:      transform,
+		Transform:      matrix,
 		Color:          batchColor,
 		IsLCD:          batchIsLCD,
 		AtlasWidth:     atlasSize,

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -353,7 +353,7 @@ func (rc *GPURenderContext) DrawText(target gg.GPURenderTarget, face any, s stri
 	engine := rc.shared.textEngine
 	rc.shared.mu.Unlock()
 
-	batch, err := engine.LayoutText(textFace, s, x, y, color, target.Width, target.Height, matrix, deviceScale)
+	batch, err := engine.LayoutText(textFace, s, x, y, color, matrix, deviceScale)
 	if err != nil {
 		slogger().Debug("DrawText: LayoutText failed", "err", err, "text", s)
 		return gg.ErrFallbackToCPU
@@ -389,7 +389,7 @@ func (rc *GPURenderContext) DrawGlyphMaskText(target gg.GPURenderTarget, face an
 	engine := rc.shared.glyphMaskEngine
 	rc.shared.mu.Unlock()
 
-	batch, err := engine.LayoutText(textFace, s, x, y, color, target.Width, target.Height, matrix, deviceScale)
+	batch, err := engine.LayoutText(textFace, s, x, y, color, matrix, deviceScale)
 	if err != nil {
 		slogger().Debug("DrawGlyphMaskText: LayoutText failed", "err", err, "text", s, "w", target.Width, "h", target.Height)
 		return gg.ErrFallbackToCPU
@@ -426,7 +426,7 @@ func (rc *GPURenderContext) DrawShapedGlyphMaskText(target gg.GPURenderTarget, f
 	engine := rc.shared.glyphMaskEngine
 	rc.shared.mu.Unlock()
 
-	batch, err := engine.LayoutShapedGlyphs(textFace, glyphs, x, y, color, target.Width, target.Height, matrix, deviceScale)
+	batch, err := engine.LayoutShapedGlyphs(textFace, glyphs, x, y, color, matrix, deviceScale)
 	if err != nil {
 		return gg.ErrFallbackToCPU
 	}

--- a/internal/gpu/gpu_text.go
+++ b/internal/gpu/gpu_text.go
@@ -89,7 +89,6 @@ func (e *GPUTextEngine) LayoutText(
 	s string,
 	x, y float64,
 	color gg.RGBA,
-	viewportW, viewportH int,
 	matrix gg.Matrix,
 	deviceScale float64,
 ) (TextBatch, error) {
@@ -172,8 +171,7 @@ func (e *GPUTextEngine) LayoutText(
 	slogger().Info("LayoutText result",
 		"text", s, "glyphs", glyphCount,
 		"quads", len(quads),
-		"outlineSkip", outlineSkip, "atlasSkip", atlasSkip, "boundsSkip", boundsSkip,
-		"viewport", fmt.Sprintf("%dx%d", viewportW, viewportH))
+		"outlineSkip", outlineSkip, "atlasSkip", atlasSkip, "boundsSkip", boundsSkip)
 
 	if len(quads) == 0 {
 		return TextBatch{}, nil
@@ -196,19 +194,13 @@ func (e *GPUTextEngine) LayoutText(
 	// The fragment shader's fwidth() automatically adapts to the composed
 	// transform, producing correct screenPxRange for anti-aliasing at any
 	// scale/rotation.
-	vw := float64(viewportW)
-	vh := float64(viewportH)
-	ortho := gg.Matrix{
-		A: 2.0 / vw, B: 0, C: -1.0,
-		D: 0, E: -2.0 / vh, F: 1.0,
-	}
-	// Compose: ortho * CTM (CTM applied first to vertex, then ortho).
-	transform := ortho.Multiply(matrix)
+	// Store device-space CTM only — ortho projection deferred to flush time
+	// when actual render target dimensions are known (ADR-025).
 
 	return TextBatch{
 		Quads:      quads,
 		Color:      color,
-		Transform:  transform,
+		Transform:  matrix,
 		AtlasIndex: 0, // Currently single atlas support.
 		PxRange:    e.pxRange,
 		AtlasSize:  float32(atlasConfig.Size),

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -129,6 +129,11 @@ type GPURenderSession struct {
 	surfaceWidth  uint32
 	surfaceHeight uint32
 
+	// Effective render target dimensions for the current frame (ADR-025).
+	// Set at flush time from effectiveDimensions(). Used by text pipelines
+	// (Tier 4/6) to compute ortho projection at flush time, not draw time.
+	frameW, frameH int
+
 	// Persistent per-frame GPU buffers (survive across frames).
 	// Grow-only: reallocated only when data exceeds current capacity.
 	sdfVertBuf       *wgpu.Buffer
@@ -603,6 +608,7 @@ func (s *GPURenderSession) RenderFrameGrouped(target gg.GPURenderTarget, groups 
 	activeView := s.resolveActiveView(target)
 
 	w, h := s.effectiveDimensions(target, activeView)
+	s.frameW, s.frameH = int(w), int(h)
 	if err := s.ensureTexturesForView(activeView, w, h); err != nil {
 		return fmt.Errorf("ensure textures: %w", err)
 	}
@@ -1628,8 +1634,13 @@ func (s *GPURenderSession) buildTextResources(batches []TextBatch) (*textFrameRe
 			continue
 		}
 
-		// Write uniform data for this batch.
-		uniformData := makeTextUniform(batch.Color, batch.Transform, batch.PxRange, batch.AtlasSize)
+		// Compose ortho projection at flush time (ADR-025, Skia sk_RTAdjust).
+		ortho := gg.Matrix{
+			A: 2.0 / float64(s.frameW), B: 0, C: -1.0,
+			D: 0, E: -2.0 / float64(s.frameH), F: 1.0,
+		}
+		finalTransform := ortho.Multiply(batch.Transform)
+		uniformData := makeTextUniform(batch.Color, finalTransform, batch.PxRange, batch.AtlasSize)
 		if err := s.queue.WriteBuffer(s.textUniformBufs[i], 0, uniformData); err != nil {
 			return nil, fmt.Errorf("write text uniform[%d]: %w", i, err)
 		}
@@ -2117,7 +2128,7 @@ func (s *GPURenderSession) buildGlyphMaskResources(batches []GlyphMaskBatch) (*g
 	s.ensureGlyphMaskBatchPools(len(batches), glyphMaskLCDUniformSize)
 
 	// Build per-batch draw calls.
-	drawCalls, err := s.buildGlyphMaskDrawCalls(batches)
+	drawCalls, err := s.buildGlyphMaskDrawCalls(batches, s.frameW, s.frameH)
 	if err != nil {
 		return nil, err
 	}
@@ -2141,9 +2152,18 @@ func hasLCDBatches(batches []GlyphMaskBatch) bool {
 }
 
 // buildGlyphMaskDrawCalls creates per-batch draw calls with uniform data upload.
-func (s *GPURenderSession) buildGlyphMaskDrawCalls(batches []GlyphMaskBatch) ([]glyphMaskDrawCall, error) {
+func (s *GPURenderSession) buildGlyphMaskDrawCalls(batches []GlyphMaskBatch, viewportW, viewportH int) ([]glyphMaskDrawCall, error) {
 	drawCalls := make([]glyphMaskDrawCall, 0, len(batches))
 	quadOffset := 0
+
+	// Ortho projection from actual render target dimensions (ADR-025, Skia sk_RTAdjust).
+	// Applied at flush time, not draw time, so offscreen textures get correct projection.
+	vw := float64(viewportW)
+	vh := float64(viewportH)
+	ortho := gg.Matrix{
+		A: 2.0 / vw, B: 0, C: -1.0,
+		D: 0, E: -2.0 / vh, F: 1.0,
+	}
 
 	for i, batch := range batches {
 		nQuads := len(batch.Quads)
@@ -2151,12 +2171,15 @@ func (s *GPURenderSession) buildGlyphMaskDrawCalls(batches []GlyphMaskBatch) ([]
 			continue
 		}
 
+		// Compose ortho with device-space CTM at flush time.
+		finalTransform := ortho.Multiply(batch.Transform)
+
 		// Write uniform data for this batch.
 		var uniformData []byte
 		if batch.IsLCD {
-			uniformData = makeGlyphMaskLCDUniform(batch.Transform, batch.Color, batch.AtlasWidth, batch.AtlasHeight)
+			uniformData = makeGlyphMaskLCDUniform(finalTransform, batch.Color, batch.AtlasWidth, batch.AtlasHeight)
 		} else {
-			uniformData = makeGlyphMaskUniform(batch.Transform, batch.Color)
+			uniformData = makeGlyphMaskUniform(finalTransform, batch.Color)
 		}
 		if err := s.queue.WriteBuffer(s.glyphMaskUniformBufs[i], 0, uniformData); err != nil {
 			return nil, fmt.Errorf("write glyph mask uniform[%d]: %w", i, err)

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -2956,9 +2956,11 @@ func (s *GPURenderSession) encodeBlitOnlyPass(
 
 	// Draw GPU texture overlays (e.g., RepaintBoundary cached textures).
 	// These are textured quads using the same blit pipeline — no MSAA needed.
+	// Per-group scissor applied for compositor clipping (ScrollView viewport).
 	for i := range grpRes {
 		gr := &grpRes[i]
 		if gr.gpuTexRes != nil && len(gr.gpuTexRes.drawCalls) > 0 {
+			s.applyGroupScissor(rp, gr.scissorRect, w, h)
 			s.imagePipeline.RecordBlitDraws(rp, gr.gpuTexRes)
 		}
 	}


### PR DESCRIPTION
## Summary

- **Deferred ortho projection** (ADR-025, Skia `sk_RTAdjust`) — text tiers (4/6) now compute ortho at flush time from actual render target dimensions. Fixes squished text in offscreen RepaintBoundary textures.
- **Scissor groups in blit-only path** — GPU texture overlays now receive per-group scissor in non-MSAA compositor path.

## Verified
- ✅ scene_gpu_visual — text correct
- ✅ Build, tests, lint — green