### PR TITLE
chore(examples): gogpu v0.34.6 (#316)

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 )
 
 require (

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.46.11 h1:VcNQTYLLNMKhLtCS0URxEzezUar9S8i35wkPt9ThreY=
 github.com/gogpu/gg v0.46.11/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 	github.com/gogpu/gpucontext v0.18.0
 )
 

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.46.11 h1:VcNQTYLLNMKhLtCS0URxEzezUar9S8i35wkPt9ThreY=
 github.com/gogpu/gg v0.46.11/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 )
 
 require (

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.46.11 h1:VcNQTYLLNMKhLtCS0URxEzezUar9S8i35wkPt9ThreY=
 github.com/gogpu/gg v0.46.11/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 	github.com/gogpu/gpucontext v0.18.0
 )
 

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.46.11 h1:VcNQTYLLNMKhLtCS0URxEzezUar9S8i35wkPt9ThreY=
 github.com/gogpu/gg v0.46.11/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 	github.com/gogpu/gpucontext v0.18.0
 )
 

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.46.11 h1:VcNQTYLLNMKhLtCS0URxEzezUar9S8i35wkPt9ThreY=
 github.com/gogpu/gg v0.46.11/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 )
 
 require (

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.46.11 h1:VcNQTYLLNMKhLtCS0URxEzezUar9S8i35wkPt9ThreY=
 github.com/gogpu/gg v0.46.11/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/multi_damage_demo/go.mod
+++ b/examples/multi_damage_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/gogpu/gg => ../..
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 	github.com/gogpu/gpucontext v0.18.0
 )
 

--- a/examples/multi_damage_demo/go.sum
+++ b/examples/multi_damage_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.1 h1:RSPR+YKT0tmbp5Uon+xwhN1veC9cehmqMptMkQuopok
 github.com/go-webgpu/goffi v0.5.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 )
 
 require (

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.46.11 h1:VcNQTYLLNMKhLtCS0URxEzezUar9S8i35wkPt9ThreY=
 github.com/gogpu/gg v0.46.11/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 )
 
 require (

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.46.11 h1:VcNQTYLLNMKhLtCS0URxEzezUar9S8i35wkPt9ThreY=
 github.com/gogpu/gg v0.46.11/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.46.11
-	github.com/gogpu/gogpu v0.34.5
+	github.com/gogpu/gogpu v0.34.6
 )
 
 require (

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXE
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/gogpu/gg v0.46.11 h1:VcNQTYLLNMKhLtCS0URxEzezUar9S8i35wkPt9ThreY=
 github.com/gogpu/gg v0.46.11/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.34.5 h1:fu4/cGhk+0qSHGDuPa5qNKeZG+8ar93lW3W0pv02xKA=
-github.com/gogpu/gogpu v0.34.5/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
+github.com/gogpu/gogpu v0.34.6 h1:mKuD8x1OqxjlQl1S8scPodHMpGqBAlnWbLRDTB7b+Bc=
+github.com/gogpu/gogpu v0.34.6/go.mod h1:knsNvdH0AiC/aqQVxOjVOwSH5ZzQqXMs4az3tTand80=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=


### PR DESCRIPTION
Update examples to gogpu v0.34.6 (deferred SetHitTestCallback — frameless drag fix).