### PR TITLE
v0.46.8: fix CJK IsCJK propagation through scene/shaper paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.46.8] - 2026-05-11
+
+### Fixed
+
+- **CJK improvements bypassed through scene/shaper paths** — `ShapedGlyph.IsCJK` field
+  (ADR-027) was never populated, silently disabling script-aware hinting, exact-size
+  rasterization, and Tier 6 routing for CJK text rendered through scene or UI compositor.
+  Fixed in 6 locations: builtin shaper, HarfBuzz shaper, LayoutText, scene encoding
+  (`TextFlagCJK` in `GlyphRunData.Flags`), scene GPU/CPU decoders. Zero breaking changes,
+  no UI modifications needed — fix is transparent through `scene.DrawText` API.
+
 ## [0.46.7] - 2026-05-11
 
 ### Added

--- a/internal/gpu/glyph_mask_engine.go
+++ b/internal/gpu/glyph_mask_engine.go
@@ -141,7 +141,7 @@ func (e *GlyphMaskEngine) LayoutText(
 
 	var shaped []text.ShapedGlyph
 	for glyph := range face.Glyphs(s) {
-		shaped = append(shaped, text.ShapedGlyph{GID: glyph.GID, X: glyph.X, Y: glyph.Y})
+		shaped = append(shaped, text.ShapedGlyph{GID: glyph.GID, X: glyph.X, Y: glyph.Y, IsCJK: text.IsCJKRune(glyph.Rune)})
 	}
 
 	return e.layoutGlyphs(shaped, x, y, fontSize, fontID, parsed, hinting, useLCD, lcdLayout, &lcdFilter, batchColor, matrix, deviceScale, isCJK), nil

--- a/scene/encoding.go
+++ b/scene/encoding.go
@@ -372,7 +372,7 @@ type TextFlags uint16
 
 const (
 	TextFlagHinting TextFlags = 1 << iota
-	TextFlagCJK                          // ADR-027: text contains CJK characters
+	TextFlagCJK               // ADR-027: text contains CJK characters
 )
 
 // GlyphRunData is the header for a TagText scene encoding element.

--- a/scene/encoding.go
+++ b/scene/encoding.go
@@ -372,6 +372,7 @@ type TextFlags uint16
 
 const (
 	TextFlagHinting TextFlags = 1 << iota
+	TextFlagCJK                          // ADR-027: text contains CJK characters
 )
 
 // GlyphRunData is the header for a TagText scene encoding element.

--- a/scene/gpu_renderer.go
+++ b/scene/gpu_renderer.go
@@ -235,9 +235,10 @@ func (r *GPUSceneRenderer) resolveText(scene *Scene, run GlyphRunData, glyphs []
 	dc.SetFont(face)
 
 	if len(glyphs) > 0 {
+		isCJK := run.Flags&TextFlagCJK != 0
 		shaped := make([]text.ShapedGlyph, len(glyphs))
 		for i, g := range glyphs {
-			shaped[i] = text.ShapedGlyph{GID: g.GlyphID, X: float64(g.X), Y: float64(g.Y)}
+			shaped[i] = text.ShapedGlyph{GID: g.GlyphID, X: float64(g.X), Y: float64(g.Y), IsCJK: isCJK}
 		}
 		dc.DrawShapedGlyphs(shaped, face, float64(run.OriginX), float64(run.OriginY))
 	} else if str != "" {

--- a/scene/renderer.go
+++ b/scene/renderer.go
@@ -903,12 +903,14 @@ func (r *Renderer) renderTextOnTile(
 	face := source.Face(float64(run.FontSize))
 
 	// Convert stored GlyphEntry → ShapedGlyph (no re-shaping).
+	isCJK := run.Flags&TextFlagCJK != 0
 	shaped := make([]text.ShapedGlyph, len(glyphs))
 	for i, g := range glyphs {
 		shaped[i] = text.ShapedGlyph{
-			GID: g.GlyphID,
-			X:   float64(g.X),
-			Y:   float64(g.Y),
+			GID:   g.GlyphID,
+			X:     float64(g.X),
+			Y:     float64(g.Y),
+			IsCJK: isCJK,
 		}
 	}
 

--- a/scene/text.go
+++ b/scene/text.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/gogpu/gg/text"
 )
@@ -516,12 +517,18 @@ func (s *Scene) encodeTextRun(str string, glyphs []text.ShapedGlyph, face text.F
 		return &text.FontError{Reason: "text string exceeds 65535 bytes (TagText TextLen is uint16)"}
 	}
 
+	// Detect CJK from first rune (ADR-027).
+	flags := TextFlagHinting
+	if r, _ := utf8.DecodeRuneInString(str); r != utf8.RuneError && text.IsCJKRune(r) {
+		flags |= TextFlagCJK
+	}
+
 	//nolint:gosec // slice lengths bounded by uint16 check above
 	run := GlyphRunData{
 		FontSourceID: fontID,
 		FontSize:     float32(face.Size()),
 		GlyphCount:   uint16(len(glyphs)),
-		Flags:        TextFlagHinting,
+		Flags:        flags,
 		OriginX:      x,
 		OriginY:      y,
 		BrushIndex:   uint32(brushIdx),

--- a/text/shaper_builtin.go
+++ b/text/shaper_builtin.go
@@ -69,6 +69,7 @@ func (s *BuiltinShaper) Shape(text string, face Face) []ShapedGlyph {
 			Y:        0,
 			XAdvance: advance,
 			YAdvance: 0,
+			IsCJK:    IsCJKRune(r),
 		})
 
 		x += advance

--- a/text/shaper_gotext.go
+++ b/text/shaper_gotext.go
@@ -114,7 +114,7 @@ func (s *GoTextShaper) Shape(text string, face Face) []ShapedGlyph {
 	s.shaperPool.Put(hbShaper)
 
 	// Convert go-text glyphs to our ShapedGlyph format.
-	result := convertGlyphs(output.Glyphs, dir)
+	result := convertGlyphs(output.Glyphs, dir, text)
 
 	// Post-process: fix tab characters that HarfBuzz mapped to notdef (GID=0).
 	// Replace with space GID and proper tab-stop advance.
@@ -212,26 +212,32 @@ func fixedToFloat(v fixed.Int26_6) float64 {
 }
 
 // convertGlyphs converts go-text/typesetting output glyphs to our ShapedGlyph slice.
-func convertGlyphs(glyphs []shaping.Glyph, dir di.Direction) []ShapedGlyph {
+func convertGlyphs(glyphs []shaping.Glyph, dir di.Direction, sourceText string) []ShapedGlyph {
 	if len(glyphs) == 0 {
 		return nil
 	}
 
 	result := make([]ShapedGlyph, len(glyphs))
+	runes := []rune(sourceText)
 
 	var x, y float64
 
 	for i, g := range glyphs {
-		// XOffset and YOffset represent fine-grained positioning adjustments
-		// applied on top of the current pen position.
 		xOff := fixedToFloat(g.XOffset)
 		yOff := fixedToFloat(g.YOffset)
 
+		cluster := g.TextIndex()
+		var cjk bool
+		if cluster >= 0 && cluster < len(runes) {
+			cjk = IsCJKRune(runes[cluster])
+		}
+
 		result[i] = ShapedGlyph{
 			GID:     GlyphID(uint16(g.GlyphID)), //nolint:gosec // GlyphID is uint16 by design; overflow is handled by font subsetting
-			Cluster: g.TextIndex(),
+			Cluster: cluster,
 			X:       x + xOff,
 			Y:       y + yOff,
+			IsCJK:   cjk,
 		}
 
 		// Advance the pen position.

--- a/text/shaper_gotext_test.go
+++ b/text/shaper_gotext_test.go
@@ -560,7 +560,7 @@ func TestGoTextShaper_FixedPointConversion(t *testing.T) {
 
 // TestGoTextShaper_ConvertGlyphsEmpty tests convertGlyphs with empty input.
 func TestGoTextShaper_ConvertGlyphsEmpty(t *testing.T) {
-	result := convertGlyphs(nil, 0)
+	result := convertGlyphs(nil, 0, "")
 	if result != nil {
 		t.Errorf("convertGlyphs(nil) = %v, want nil", result)
 	}


### PR DESCRIPTION
IsCJK field was added but never populated — CJK improvements silently bypassed through scene and UI paths. Fixed in 6 locations. Zero breaking changes, no UI changes needed.