### PR TITLE
feat: pixel-perfect mode (SetAntiAlias) — ADR-030, #319

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.47.0] - 2026-05-16
+
+### Added
+
+- **Pixel-Perfect Mode (Anti-Aliasing Toggle)** — `dc.SetAntiAlias(false)` disables
+  anti-aliasing for geometry rendering, producing crisp aliased edges with binary
+  coverage (fully inside or fully outside). Use cases: pixel art, retro-style graphics,
+  L-System fractals, technical drawings, sharp grid lines. (#319, @rcarlier)
+
+  - **API:** `Context.SetAntiAlias(enabled bool)` / `Context.AntiAlias() bool`.
+    Context-level state, participates in Push/Pop. Text AA remains independent (TextMode).
+  - **CPU:** Dedicated `NoAAFiller` — integer scanline walker with `FixedRoundToInt`
+    edge rounding. Completely separate code path (Skia `SkScan::FillPath` / tiny-skia
+    `scan::path` pattern), ~2-3× faster than analytic AA.
+  - **GPU SDF:** Binary step coverage via `anti_alias` uniform flag. Shapes render
+    with hard pixel edges on all backends (Vulkan, DX12, Metal, GLES, Software).
+  - **Recording:** `Recorder.SetAntiAlias()` mirrors the Context API for vector export.
+  - **Architecture:** ADR-030, based on research of 5 enterprise engines (Skia, Cairo,
+    tiny-skia, Vello, femtovg). All use separate non-AA code paths, not threshold on
+    AA output.
+
+  ```go
+  dc.SetAntiAlias(false)  // all subsequent draws — pixel-perfect
+  dc.DrawRectangle(10, 10, 100, 50)
+  dc.Fill()               // binary fill, no gray edge pixels
+  dc.SetAntiAlias(true)   // back to smooth AA
+  ```
+
 ## [0.46.11] - 2026-05-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -121,6 +121,22 @@ dc.Fill()
 dc.SetRasterizerMode(gg.RasterizerSparseStrips)
 ```
 
+### Pixel-Perfect Mode (No Anti-Aliasing)
+
+Disable anti-aliasing for crisp, aliased edges — useful for pixel art, retro graphics,
+technical drawings, and sharp grid lines:
+
+```go
+dc.SetAntiAlias(false)          // binary coverage: inside=opaque, outside=transparent
+dc.DrawRectangle(10, 10, 100, 50)
+dc.Fill()                        // no gray edge pixels
+dc.SetAntiAlias(true)           // back to smooth AA
+```
+
+Uses a dedicated integer scanline rasterizer (Skia/tiny-skia pattern) — ~2-3× faster
+than analytic AA. Works on both CPU and GPU (all backends). Text AA is independent
+(controlled via `SetTextMode`).
+
 ### GPU Acceleration (Optional)
 
 gg supports optional GPU acceleration through the `GPUAccelerator` interface with

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 | Category | Capabilities |
 |----------|--------------|
-| **Rendering** | Immediate and retained mode, seven-tier GPU acceleration (SDF, Convex, Stencil+Cover, Textured Quad, MSDF Text, Compute, Glyph Mask), per-context GPU isolation (Skia GrContext pattern), scene GPU auto-select, Skia AAA pixel-perfect rasterizer, CPU fallback |
+| **Rendering** | Immediate and retained mode, seven-tier GPU acceleration (SDF, Convex, Stencil+Cover, Textured Quad, MSDF Text, Compute, Glyph Mask), per-context GPU isolation (Skia GrContext pattern), scene GPU auto-select, Skia AAA pixel-perfect rasterizer, **pixel-perfect mode** (`SetAntiAlias(false)` — dedicated NoAAFiller, Skia/Cairo/tiny-skia pattern), CPU fallback |
 | **Shapes** | Rectangles, circles, ellipses, arcs, bezier curves, polygons, stars |
 | **Text** | TrueType fonts, MSDF + glyph mask dual-strategy rendering, TextMode auto-selection, DPI-aware HiDPI text, **ClearType LCD auto-detection** (Windows SPI + registry, macOS grayscale, Linux Xft/Wayland), **CJK script-aware rendering** (ADR-027: per-script hinting, exact-size rasterization, dual MSDF atlas 64/128px), font hinting (auto-hinter + CJK vertical-only), transform-aware CPU text (scale/rotate/shear), glyph outline caching, emoji support, bidirectional text, HarfBuzz shaping, scene text via TagText glyph references (shape-once, Skia drawTextBlob pattern), atlas zoom resilience (size buckets + frame-based compaction) |
 | **Compositing** | 29 blend modes (Porter-Duff, Advanced, HSL), layer isolation, alpha masks, zero-readback compositor (non-MSAA blit fast path, damage-aware multi-rect sub-region updates, per-draw dynamic scissor ADR-028) |

--- a/antialias_test.go
+++ b/antialias_test.go
@@ -1,0 +1,134 @@
+package gg
+
+import (
+	"testing"
+)
+
+// noaaPixelAlpha returns alpha channel of a pixel as uint8 (0-255).
+func noaaPixelAlpha(pm *Pixmap, x, y int) uint8 {
+	c := pm.GetPixel(x, y)
+	a := int(c.A * 255)
+	if a > 255 {
+		a = 255
+	}
+	if a < 0 {
+		a = 0
+	}
+	return uint8(a) //nolint:gosec // clamped above
+}
+
+func TestSetAntiAlias_BinaryPixelsOnly(t *testing.T) {
+	dc := NewContext(64, 64)
+	defer dc.Close()
+
+	dc.SetAntiAlias(false)
+	dc.SetRGB(1, 0, 0)
+
+	// Draw a diagonal line (would produce gray fringe with AA)
+	dc.SetLineWidth(2)
+	dc.DrawLine(5, 5, 58, 58)
+	dc.Stroke()
+
+	// Draw a circle (would produce smooth edges with AA)
+	dc.DrawCircle(32, 32, 20)
+	dc.Fill()
+
+	pm := dc.pixmap
+	w, h := pm.Width(), pm.Height()
+
+	for y := range h {
+		for x := range w {
+			a := noaaPixelAlpha(pm, x, y)
+			if a != 0 && a != 255 {
+				t.Fatalf("pixel (%d,%d) has gray alpha=%d; want 0 or 255 (no-AA mode)", x, y, a)
+			}
+		}
+	}
+}
+
+func TestSetAntiAlias_AAHasGrayPixels(t *testing.T) {
+	dc := NewContext(64, 64)
+	defer dc.Close()
+
+	// AA enabled (default) — diagonal line MUST produce gray pixels
+	dc.SetRGB(1, 0, 0)
+	dc.SetLineWidth(2)
+	dc.DrawLine(5, 5, 58, 58)
+	dc.Stroke()
+
+	pm := dc.pixmap
+	w, h := pm.Width(), pm.Height()
+
+	hasGray := false
+	for y := range h {
+		for x := range w {
+			a := noaaPixelAlpha(pm, x, y)
+			if a != 0 && a != 255 {
+				hasGray = true
+				break
+			}
+		}
+		if hasGray {
+			break
+		}
+	}
+
+	if !hasGray {
+		t.Fatal("AA mode should produce gray edge pixels for diagonal line")
+	}
+}
+
+func TestSetAntiAlias_PushPop(t *testing.T) {
+	dc := NewContext(32, 32)
+	defer dc.Close()
+
+	if !dc.AntiAlias() {
+		t.Fatal("default should be true")
+	}
+
+	dc.SetAntiAlias(false)
+	dc.Push()
+	dc.SetAntiAlias(true)
+
+	if !dc.AntiAlias() {
+		t.Fatal("after Push+SetAntiAlias(true) should be true")
+	}
+
+	dc.Pop()
+
+	if dc.AntiAlias() {
+		t.Fatal("after Pop should restore false")
+	}
+}
+
+func TestSetAntiAlias_RectNoCoverage(t *testing.T) {
+	dc := NewContext(32, 32)
+	defer dc.Close()
+
+	dc.SetAntiAlias(false)
+	dc.SetRGB(0, 0, 1)
+
+	// Axis-aligned rect at integer coords — all interior pixels fully opaque
+	dc.DrawRectangle(4, 4, 16, 16)
+	dc.Fill()
+
+	pm := dc.pixmap
+
+	// Check interior is fully opaque
+	for y := 4; y < 20; y++ {
+		for x := 4; x < 20; x++ {
+			a := noaaPixelAlpha(pm, x, y)
+			if a != 255 {
+				t.Fatalf("interior pixel (%d,%d) alpha=%d; want 255", x, y, a)
+			}
+		}
+	}
+
+	// Check exterior is fully transparent
+	for x := range 32 {
+		a := noaaPixelAlpha(pm, x, 0)
+		if a != 0 {
+			t.Fatalf("exterior pixel (%d,0) alpha=%d; want 0", x, a)
+		}
+	}
+}

--- a/context.go
+++ b/context.go
@@ -64,6 +64,10 @@ type Context struct {
 	// Rasterizer mode
 	rasterizerMode RasterizerMode // CPU rasterizer selection mode
 
+	// Anti-aliasing
+	antiAlias      bool   // anti-aliasing enabled (default: true)
+	antiAliasStack []bool // Push/Pop stack for antiAlias state
+
 	// Text rendering
 	textMode         TextMode               // text strategy selection (default: Auto)
 	outlineExtractor *text.OutlineExtractor // lazy: for transform-aware text (Strategy B)
@@ -171,6 +175,7 @@ func NewContext(width, height int, opts ...ContextOption) *Context {
 		clipStackDepth:        make([]int, 0, 8),
 		pipelineMode:          options.pipelineMode,
 		damageTrackingEnabled: true,
+		antiAlias:             true,
 	}
 }
 
@@ -307,6 +312,29 @@ func (c *Context) SetRasterizerMode(mode RasterizerMode) {
 // RasterizerMode returns the current rasterizer mode.
 func (c *Context) RasterizerMode() RasterizerMode {
 	return c.rasterizerMode
+}
+
+// SetAntiAlias enables or disables anti-aliasing for geometry rendering.
+//
+// When enabled (default), shapes are rendered with smooth edges using analytic
+// anti-aliasing (Skia AAA). When disabled, shapes are rendered with binary
+// coverage (fully inside or fully outside) producing crisp, aliased edges.
+//
+// This is useful for pixel art, retro-style graphics, technical drawings,
+// and any use case where sub-pixel blending is undesirable.
+//
+// Text anti-aliasing is controlled independently via SetTextMode.
+// The anti-aliasing state participates in Push/Pop.
+//
+// Reference: Skia SkPaint::setAntiAlias, Cairo cairo_set_antialias,
+// tiny-skia Paint.anti_alias.
+func (c *Context) SetAntiAlias(enabled bool) {
+	c.antiAlias = enabled
+}
+
+// AntiAlias returns whether anti-aliasing is enabled for geometry rendering.
+func (c *Context) AntiAlias() bool {
+	return c.antiAlias
 }
 
 // SetTextMode sets the text rendering strategy.
@@ -868,6 +896,9 @@ func (c *Context) Push() {
 		maskCopy = c.mask.Clone()
 	}
 	c.maskStack = append(c.maskStack, maskCopy)
+
+	// Save current anti-aliasing state
+	c.antiAliasStack = append(c.antiAliasStack, c.antiAlias)
 }
 
 // Pop restores the last saved state.
@@ -901,6 +932,12 @@ func (c *Context) Pop() {
 	if len(c.maskStack) > 0 {
 		c.mask = c.maskStack[len(c.maskStack)-1]
 		c.maskStack = c.maskStack[:len(c.maskStack)-1]
+	}
+
+	// Restore anti-aliasing state
+	if len(c.antiAliasStack) > 0 {
+		c.antiAlias = c.antiAliasStack[len(c.antiAliasStack)-1]
+		c.antiAliasStack = c.antiAliasStack[:len(c.antiAliasStack)-1]
 	}
 }
 
@@ -1416,6 +1453,7 @@ type gpuContextOps interface {
 	ClearClipPath()
 	BeginFrame()
 	SetPipelineMode(mode PipelineMode)
+	SetAntiAlias(enabled bool)
 	PendingCount() int
 	Close()
 }
@@ -1645,6 +1683,11 @@ func (c *Context) doFill() error {
 	// At scale=1.0 this is a zero-copy no-op.
 	devicePath := c.deviceSpacePath()
 
+	// Propagate anti-aliasing state to GPU render context.
+	if rc := c.gpuCtxOps(); rc != nil {
+		rc.SetAntiAlias(c.antiAlias)
+	}
+
 	// Temporarily swap c.path to device-space for GPU tryGPUOp
 	// (which reads c.path for shape detection and path rendering).
 	origPath := c.path
@@ -1655,11 +1698,15 @@ func (c *Context) doFill() error {
 		return nil
 	}
 
-	// CPU path: flush pending GPU, apply mode to software renderer.
+	// CPU path: flush pending GPU, apply mode and AA state to software renderer.
 	c.flushGPUAccelerator()
 	if sr, ok := c.renderer.(*SoftwareRenderer); ok {
 		sr.rasterizerMode = cpuMode
-		defer func() { sr.rasterizerMode = RasterizerAuto }()
+		sr.antiAlias = c.antiAlias
+		defer func() {
+			sr.rasterizerMode = RasterizerAuto
+			sr.antiAlias = true
+		}()
 	}
 
 	return c.renderer.Fill(c.pixmap, devicePath, c.paint)
@@ -1684,6 +1731,11 @@ func (c *Context) doStroke() error {
 	// Transform path to device-space for rendering.
 	devicePath := c.deviceSpacePath()
 
+	// Propagate anti-aliasing state to GPU render context.
+	if rc := c.gpuCtxOps(); rc != nil {
+		rc.SetAntiAlias(c.antiAlias)
+	}
+
 	// Temporarily swap c.path to device-space for GPU tryGPUOp.
 	origPath := c.path
 	c.path = devicePath
@@ -1696,7 +1748,11 @@ func (c *Context) doStroke() error {
 	c.flushGPUAccelerator()
 	if sr, ok := c.renderer.(*SoftwareRenderer); ok {
 		sr.rasterizerMode = cpuMode
-		defer func() { sr.rasterizerMode = RasterizerAuto }()
+		sr.antiAlias = c.antiAlias
+		defer func() {
+			sr.rasterizerMode = RasterizerAuto
+			sr.antiAlias = true
+		}()
 	}
 
 	return c.renderer.Stroke(c.pixmap, devicePath, c.paint)

--- a/examples/pixel_perfect/main.go
+++ b/examples/pixel_perfect/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"log"
+
+	"github.com/gogpu/gg"
+)
+
+func main() {
+	dc := gg.NewContext(512, 256)
+	dc.ClearWithColor(gg.White)
+
+	// Left half: Anti-Aliased (default)
+	drawShapes(dc, 0)
+
+	// Right half: Pixel-Perfect (no AA)
+	dc.SetAntiAlias(false)
+	drawShapes(dc, 256)
+
+	// Labels
+	dc.SetAntiAlias(true)
+	dc.SetRGB(0, 0, 0)
+	dc.DrawStringAnchored("Anti-Aliased", 128, 240, 0.5, 0.5)
+	dc.DrawStringAnchored("Pixel-Perfect", 384, 240, 0.5, 0.5)
+
+	if err := dc.SavePNG("pixel_perfect.png"); err != nil {
+		log.Fatalf("Failed to save PNG: %v", err)
+	}
+
+	log.Println("Created pixel_perfect.png — compare left (AA) vs right (no-AA)")
+}
+
+func drawShapes(dc *gg.Context, offsetX float64) {
+	// Diagonal line
+	dc.SetRGB(1, 0, 0)
+	dc.SetLineWidth(1)
+	dc.DrawLine(offsetX+20, 20, offsetX+100, 80)
+	dc.Stroke()
+
+	// Circle
+	dc.SetRGB(0, 0, 1)
+	dc.DrawCircle(offsetX+180, 60, 30)
+	dc.Fill()
+
+	// Rectangle (axis-aligned)
+	dc.SetRGB(0, 0.6, 0)
+	dc.DrawRectangle(offsetX+30, 110, 80, 50)
+	dc.Fill()
+
+	// Stroked circle
+	dc.SetRGB(0.5, 0, 0.5)
+	dc.SetLineWidth(2)
+	dc.DrawCircle(offsetX+180, 150, 25)
+	dc.Stroke()
+
+	// Grid lines (1px)
+	dc.SetRGB(0.3, 0.3, 0.3)
+	dc.SetLineWidth(1)
+	for i := 0; i < 5; i++ {
+		y := float64(185 + i*10)
+		dc.DrawLine(offsetX+30, y, offsetX+230, y)
+		dc.Stroke()
+	}
+}

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -463,6 +463,7 @@ func (rc *GPURenderContext) FillPath(target gg.GPURenderTarget, path *gg.Path, p
 		va := rc.shared.velloAccel
 		rc.shared.mu.Unlock()
 		if va != nil && va.CanCompute() {
+			va.SetAntiAlias(rc.antiAlias)
 			return va.FillPath(target, path, paint)
 		}
 	}
@@ -524,6 +525,7 @@ func (rc *GPURenderContext) StrokePath(target gg.GPURenderTarget, path *gg.Path,
 		va := rc.shared.velloAccel
 		rc.shared.mu.Unlock()
 		if va != nil && va.CanCompute() {
+			va.SetAntiAlias(rc.antiAlias)
 			return va.StrokePath(target, path, paint)
 		}
 	}
@@ -573,6 +575,7 @@ func (rc *GPURenderContext) FillShape(target gg.GPURenderTarget, shape gg.Detect
 		va := rc.shared.velloAccel
 		rc.shared.mu.Unlock()
 		if va != nil && va.CanCompute() {
+			va.SetAntiAlias(rc.antiAlias)
 			return va.FillShape(target, shape, paint)
 		}
 	}
@@ -593,6 +596,7 @@ func (rc *GPURenderContext) StrokeShape(target gg.GPURenderTarget, shape gg.Dete
 		va := rc.shared.velloAccel
 		rc.shared.mu.Unlock()
 		if va != nil && va.CanCompute() {
+			va.SetAntiAlias(rc.antiAlias)
 			return va.StrokeShape(target, shape, paint)
 		}
 	}

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -58,6 +58,9 @@ type GPURenderContext struct {
 	sceneStats   gg.SceneStats
 	pipelineMode gg.PipelineMode
 
+	// Anti-aliasing state for GPU rendering (propagated from Context).
+	antiAlias bool
+
 	// Shared command encoder for single-command-buffer frames (ADR-017).
 	// When set, Flush records render passes into this encoder instead of
 	// creating its own + submitting. The caller owns Finish + Submit.
@@ -78,6 +81,12 @@ func (rc *GPURenderContext) PendingCount() int {
 // SetPipelineMode sets the pipeline mode for this context's operations.
 func (rc *GPURenderContext) SetPipelineMode(mode gg.PipelineMode) {
 	rc.pipelineMode = mode
+}
+
+// SetAntiAlias sets the anti-aliasing state for GPU rendering.
+// When false, SDF shapes use binary step coverage instead of smoothstep.
+func (rc *GPURenderContext) SetAntiAlias(enabled bool) {
+	rc.antiAlias = enabled
 }
 
 // SetClipRect records a scissor rect change for this context.
@@ -625,6 +634,9 @@ func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cy
 		rc.session.SetConvexRenderer(convexRend)
 		rc.session.SetStencilRenderer(stencilRend)
 	}
+
+	// Propagate per-frame anti-aliasing state to session.
+	rc.session.antiAlias = rc.antiAlias
 
 	// Transfer per-context frame tracking to session before rendering.
 	rc.session.SetFrameState(rc.frameRendered, rc.lastView)

--- a/internal/gpu/gpu_shared.go
+++ b/internal/gpu/gpu_shared.go
@@ -77,7 +77,8 @@ func (s *GPUShared) NewRenderContext() *GPURenderContext {
 	// This avoids creating a standalone Vulkan instance before gogpu has a
 	// chance to provide its DeviceProvider (which may be software/CPU).
 	return &GPURenderContext{
-		shared: s,
+		shared:    s,
+		antiAlias: true,
 	}
 }
 

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -222,6 +222,11 @@ type GPURenderSession struct {
 	// Porter-Duff "over" during readback, so LoadOpClear is always safe.
 	frameRendered bool
 
+	// antiAlias determines SDF coverage computation mode.
+	// When true (default), smoothstep produces smooth edges.
+	// When false, binary step produces aliased edges.
+	antiAlias bool
+
 	// lastView tracks the most recent per-pass view used for rendering.
 	// When the view changes between Flush calls (e.g., two gg.Context
 	// instances rendering to different targets), frameRendered is reset
@@ -249,8 +254,9 @@ type GPURenderSession struct {
 // queue. Textures and pipelines are not allocated until RenderFrame is called.
 func NewGPURenderSession(device *wgpu.Device, queue *wgpu.Queue) *GPURenderSession {
 	return &GPURenderSession{
-		device: device,
-		queue:  queue,
+		device:    device,
+		queue:     queue,
+		antiAlias: true,
 	}
 }
 
@@ -1367,7 +1373,7 @@ func (s *GPURenderSession) buildSDFResources(shapes []SDFRenderShape, w, h uint3
 		return nil, fmt.Errorf("write vertex buffer: %w", err)
 	}
 
-	uniformData := makeSDFRenderUniform(w, h)
+	uniformData := makeSDFRenderUniform(w, h, s.antiAlias)
 	if s.sdfUniformBuf == nil {
 		buf, err := s.device.CreateBuffer(&wgpu.BufferDescriptor{
 			Label: "session_sdf_uniform",
@@ -1448,7 +1454,7 @@ func (s *GPURenderSession) buildConvexResources(commands []ConvexDrawCommand, w,
 		return nil, fmt.Errorf("write convex vertex buffer: %w", err)
 	}
 
-	uniformData := makeSDFRenderUniform(w, h) // Same 16-byte viewport layout.
+	uniformData := makeSDFRenderUniform(w, h, true) // Same 16-byte viewport layout; convex AA is per-vertex.
 	if s.convexUniformBuf == nil {
 		buf, err := s.device.CreateBuffer(&wgpu.BufferDescriptor{
 			Label: "session_convex_uniform",

--- a/internal/gpu/sdf_render.go
+++ b/internal/gpu/sdf_render.go
@@ -151,7 +151,7 @@ func (p *SDFRenderPipeline) RenderShapes(target gg.GPURenderTarget, shapes []SDF
 	}
 	defer vertBuf.Release()
 
-	uniformData := makeSDFRenderUniform(w, h)
+	uniformData := makeSDFRenderUniform(w, h, true)
 	uniformBuf, err := p.createAndUploadBuffer("sdf_render_uniform", uniformData,
 		gputypes.BufferUsageUniform|gputypes.BufferUsageCopyDst)
 	if err != nil {
@@ -789,12 +789,17 @@ func writeSDFRenderVertex(buf []byte, px, py, lx, ly float32, s *SDFRenderShape)
 }
 
 // makeSDFRenderUniform creates the 16-byte uniform buffer.
-// Layout: viewport (vec2<f32>) + padding (vec2<f32>).
-func makeSDFRenderUniform(w, h uint32) []byte {
+// Layout: viewport (vec2<f32>) + anti_alias (u32) + padding (u32).
+func makeSDFRenderUniform(w, h uint32, antiAlias bool) []byte {
 	buf := make([]byte, sdfRenderUniformSize)
 	binary.LittleEndian.PutUint32(buf[0:4], math.Float32bits(float32(w)))
 	binary.LittleEndian.PutUint32(buf[4:8], math.Float32bits(float32(h)))
-	// Padding bytes 8..15 remain zero.
-	slogger().Debug("SDF uniform viewport", "width", w, "height", h)
+	aa := uint32(1)
+	if !antiAlias {
+		aa = 0
+	}
+	binary.LittleEndian.PutUint32(buf[8:12], aa)
+	// Padding byte 12..15 remains zero.
+	slogger().Debug("SDF uniform viewport", "width", w, "height", h, "anti_alias", antiAlias)
 	return buf
 }

--- a/internal/gpu/sdf_render_test.go
+++ b/internal/gpu/sdf_render_test.go
@@ -439,7 +439,7 @@ func TestBuildSDFRenderVerticesEmpty(t *testing.T) {
 }
 
 func TestMakeSDFRenderUniform(t *testing.T) {
-	data := makeSDFRenderUniform(800, 600)
+	data := makeSDFRenderUniform(800, 600, true)
 	if len(data) != sdfRenderUniformSize {
 		t.Fatalf("expected %d bytes, got %d", sdfRenderUniformSize, len(data))
 	}
@@ -453,11 +453,23 @@ func TestMakeSDFRenderUniform(t *testing.T) {
 		t.Errorf("viewport height = %f, expected 600.0", h)
 	}
 
+	// anti_alias should be 1 (true).
+	aa := binary.LittleEndian.Uint32(data[8:12])
+	if aa != 1 {
+		t.Errorf("expected anti_alias=1, got %d", aa)
+	}
+
 	// Padding should be zero.
-	pad1 := binary.LittleEndian.Uint32(data[8:12])
-	pad2 := binary.LittleEndian.Uint32(data[12:16])
-	if pad1 != 0 || pad2 != 0 {
-		t.Errorf("expected zero padding, got %d, %d", pad1, pad2)
+	pad := binary.LittleEndian.Uint32(data[12:16])
+	if pad != 0 {
+		t.Errorf("expected zero padding, got %d", pad)
+	}
+
+	// Test with AA disabled.
+	data2 := makeSDFRenderUniform(100, 200, false)
+	aa2 := binary.LittleEndian.Uint32(data2[8:12])
+	if aa2 != 0 {
+		t.Errorf("expected anti_alias=0, got %d", aa2)
 	}
 }
 

--- a/internal/gpu/shaders/sdf_render.wgsl
+++ b/internal/gpu/shaders/sdf_render.wgsl
@@ -15,7 +15,8 @@
 
 struct Uniforms {
     viewport: vec2<f32>,   // width, height in pixels
-    _pad: vec2<f32>,
+    anti_alias: u32,       // 1 = anti-aliased (smoothstep), 0 = aliased (binary step)
+    _pad: u32,
 }
 
 struct VertexInput {
@@ -149,13 +150,27 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let abs_d = sqrt(d * d);
     let effective_dist = d + in.is_stroked * (abs_d - in.half_stroke - d);
 
-    // --- Coverage via smoothstep (arithmetic implementation) ---
+    // --- Coverage computation ---
+    // AA path: smoothstep (arithmetic implementation, 1px transition zone).
     let t_raw = effective_dist + 0.5;
     // clamp(t_raw, 0, 1) via arithmetic
     let t_pos = (t_raw + sqrt(t_raw * t_raw)) * 0.5;
     let t_diff = t_pos - 1.0;
     let t = (t_pos + 1.0 - sqrt(t_diff * t_diff)) * 0.5;
-    let coverage = 1.0 - t * t * (3.0 - 2.0 * t);
+    let aa_coverage = 1.0 - t * t * (3.0 - 2.0 * t);
+
+    // No-AA path: binary step (inside=1.0, outside=0.0).
+    // Uses steep ramp via naga-safe arithmetic (same max/min pattern).
+    // Factor 65536 makes the transition zone < 0.001px — effectively binary.
+    let steep = -effective_dist * 65536.0;
+    let sp = (steep + sqrt(steep * steep)) * 0.5;
+    let sd = sp - 1.0;
+    let noaa_coverage = (sp + 1.0 - sqrt(sd * sd)) * 0.5;
+
+    // Blend between AA and no-AA based on uniform flag.
+    // anti_alias=1 → aa_coverage, anti_alias=0 → noaa_coverage.
+    let aa_f = f32(u.anti_alias);
+    let coverage = aa_f * aa_coverage + (1.0 - aa_f) * noaa_coverage;
 
     // Apply RRect clip coverage.
     let clip_cov = rrect_clip_coverage(in.clip_position.xy);

--- a/internal/gpu/vello_accelerator.go
+++ b/internal/gpu/vello_accelerator.go
@@ -50,6 +50,11 @@ type VelloAccelerator struct {
 	pendingPaths  []tilecompute.PathDef
 	pendingTarget *gg.GPURenderTarget // target for the pending scene (nil if empty)
 
+	// antiAlias controls whether paths are rendered with anti-aliasing.
+	// When false, path coordinates are snapped to pixel grid before encoding
+	// (Skia Graphite snap_rect_to_pixels pattern) for crisp binary-coverage output.
+	antiAlias bool
+
 	gpuReady       bool
 	externalDevice bool // true when using shared device (don't destroy on Close)
 }
@@ -107,6 +112,14 @@ func (a *VelloAccelerator) Close() {
 // Called by gg.SetLogger to propagate logging configuration.
 func (a *VelloAccelerator) SetLogger(l *slog.Logger) {
 	setLogger(l)
+}
+
+// SetAntiAlias sets the anti-aliasing state for subsequent FillPath/StrokePath calls.
+// When disabled, path coordinates are snapped to the pixel grid before encoding,
+// producing crisp binary-coverage output for axis-aligned geometry.
+// Reference: Skia Graphite snap_rect_to_pixels pattern.
+func (a *VelloAccelerator) SetAntiAlias(enabled bool) {
+	a.antiAlias = enabled
 }
 
 // CanAccelerate reports whether this accelerator supports the given operation.
@@ -182,6 +195,9 @@ func (a *VelloAccelerator) SetDeviceProvider(provider gpucontext.DeviceProvider)
 // FillPath converts a path to a PathDef and accumulates it for the next Flush.
 // The actual GPU dispatch happens when Flush is called. Returns ErrFallbackToCPU
 // if the GPU is not ready or the path is empty.
+//
+// When anti-aliasing is disabled, path coordinates are snapped to pixel grid
+// before encoding, producing exact pixel coverage for axis-aligned geometry.
 func (a *VelloAccelerator) FillPath(target gg.GPURenderTarget, path *gg.Path, paint *gg.Paint) error {
 	if path == nil || path.NumVerbs() == 0 {
 		return nil
@@ -201,7 +217,13 @@ func (a *VelloAccelerator) FillPath(target gg.GPURenderTarget, path *gg.Path, pa
 		}
 	}
 
-	pathDef := convertPathToPathDef(path, paint)
+	// Snap path coordinates to pixel grid when AA is disabled.
+	pathToEncode := path
+	if !a.antiAlias {
+		pathToEncode = snapPathToPixelGrid(path)
+	}
+
+	pathDef := convertPathToPathDef(pathToEncode, paint)
 	if len(pathDef.Lines) == 0 {
 		return nil
 	}
@@ -421,6 +443,37 @@ func compositeOver(target gg.GPURenderTarget, src *image.RGBA) {
 func velloSameTarget(a *gg.GPURenderTarget, b *gg.GPURenderTarget) bool {
 	return a.Width == b.Width && a.Height == b.Height &&
 		len(a.Data) == len(b.Data) && len(a.Data) > 0 && &a.Data[0] == &b.Data[0]
+}
+
+// snapPathToPixelGrid rounds all path coordinates to the nearest integer pixel.
+// For axis-aligned geometry this produces exact pixel coverage (no partial coverage
+// from anti-aliasing). Paths already in device-space coordinates (transformed by
+// Context.doFill before reaching the accelerator) are rounded in-place.
+//
+// Reference: Skia Graphite snap_rect_to_pixels pattern — ensures rectangles and
+// other axis-aligned shapes land exactly on pixel boundaries when AA is disabled.
+func snapPathToPixelGrid(path *gg.Path) *gg.Path {
+	snapped := gg.NewPath()
+	path.Iterate(func(verb gg.PathVerb, coords []float64) {
+		switch verb {
+		case gg.MoveTo:
+			snapped.MoveTo(math.Round(coords[0]), math.Round(coords[1]))
+		case gg.LineTo:
+			snapped.LineTo(math.Round(coords[0]), math.Round(coords[1]))
+		case gg.QuadTo:
+			snapped.QuadraticTo(
+				math.Round(coords[0]), math.Round(coords[1]),
+				math.Round(coords[2]), math.Round(coords[3]))
+		case gg.CubicTo:
+			snapped.CubicTo(
+				math.Round(coords[0]), math.Round(coords[1]),
+				math.Round(coords[2]), math.Round(coords[3]),
+				math.Round(coords[4]), math.Round(coords[5]))
+		case gg.Close:
+			snapped.Close()
+		}
+	})
+	return snapped
 }
 
 // RenderSceneCompute renders paths through the GPU compute pipeline.

--- a/internal/gpu/vello_antialias_test.go
+++ b/internal/gpu/vello_antialias_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+//go:build !nogpu
+
+package gpu
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gogpu/gg"
+)
+
+// TestSnapPathToPixelGrid verifies that coordinates are rounded to integers.
+func TestSnapPathToPixelGrid(t *testing.T) {
+	path := gg.NewPath()
+	path.MoveTo(10.3, 20.7)
+	path.LineTo(50.5, 30.2)
+	path.QuadraticTo(60.1, 40.9, 70.5, 50.5)
+	path.CubicTo(80.1, 60.9, 90.4, 70.6, 100.5, 80.5)
+	path.Close()
+
+	snapped := snapPathToPixelGrid(path)
+
+	// Collect coordinates from the snapped path.
+	var coords []float64
+	snapped.Iterate(func(verb gg.PathVerb, c []float64) {
+		coords = append(coords, c...)
+	})
+
+	// Expected: all coordinates rounded to nearest integer (half away from zero).
+	expected := []float64{
+		10, 21, // MoveTo(10.3→10, 20.7→21)
+		51, 30, // LineTo(50.5→51, 30.2→30)
+		60, 41, 71, 51, // QuadTo(60.1→60, 40.9→41, 70.5→71, 50.5→51)
+		80, 61, 90, 71, 101, 81, // CubicTo(80.1→80, 60.9→61, 90.4→90, 70.6→71, 100.5→101, 80.5→81)
+		// Close has no coordinates
+	}
+
+	if len(coords) != len(expected) {
+		t.Fatalf("coord count: got %d, want %d", len(coords), len(expected))
+	}
+
+	for i, got := range coords {
+		want := expected[i]
+		if got != want {
+			t.Errorf("coord[%d] = %v, want %v", i, got, want)
+		}
+	}
+}
+
+// TestSnapPathToPixelGrid_AlreadyAligned verifies no-op for integer coords.
+func TestSnapPathToPixelGrid_AlreadyAligned(t *testing.T) {
+	path := gg.NewPath()
+	path.MoveTo(10, 20)
+	path.LineTo(100, 20)
+	path.LineTo(100, 80)
+	path.LineTo(10, 80)
+	path.Close()
+
+	snapped := snapPathToPixelGrid(path)
+
+	var original, result []float64
+	path.Iterate(func(_ gg.PathVerb, c []float64) {
+		original = append(original, c...)
+	})
+	snapped.Iterate(func(_ gg.PathVerb, c []float64) {
+		result = append(result, c...)
+	})
+
+	if len(original) != len(result) {
+		t.Fatalf("coord count mismatch: %d vs %d", len(original), len(result))
+	}
+	for i := range original {
+		if original[i] != result[i] {
+			t.Errorf("coord[%d]: snapped %v != original %v (should be identical for integer coords)", i, result[i], original[i])
+		}
+	}
+}
+
+// TestVelloAccelerator_NoAA_SnapsPath verifies FillPath applies pixel snapping
+// when anti-aliasing is disabled.
+func TestVelloAccelerator_NoAA_SnapsPath(t *testing.T) {
+	a := &VelloAccelerator{gpuReady: true, antiAlias: true}
+	target := makeTestTargetForAA(100, 100)
+
+	path := gg.NewPath()
+	path.MoveTo(10.3, 20.7)
+	path.LineTo(90.5, 50.2)
+	path.Close()
+
+	paint := gg.NewPaint()
+	paint.SetBrush(gg.Solid(gg.Red))
+
+	// With AA enabled: path should NOT be snapped (coordinates preserve fractional).
+	err := a.FillPath(target, path, paint)
+	if err != nil {
+		t.Fatalf("FillPath with AA: unexpected error: %v", err)
+	}
+	if a.PendingCount() != 1 {
+		t.Fatalf("expected 1 pending path, got %d", a.PendingCount())
+	}
+
+	// Check first pending path has fractional coords (line endpoints).
+	firstPath := a.pendingPaths[0]
+	hasNonInteger := false
+	for _, line := range firstPath.Lines {
+		if math.Floor(float64(line.P0[0])) != float64(line.P0[0]) ||
+			math.Floor(float64(line.P0[1])) != float64(line.P0[1]) {
+			hasNonInteger = true
+			break
+		}
+	}
+	if !hasNonInteger {
+		t.Error("AA enabled: expected some fractional coordinates in path lines")
+	}
+
+	// Now disable AA and add another path.
+	a.pendingPaths = nil
+	a.SetAntiAlias(false)
+
+	err = a.FillPath(target, path, paint)
+	if err != nil {
+		t.Fatalf("FillPath no-AA: unexpected error: %v", err)
+	}
+	if a.PendingCount() != 1 {
+		t.Fatalf("expected 1 pending path, got %d", a.PendingCount())
+	}
+
+	// Check second pending path has integer coords (all snapped).
+	secondPath := a.pendingPaths[0]
+	for i, line := range secondPath.Lines {
+		if math.Round(float64(line.P0[0])) != float64(line.P0[0]) ||
+			math.Round(float64(line.P0[1])) != float64(line.P0[1]) ||
+			math.Round(float64(line.P1[0])) != float64(line.P1[0]) ||
+			math.Round(float64(line.P1[1])) != float64(line.P1[1]) {
+			t.Errorf("no-AA: line[%d] has non-integer coords P0=%v P1=%v",
+				i, line.P0, line.P1)
+		}
+	}
+}
+
+// makeTestTargetForAA creates a simple GPURenderTarget for anti-alias testing.
+// (makeTestTarget already declared in vello_accumulate_test.go)
+func makeTestTargetForAA(w, h int) gg.GPURenderTarget {
+	return gg.GPURenderTarget{
+		Width:  w,
+		Height: h,
+		Stride: w * 4,
+		Data:   make([]byte, w*h*4),
+	}
+}

--- a/internal/raster/noaa_filler.go
+++ b/internal/raster/noaa_filler.go
@@ -1,0 +1,186 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package raster
+
+import (
+	"math"
+)
+
+// NoAAFiller performs non-anti-aliased (binary) scanline rasterization.
+//
+// This is a dedicated integer scanline walker that produces solid horizontal
+// spans with full coverage (255) or zero coverage. No sub-pixel arithmetic,
+// no fractional coverage, no AlphaRuns.
+//
+// The algorithm follows Skia's SkScan::FillPath (SkScan_Path.cpp) and
+// tiny-skia's scan::path — a completely separate code path from the AA
+// rasterizer, not a flag on the AnalyticFiller. Every enterprise 2D engine
+// (Skia, Cairo, tiny-skia) uses separate non-AA code paths because:
+//   - Integer arithmetic only (no fixed-point fractional bits for coverage)
+//   - Solid span output (no alpha blending at edges)
+//   - ~2-3x faster than analytic AA
+//
+// The filler reuses EdgeBuilder infrastructure and CurveAwareAET for edge
+// management, but iterates at integer Y steps and rounds edge X positions
+// to integer pixels via FixedRoundToInt.
+//
+// Usage:
+//
+//	filler := NewNoAAFiller(width, height)
+//	filler.Fill(edgeBuilder, FillRuleNonZero, func(y, left, width int) {
+//	    // Blit solid span: all pixels in [left, left+width) get coverage=255
+//	})
+type NoAAFiller struct {
+	width, height int
+}
+
+// NewNoAAFiller creates a new non-AA filler for the given dimensions.
+func NewNoAAFiller(width, height int) *NoAAFiller {
+	return &NoAAFiller{
+		width:  width,
+		height: height,
+	}
+}
+
+// Fill performs non-anti-aliased rasterization using integer scanline walking.
+//
+// The callback receives solid horizontal spans: (y, left, spanWidth) where
+// every pixel in [left, left+spanWidth) should be blitted with full coverage.
+// This matches Skia's blitter->blitH(left, curr_y, width) pattern.
+//
+// Parameters:
+//   - eb: EdgeBuilder containing the path edges (aaShift=0 for non-AA)
+//   - fillRule: NonZero or EvenOdd fill rule
+//   - blitH: callback for each solid span (y, leftX, spanWidth)
+func (nf *NoAAFiller) Fill(
+	eb *EdgeBuilder,
+	fillRule FillRule,
+	blitH func(y, left, width int),
+) {
+	if eb.IsEmpty() {
+		return
+	}
+
+	bounds := eb.Bounds()
+	aaShift := eb.AAShift()
+
+	yMin := int(math.Floor(float64(bounds.MinY)))
+	yMax := int(math.Ceil(float64(bounds.MaxY)))
+
+	if yMin < 0 {
+		yMin = 0
+	}
+	if yMax > nf.height {
+		yMax = nf.height
+	}
+	if yMin >= yMax {
+		return
+	}
+
+	//nolint:gosec // G115: aaShift is bounded by MaxCoeffShift (6), safe conversion
+	aaScale := int32(1) << uint(aaShift)
+
+	sortedBuf := eb.sortedEdgesSlice()
+	if len(sortedBuf) == 0 {
+		return
+	}
+
+	// Build edge variant buffer (same pattern as AnalyticFiller).
+	edgeBuf := make([]CurveEdgeVariant, len(sortedBuf))
+	for i := range sortedBuf {
+		edgeBuf[i] = sortedBuf[i].variant
+	}
+
+	// Winding mask: for EvenOdd, test bit 0 only; for NonZero, test != 0.
+	// Skia uses windingMask = isEvenOdd ? 1 : -1, then (w & mask) == 0 means outside.
+	windingMask := int32(-1) // NonZero
+	if fillRule == FillRuleEvenOdd {
+		windingMask = 1
+	}
+
+	aet := NewCurveAwareAET()
+	edgeIdx := 0
+
+	for y := yMin; y < yMax; y++ {
+		//nolint:gosec // y is bounded by height which fits in int32
+		ySubpixel := int32(y) * aaScale
+		ySubpixelNext := ySubpixel + aaScale
+
+		aet.RemoveExpiredSubpixel(ySubpixel)
+
+		// Insert new edges whose top Y falls within this scanline.
+		for edgeIdx < len(edgeBuf) {
+			topY := edgeBuf[edgeIdx].TopY()
+			if topY >= ySubpixelNext {
+				break
+			}
+			aet.Insert(edgeBuf[edgeIdx])
+			edgeIdx++
+		}
+
+		if aet.Len() == 0 {
+			continue
+		}
+
+		aet.SortByX()
+
+		// Walk edges left-to-right, tracking winding number.
+		// When we enter a filled region (winding becomes non-zero for NonZero,
+		// or odd for EvenOdd), record left X. When we exit, emit solid span.
+		var w int32
+		var left int
+
+		for i := range aet.Len() {
+			edge := aet.EdgeAt(i)
+			line := edge.AsLine()
+			if line == nil {
+				continue
+			}
+
+			// Round edge X to nearest integer pixel (Skia: SkFixedRoundToInt).
+			x := fixedRoundToInt(line.X)
+
+			// Clamp to canvas bounds.
+			if x < 0 {
+				x = 0
+			}
+			if x > nf.width {
+				x = nf.width
+			}
+
+			if (w & windingMask) == 0 {
+				// Starting a filled interval.
+				left = x
+			}
+
+			w += int32(line.Winding)
+
+			if (w & windingMask) == 0 {
+				// Finished a filled interval.
+				spanWidth := x - left
+				if spanWidth > 0 {
+					blitH(y, left, spanWidth)
+				}
+			}
+		}
+
+		// Handle case where right edge was clipped away (winding still non-zero).
+		if (w & windingMask) != 0 {
+			spanWidth := nf.width - left
+			if spanWidth > 0 {
+				blitH(y, left, spanWidth)
+			}
+		}
+
+		// Advance all edges: step X by slope, then transition curve segments.
+		aet.AdvanceX()
+		aet.StepCurves()
+	}
+}
+
+// fixedRoundToInt rounds a FDot16 (16.16 fixed-point) value to the nearest
+// integer. Matches Skia's SkFixedRoundToInt: (x + 0x8000) >> 16.
+func fixedRoundToInt(x FDot16) int {
+	return int((x + FDot16Half) >> FDot16Shift)
+}

--- a/internal/raster/noaa_filler_test.go
+++ b/internal/raster/noaa_filler_test.go
@@ -1,0 +1,308 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package raster
+
+import (
+	"testing"
+)
+
+// buildRectPath creates a simple rectangle path for testing.
+func buildRectPath(x, y, w, h float32) PathLike {
+	return &testPath{
+		verbs: []PathVerb{MoveTo, LineTo, LineTo, LineTo, Close},
+		points: []float32{
+			x, y, // moveTo
+			x + w, y, // lineTo
+			x + w, y + h, // lineTo
+			x, y + h, // lineTo
+		},
+	}
+}
+
+// buildCirclePath creates a circle approximation using 4 quadratic beziers.
+func buildCirclePath(cx, cy, r float32) PathLike {
+	// Approximate circle with 8 line segments.
+	const n = 8
+	verbs := make([]PathVerb, 0, n+2)
+	points := make([]float32, 0, (n+1)*2)
+
+	verbs = append(verbs, MoveTo)
+	points = append(points, cx+r, cy)
+
+	for i := 1; i <= n; i++ {
+		angle := float32(i) * 2.0 * 3.14159265 / float32(n)
+		x := cx + r*cos32(angle)
+		y := cy + r*sin32(angle)
+		verbs = append(verbs, LineTo)
+		points = append(points, x, y)
+	}
+	verbs = append(verbs, Close)
+
+	return &testPath{verbs: verbs, points: points}
+}
+
+func cos32(x float32) float32 {
+	// Simple Taylor series for testing (accurate enough for coarse circle).
+	x2 := x * x
+	return 1.0 - x2/2.0 + x2*x2/24.0 - x2*x2*x2/720.0
+}
+
+func sin32(x float32) float32 {
+	x2 := x * x
+	return x - x*x2/6.0 + x*x2*x2/120.0 - x*x2*x2*x2/5040.0
+}
+
+// testPath is already defined in analytic_filler_test.go within this package.
+
+func TestNoAAFiller_AxisAlignedRect(t *testing.T) {
+	// A 10x10 rectangle at (5,5) should fill pixels [5,14] x [5,14]
+	// with ALL pixels having full coverage (255). NO gray edge pixels.
+	const w, h = 20, 20
+	filler := NewNoAAFiller(w, h)
+	eb := NewEdgeBuilder(0) // aaShift=0 for non-AA
+	eb.SetFlattenCurves(true)
+
+	path := buildRectPath(5, 5, 10, 10)
+	eb.BuildFromPath(path, IdentityTransform{})
+
+	// Collect all blitted spans.
+	type span struct{ y, left, width int }
+	var spans []span
+	filler.Fill(eb, FillRuleNonZero, func(y, left, width int) {
+		spans = append(spans, span{y, left, width})
+	})
+
+	// Verify: should have 10 scanlines (y=5..14), each spanning [5, 15).
+	if len(spans) != 10 {
+		t.Fatalf("expected 10 spans, got %d", len(spans))
+	}
+	for i, s := range spans {
+		expectedY := 5 + i
+		if s.y != expectedY {
+			t.Errorf("span[%d]: y=%d, expected %d", i, s.y, expectedY)
+		}
+		if s.left != 5 {
+			t.Errorf("span[%d]: left=%d, expected 5", i, s.left)
+		}
+		if s.width != 10 {
+			t.Errorf("span[%d]: width=%d, expected 10", i, s.width)
+		}
+	}
+}
+
+func TestNoAAFiller_NoCoverageOutside(t *testing.T) {
+	// Verify that a rectangle produces NO spans outside its bounds.
+	const w, h = 50, 50
+	filler := NewNoAAFiller(w, h)
+	eb := NewEdgeBuilder(0)
+	eb.SetFlattenCurves(true)
+
+	path := buildRectPath(10, 10, 5, 5)
+	eb.BuildFromPath(path, IdentityTransform{})
+
+	filler.Fill(eb, FillRuleNonZero, func(y, left, width int) {
+		if y < 10 || y > 14 {
+			t.Errorf("span at y=%d is outside rect bounds [10, 14]", y)
+		}
+		if left < 10 || left+width > 15 {
+			t.Errorf("span at y=%d: [%d, %d) exceeds rect bounds [10, 15)", y, left, left+width)
+		}
+	})
+}
+
+func TestNoAAFiller_CircleBinaryCoverage(t *testing.T) {
+	// A circle should produce spans with only full coverage.
+	// No gray/fractional pixels — that's the point of no-AA.
+	const w, h = 100, 100
+	filler := NewNoAAFiller(w, h)
+	eb := NewEdgeBuilder(0)
+	eb.SetFlattenCurves(true)
+
+	path := buildCirclePath(50, 50, 20)
+	eb.BuildFromPath(path, IdentityTransform{})
+
+	spanCount := 0
+	filler.Fill(eb, FillRuleNonZero, func(y, left, width int) {
+		spanCount++
+		if width <= 0 {
+			t.Errorf("span at y=%d has zero/negative width %d", y, width)
+		}
+		if left < 0 || left+width > w {
+			t.Errorf("span at y=%d: [%d, %d) exceeds canvas bounds [0, %d)", y, left, left+width, w)
+		}
+	})
+
+	if spanCount == 0 {
+		t.Error("circle produced no spans")
+	}
+}
+
+func TestNoAAFiller_EvenOddFillRule(t *testing.T) {
+	// Two concentric rectangles with EvenOdd should produce a frame (hole in center).
+	const w, h = 30, 30
+	filler := NewNoAAFiller(w, h)
+	eb := NewEdgeBuilder(0)
+	eb.SetFlattenCurves(true)
+
+	// Outer rect: 5,5 to 25,25
+	// Inner rect: 10,10 to 20,20 (wound same direction — EvenOdd makes hole)
+	outerInner := &testPath{
+		verbs: []PathVerb{
+			MoveTo, LineTo, LineTo, LineTo, Close,
+			MoveTo, LineTo, LineTo, LineTo, Close,
+		},
+		points: []float32{
+			5, 5, 25, 5, 25, 25, 5, 25, // outer
+			10, 10, 20, 10, 20, 20, 10, 20, // inner
+		},
+	}
+	eb.BuildFromPath(outerInner, IdentityTransform{})
+
+	// Track which pixels are filled.
+	filled := make([][]bool, h)
+	for i := range filled {
+		filled[i] = make([]bool, w)
+	}
+
+	filler.Fill(eb, FillRuleEvenOdd, func(y, left, width int) {
+		for x := left; x < left+width; x++ {
+			if x >= 0 && x < w && y >= 0 && y < h {
+				filled[y][x] = true
+			}
+		}
+	})
+
+	// Verify outer area is filled.
+	for y := 5; y < 10; y++ {
+		for x := 5; x < 25; x++ {
+			if !filled[y][x] {
+				t.Errorf("pixel (%d,%d) should be filled (outer frame)", x, y)
+				return
+			}
+		}
+	}
+
+	// Verify inner area is NOT filled (EvenOdd hole).
+	for y := 10; y < 20; y++ {
+		for x := 10; x < 20; x++ {
+			if filled[y][x] {
+				t.Errorf("pixel (%d,%d) should NOT be filled (EvenOdd hole)", x, y)
+				return
+			}
+		}
+	}
+}
+
+func TestNoAAFiller_NonZeroFillRule(t *testing.T) {
+	// Same concentric rects with NonZero — inner should be filled (same winding).
+	const w, h = 30, 30
+	filler := NewNoAAFiller(w, h)
+	eb := NewEdgeBuilder(0)
+	eb.SetFlattenCurves(true)
+
+	outerInner := &testPath{
+		verbs: []PathVerb{
+			MoveTo, LineTo, LineTo, LineTo, Close,
+			MoveTo, LineTo, LineTo, LineTo, Close,
+		},
+		points: []float32{
+			5, 5, 25, 5, 25, 25, 5, 25,
+			10, 10, 20, 10, 20, 20, 10, 20,
+		},
+	}
+	eb.BuildFromPath(outerInner, IdentityTransform{})
+
+	filled := make([][]bool, h)
+	for i := range filled {
+		filled[i] = make([]bool, w)
+	}
+
+	filler.Fill(eb, FillRuleNonZero, func(y, left, width int) {
+		for x := left; x < left+width; x++ {
+			if x >= 0 && x < w && y >= 0 && y < h {
+				filled[y][x] = true
+			}
+		}
+	})
+
+	// With NonZero and same-direction winding, inner should be filled.
+	for y := 10; y < 20; y++ {
+		for x := 10; x < 20; x++ {
+			if !filled[y][x] {
+				t.Errorf("pixel (%d,%d) should be filled (NonZero, same winding)", x, y)
+				return
+			}
+		}
+	}
+}
+
+func TestNoAAFiller_EmptyPath(t *testing.T) {
+	filler := NewNoAAFiller(100, 100)
+	eb := NewEdgeBuilder(0)
+
+	// Empty path — no edges.
+	filler.Fill(eb, FillRuleNonZero, func(y, left, width int) {
+		t.Error("should not produce spans for empty path")
+	})
+}
+
+func TestNoAAFiller_PathOutsideBounds(t *testing.T) {
+	// Rectangle entirely outside canvas bounds.
+	filler := NewNoAAFiller(10, 10)
+	eb := NewEdgeBuilder(0)
+	eb.SetFlattenCurves(true)
+
+	path := buildRectPath(20, 20, 10, 10) // completely outside [0,10)
+	eb.BuildFromPath(path, IdentityTransform{})
+
+	filler.Fill(eb, FillRuleNonZero, func(y, left, width int) {
+		t.Errorf("should not produce spans for path outside bounds: y=%d left=%d w=%d", y, left, width)
+	})
+}
+
+func TestNoAAFiller_SinglePixelRect(t *testing.T) {
+	// A 1x1 pixel rectangle should produce exactly 1 span.
+	filler := NewNoAAFiller(10, 10)
+	eb := NewEdgeBuilder(0)
+	eb.SetFlattenCurves(true)
+
+	path := buildRectPath(3, 3, 1, 1)
+	eb.BuildFromPath(path, IdentityTransform{})
+
+	spans := 0
+	filler.Fill(eb, FillRuleNonZero, func(y, left, width int) {
+		spans++
+		if y != 3 || left != 3 || width != 1 {
+			t.Errorf("expected span (y=3, left=3, w=1), got (y=%d, left=%d, w=%d)", y, left, width)
+		}
+	})
+	if spans != 1 {
+		t.Errorf("expected 1 span, got %d", spans)
+	}
+}
+
+func TestFixedRoundToInt(t *testing.T) {
+	tests := []struct {
+		name  string
+		input FDot16
+		want  int
+	}{
+		{"zero", 0, 0},
+		{"one", FDot16One, 1},
+		{"half_rounds_up", FDot16Half, 1},
+		{"just_below_half", FDot16Half - 1, 0},
+		{"negative_one", -FDot16One, -1},
+		{"ten", 10 * FDot16One, 10},
+		{"quarter", FDot16One / 4, 0},
+		{"three_quarters", FDot16One * 3 / 4, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fixedRoundToInt(tt.input)
+			if got != tt.want {
+				t.Errorf("fixedRoundToInt(%d) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/recording/command.go
+++ b/recording/command.go
@@ -62,6 +62,7 @@ const (
 	CmdSetMiterLimit  // Set miter limit
 	CmdSetDash        // Set dash pattern
 	CmdSetFillRule    // Set fill rule
+	CmdSetAntiAlias   // Set anti-aliasing mode
 )
 
 // commandTypeNames maps CommandType values to their string representation.
@@ -86,6 +87,7 @@ var commandTypeNames = [...]string{
 	CmdSetMiterLimit:  "SetMiterLimit",
 	CmdSetDash:        "SetDash",
 	CmdSetFillRule:    "SetFillRule",
+	CmdSetAntiAlias:   "SetAntiAlias",
 }
 
 // String returns the string representation of a CommandType.
@@ -364,6 +366,15 @@ type SetFillRuleCommand struct {
 
 // Type implements Command.
 func (SetFillRuleCommand) Type() CommandType { return CmdSetFillRule }
+
+// SetAntiAliasCommand enables or disables anti-aliasing for geometry rendering.
+type SetAntiAliasCommand struct {
+	// Enabled is true for anti-aliased rendering, false for aliased.
+	Enabled bool
+}
+
+// Type implements Command.
+func (SetAntiAliasCommand) Type() CommandType { return CmdSetAntiAlias }
 
 // --------------------------------------------------------------------------
 // Supporting Types

--- a/recording/recorder.go
+++ b/recording/recorder.go
@@ -41,6 +41,7 @@ type Recorder struct {
 	dashPattern []float64
 	dashOffset  float64
 	fillRule    FillRule
+	antiAlias   bool
 	transform   Matrix
 
 	// Current font
@@ -63,6 +64,7 @@ type recorderState struct {
 	dashPattern []float64
 	dashOffset  float64
 	fillRule    FillRule
+	antiAlias   bool
 	transform   Matrix
 	fontFace    text.Face
 	fontFamily  string
@@ -87,6 +89,7 @@ func NewRecorder(width, height int) *Recorder {
 		lineJoin:    LineJoinMiter,
 		miterLimit:  4.0,
 		fillRule:    FillRuleNonZero,
+		antiAlias:   true,
 		transform:   Identity(),
 		stateStack:  make([]recorderState, 0, 8),
 	}
@@ -226,6 +229,7 @@ func (r *Recorder) Save() {
 		dashPattern: dashCopy,
 		dashOffset:  r.dashOffset,
 		fillRule:    r.fillRule,
+		antiAlias:   r.antiAlias,
 		transform:   r.transform,
 		fontFace:    r.fontFace,
 		fontFamily:  r.fontFamily,
@@ -254,6 +258,7 @@ func (r *Recorder) Restore() {
 	r.dashPattern = state.dashPattern
 	r.dashOffset = state.dashOffset
 	r.fillRule = state.fillRule
+	r.antiAlias = state.antiAlias
 	r.transform = state.transform
 	r.fontFace = state.fontFace
 	r.fontFamily = state.fontFamily
@@ -494,6 +499,18 @@ func (r *Recorder) SetFillRule(rule FillRule) {
 func (r *Recorder) SetFillRuleGG(rule gg.FillRule) {
 	// #nosec G115 -- FillRule enum values are within uint8 range
 	r.SetFillRule(FillRule(rule))
+}
+
+// SetAntiAlias enables or disables anti-aliasing for geometry rendering.
+// When disabled, shapes are rendered with binary coverage (no gray edge pixels).
+func (r *Recorder) SetAntiAlias(enabled bool) {
+	r.antiAlias = enabled
+	r.commands = append(r.commands, SetAntiAliasCommand{Enabled: enabled})
+}
+
+// AntiAlias returns whether anti-aliasing is enabled.
+func (r *Recorder) AntiAlias() bool {
+	return r.antiAlias
 }
 
 // --------------------------------------------------------------------------

--- a/scene/antialias_test.go
+++ b/scene/antialias_test.go
@@ -1,0 +1,233 @@
+package scene
+
+import (
+	"testing"
+
+	"github.com/gogpu/gg"
+)
+
+func TestSceneSetAntiAlias(t *testing.T) {
+	s := NewScene()
+
+	// Default: AA enabled.
+	if !s.AntiAlias() {
+		t.Error("default AntiAlias() should be true")
+	}
+
+	// Disable.
+	s.SetAntiAlias(false)
+	if s.AntiAlias() {
+		t.Error("AntiAlias() should be false after SetAntiAlias(false)")
+	}
+
+	// Re-enable.
+	s.SetAntiAlias(true)
+	if !s.AntiAlias() {
+		t.Error("AntiAlias() should be true after SetAntiAlias(true)")
+	}
+}
+
+func TestSceneAntiAliasResetRestoresDefault(t *testing.T) {
+	s := NewScene()
+	s.SetAntiAlias(false)
+	s.Reset()
+
+	if !s.AntiAlias() {
+		t.Error("AntiAlias() should be true after Reset()")
+	}
+}
+
+func TestSceneAntiAliasEncodedInStream(t *testing.T) {
+	s := NewScene()
+	rect := NewRectShape(0, 0, 100, 100)
+	brush := SolidBrush(gg.Red)
+
+	// Draw with AA enabled (default) — no TagSetAntiAlias should be emitted.
+	s.Fill(FillNonZero, IdentityAffine(), brush, rect)
+
+	enc := s.Encoding()
+	if countTag(enc.Tags(), TagSetAntiAlias) != 0 {
+		t.Error("should not emit TagSetAntiAlias when AA hasn't changed from default (true)")
+	}
+}
+
+func TestSceneAntiAliasEmittedOnChange(t *testing.T) {
+	s := NewScene()
+	rect := NewRectShape(0, 0, 100, 100)
+	brush := SolidBrush(gg.Red)
+
+	// Change AA to false before fill.
+	s.SetAntiAlias(false)
+	s.Fill(FillNonZero, IdentityAffine(), brush, rect)
+
+	enc := s.Encoding()
+	tags := enc.Tags()
+
+	count := countTag(tags, TagSetAntiAlias)
+	if count != 1 {
+		t.Errorf("expected 1 TagSetAntiAlias, got %d", count)
+	}
+}
+
+func TestSceneAntiAliasDeltaEncoding(t *testing.T) {
+	s := NewScene()
+	rect := NewRectShape(0, 0, 100, 100)
+	brush := SolidBrush(gg.Red)
+
+	// Disable AA and draw twice — should only emit ONE TagSetAntiAlias.
+	s.SetAntiAlias(false)
+	s.Fill(FillNonZero, IdentityAffine(), brush, rect)
+	s.Fill(FillNonZero, IdentityAffine(), brush, rect)
+
+	enc := s.Encoding()
+	tags := enc.Tags()
+
+	count := countTag(tags, TagSetAntiAlias)
+	if count != 1 {
+		t.Errorf("delta encoding: expected 1 TagSetAntiAlias for two fills with same state, got %d", count)
+	}
+}
+
+func TestSceneAntiAliasMultipleTransitions(t *testing.T) {
+	s := NewScene()
+	rect := NewRectShape(0, 0, 100, 100)
+	brush := SolidBrush(gg.Red)
+
+	// false → fill → true → fill → false → fill = 3 TagSetAntiAlias
+	s.SetAntiAlias(false)
+	s.Fill(FillNonZero, IdentityAffine(), brush, rect)
+	s.SetAntiAlias(true)
+	s.Fill(FillNonZero, IdentityAffine(), brush, rect)
+	s.SetAntiAlias(false)
+	s.Fill(FillNonZero, IdentityAffine(), brush, rect)
+
+	enc := s.Encoding()
+	tags := enc.Tags()
+
+	count := countTag(tags, TagSetAntiAlias)
+	if count != 3 {
+		t.Errorf("expected 3 TagSetAntiAlias for 3 transitions, got %d", count)
+	}
+}
+
+func TestSceneAntiAliasDecodeRoundTrip(t *testing.T) {
+	s := NewScene()
+	rect := NewRectShape(0, 0, 100, 100)
+	brush := SolidBrush(gg.Red)
+
+	s.SetAntiAlias(false)
+	s.Fill(FillNonZero, IdentityAffine(), brush, rect)
+
+	enc := s.Encoding()
+	dec := NewDecoder(enc)
+
+	foundAA := false
+	aaValue := true
+	for dec.Next() {
+		if dec.Tag() == TagSetAntiAlias {
+			foundAA = true
+			aaValue = dec.AntiAlias()
+		}
+	}
+
+	if !foundAA {
+		t.Fatal("TagSetAntiAlias not found in encoded stream")
+	}
+	if aaValue {
+		t.Error("decoded AntiAlias() should be false")
+	}
+}
+
+func TestSceneAntiAliasDecoderDefaultTrue(t *testing.T) {
+	// Test decoder returns true (default) when drawData is exhausted.
+	enc := NewEncoding()
+	// Manually emit a tag without data to test boundary.
+	enc.tags = append(enc.tags, TagSetAntiAlias)
+	// Don't add drawData — simulates corrupt/truncated stream.
+
+	dec := NewDecoder(enc)
+	dec.Next()
+	if !dec.AntiAlias() {
+		t.Error("AntiAlias() should default to true on exhausted data")
+	}
+}
+
+func TestSceneBuilderSetAntiAlias(t *testing.T) {
+	b := NewSceneBuilder()
+	rect := NewRectShape(0, 0, 50, 50)
+	brush := SolidBrush(gg.Blue)
+
+	b.SetAntiAlias(false).Fill(rect, brush)
+
+	if b.AntiAlias() {
+		t.Error("builder AntiAlias() should be false")
+	}
+
+	scene := b.Build()
+	enc := scene.Encoding()
+	count := countTag(enc.Tags(), TagSetAntiAlias)
+	if count != 1 {
+		t.Errorf("builder: expected 1 TagSetAntiAlias, got %d", count)
+	}
+}
+
+func TestSceneAntiAliasStroke(t *testing.T) {
+	s := NewScene()
+	line := NewLineShape(0, 0, 100, 100)
+	brush := SolidBrush(gg.Black)
+	style := DefaultStrokeStyle()
+
+	s.SetAntiAlias(false)
+	s.Stroke(style, IdentityAffine(), brush, line)
+
+	enc := s.Encoding()
+	count := countTag(enc.Tags(), TagSetAntiAlias)
+	if count != 1 {
+		t.Errorf("stroke: expected 1 TagSetAntiAlias, got %d", count)
+	}
+}
+
+func TestSceneAntiAliasAppendWithTranslation(t *testing.T) {
+	// Create child scene with AA disabled.
+	child := NewScene()
+	child.SetAntiAlias(false)
+	child.Fill(FillNonZero, IdentityAffine(), SolidBrush(gg.Red), NewRectShape(0, 0, 50, 50))
+
+	// Append into parent with translation.
+	parent := NewScene()
+	parent.AppendWithTranslation(child, 10, 20)
+
+	enc := parent.Encoding()
+	tags := enc.Tags()
+
+	// The appended encoding should contain the TagSetAntiAlias.
+	count := countTag(tags, TagSetAntiAlias)
+	if count != 1 {
+		t.Errorf("AppendWithTranslation: expected 1 TagSetAntiAlias, got %d", count)
+	}
+
+	// Verify decode: find TagSetAntiAlias and check it decodes to false.
+	dec := NewDecoder(enc)
+	for dec.Next() {
+		if dec.Tag() == TagSetAntiAlias {
+			if dec.AntiAlias() {
+				t.Error("AppendWithTranslation: decoded AntiAlias should be false")
+			}
+			return
+		}
+	}
+	t.Fatal("AppendWithTranslation: TagSetAntiAlias not found in decoded stream")
+}
+
+// countTag counts occurrences of a specific tag in the tag stream.
+//
+//nolint:unparam // test utility: target is always TagSetAntiAlias in this file but the function is generic
+func countTag(tags []Tag, target Tag) int {
+	count := 0
+	for _, t := range tags {
+		if t == target {
+			count++
+		}
+	}
+	return count
+}

--- a/scene/builder.go
+++ b/scene/builder.go
@@ -43,6 +43,22 @@ func NewSceneBuilderFrom(scene *Scene) *SceneBuilder {
 }
 
 // ---------------------------------------------------------------------------
+// State Operations
+// ---------------------------------------------------------------------------
+
+// SetAntiAlias enables or disables anti-aliasing for subsequent draw operations.
+// When disabled, shapes use binary coverage for pixel-perfect rendering.
+func (b *SceneBuilder) SetAntiAlias(enabled bool) *SceneBuilder {
+	b.scene.SetAntiAlias(enabled)
+	return b
+}
+
+// AntiAlias returns whether anti-aliasing is enabled for subsequent draws.
+func (b *SceneBuilder) AntiAlias() bool {
+	return b.scene.AntiAlias()
+}
+
+// ---------------------------------------------------------------------------
 // Drawing Operations
 // ---------------------------------------------------------------------------
 

--- a/scene/decoder.go
+++ b/scene/decoder.go
@@ -187,6 +187,22 @@ func (d *Decoder) Transform() Affine {
 }
 
 // ---------------------------------------------------------------------------
+// State Command Decoders
+// ---------------------------------------------------------------------------
+
+// AntiAlias reads the current SetAntiAlias command data.
+// Returns true if anti-aliasing is enabled, false if disabled.
+// Only valid when Tag() == TagSetAntiAlias.
+func (d *Decoder) AntiAlias() bool {
+	if d.drawIdx+1 > len(d.enc.drawData) {
+		return true // default: AA enabled
+	}
+	val := d.enc.drawData[d.drawIdx]
+	d.drawIdx++
+	return val != 0
+}
+
+// ---------------------------------------------------------------------------
 // Draw Command Decoders
 // ---------------------------------------------------------------------------
 

--- a/scene/encoding.go
+++ b/scene/encoding.go
@@ -474,6 +474,17 @@ func (e *Encoding) Reset() {
 	e.shapeCount = 0
 }
 
+// EncodeAntiAlias adds an anti-aliasing state change command.
+// The value is stored as 1 uint32 in drawData (0 = disabled, 1 = enabled).
+func (e *Encoding) EncodeAntiAlias(enabled bool) {
+	e.tags = append(e.tags, TagSetAntiAlias)
+	var val uint32
+	if enabled {
+		val = 1
+	}
+	e.drawData = append(e.drawData, val)
+}
+
 // EncodeTransform adds a transform command.
 func (e *Encoding) EncodeTransform(t Affine) {
 	e.tags = append(e.tags, TagTransform)
@@ -848,6 +859,8 @@ func (e *Encoding) AppendWithImages(other *Encoding, imageOffset uint32) {
 			drawIdx += 5
 		case TagPushLayer:
 			drawIdx += 2
+		case TagSetAntiAlias:
+			drawIdx++ // 1 uint32: 0 or 1
 		case TagImage:
 			if imageOffset > 0 && drawIdx < len(other.drawData) {
 				e.drawData[drawDataStart+drawIdx] += imageOffset
@@ -996,6 +1009,9 @@ func (e *Encoding) AppendWithTranslation(other *Encoding, dx, dy float32, imageO
 
 		case TagPushLayer:
 			drawIdx += 2 // blend mode + alpha
+
+		case TagSetAntiAlias:
+			drawIdx++ // 1 uint32: 0 or 1, no coordinate data
 
 		case TagImage:
 			if imageOffset > 0 && drawIdx < len(other.drawData) {

--- a/scene/gpu_renderer.go
+++ b/scene/gpu_renderer.go
@@ -195,6 +195,10 @@ func (r *GPUSceneRenderer) RenderScene(scene *Scene) error { //nolint:gocyclo,cy
 		case TagEndClip:
 			dc.Pop()
 
+		case TagSetAntiAlias:
+			aa := dec.AntiAlias()
+			dc.SetAntiAlias(aa)
+
 		case TagText:
 			run, glyphs, str, brush := dec.Text()
 			r.resolveText(scene, run, glyphs, str, brush)

--- a/scene/renderer.go
+++ b/scene/renderer.go
@@ -781,6 +781,10 @@ func (r *Renderer) executeEncodingOnTile(dec *Decoder, tile *parallel.Tile, pm *
 			run, glyphs, _, brush := dec.Text()
 			r.renderTextOnTile(run, glyphs, brush, currentTransform, tileX, tileY, activePM, sr, fillPaint)
 
+		case TagSetAntiAlias:
+			aa := dec.AntiAlias()
+			sr.SetAntiAlias(aa)
+
 		case TagBrush:
 			// Brush definitions are stored in the brushes array and referenced
 			// by index from Fill/Stroke/Text commands. The TagBrush tag encodes

--- a/scene/scene.go
+++ b/scene/scene.go
@@ -39,6 +39,15 @@ type Scene struct {
 	// currentTransform is the current combined transform
 	currentTransform Affine
 
+	// antiAlias controls whether subsequent draws use anti-aliasing.
+	// Default: true. State changes are delta-encoded (TagSetAntiAlias emitted
+	// only when the value differs from lastEncodedAA).
+	antiAlias bool
+
+	// lastEncodedAA tracks the last AA state emitted into the encoding.
+	// Used for dirty tracking to avoid redundant TagSetAntiAlias tags.
+	lastEncodedAA bool
+
 	// imageRegistry maps image handles to indices
 	imageRegistry []*Image
 
@@ -61,6 +70,8 @@ func NewScene() *Scene {
 		version:          0,
 		bounds:           EmptyRect(),
 		currentTransform: IdentityAffine(),
+		antiAlias:        true,
+		lastEncodedAA:    true,
 		imageRegistry:    make([]*Image, 0, 8),
 		fontRegistry:     make(map[uint64]*text.FontSource, 4),
 	}
@@ -75,8 +86,38 @@ func (s *Scene) Reset() {
 	s.version++
 	s.bounds = EmptyRect()
 	s.currentTransform = IdentityAffine()
+	s.antiAlias = true
+	s.lastEncodedAA = true
 	s.imageRegistry = s.imageRegistry[:0]
 	clear(s.fontRegistry)
+}
+
+// SetAntiAlias enables or disables anti-aliasing for subsequent fill and stroke
+// operations. When disabled, shapes are rendered with binary (pixel-perfect)
+// coverage, producing crisp edges ideal for UI elements at exact pixel boundaries.
+//
+// The state change is delta-encoded: TagSetAntiAlias is emitted into the encoding
+// only when the value differs from the previously encoded state. Default is true.
+//
+// Reference: Skia SkPaint::setAntiAlias, Cairo cairo_set_antialias.
+func (s *Scene) SetAntiAlias(enabled bool) {
+	s.antiAlias = enabled
+	s.version++
+}
+
+// AntiAlias returns whether anti-aliasing is enabled for subsequent draws.
+func (s *Scene) AntiAlias() bool {
+	return s.antiAlias
+}
+
+// emitAntiAliasIfNeeded emits TagSetAntiAlias into the given encoding when
+// the current AA state differs from the last-encoded state. This implements
+// delta encoding to avoid redundant tags in the stream.
+func (s *Scene) emitAntiAliasIfNeeded(enc *Encoding) {
+	if s.antiAlias != s.lastEncodedAA {
+		enc.EncodeAntiAlias(s.antiAlias)
+		s.lastEncodedAA = s.antiAlias
+	}
 }
 
 // Fill fills a shape with the given style, transform, and brush.
@@ -90,6 +131,9 @@ func (s *Scene) Fill(style FillStyle, transform Affine, brush Brush, shape Shape
 
 	// Get the current layer's encoding
 	enc := s.currentEncoding()
+
+	// Emit AA state change if needed (delta encoding).
+	s.emitAntiAliasIfNeeded(enc)
 
 	// Optimization: RoundRectShape uses dedicated SDF encoding
 	// which bypasses path construction entirely.
@@ -156,6 +200,9 @@ func (s *Scene) Stroke(style *StrokeStyle, transform Affine, brush Brush, shape 
 
 	// Get the current layer's encoding
 	enc := s.currentEncoding()
+
+	// Emit AA state change if needed (delta encoding).
+	s.emitAntiAliasIfNeeded(enc)
 
 	// Encode transform if not identity
 	if !combinedTransform.IsIdentity() {

--- a/scene/tag.go
+++ b/scene/tag.go
@@ -29,6 +29,12 @@ const (
 	//   | d  e  f |
 	TagTransform Tag = 0x01
 
+	// TagSetAntiAlias sets the anti-aliasing state for subsequent draw commands.
+	// Data: 1 uint32 in drawData (0 = disabled, 1 = enabled).
+	// Emitted only when the AA state changes (delta encoding, like TagTransform).
+	// Reference: Skia SkPaint::setAntiAlias, Cairo cairo_set_antialias.
+	TagSetAntiAlias Tag = 0x02
+
 	// TagBeginPath marks the start of a new path.
 	// Data: none (marker only)
 	TagBeginPath Tag = 0x10
@@ -104,10 +110,14 @@ const (
 )
 
 // String returns a human-readable name for the tag.
+//
+//nolint:cyclop // simple switch dispatch over all tag values
 func (t Tag) String() string {
 	switch t {
 	case TagTransform:
 		return "Transform"
+	case TagSetAntiAlias:
+		return "SetAntiAlias"
 	case TagBeginPath:
 		return "BeginPath"
 	case TagMoveTo:

--- a/software.go
+++ b/software.go
@@ -29,6 +29,18 @@ type SoftwareRenderer struct {
 	// to support forced algorithm selection (RasterizerSparseStrips, etc.).
 	// Reset to RasterizerAuto after each call.
 	rasterizerMode RasterizerMode
+
+	// antiAlias is set by Context before calling Fill/Stroke.
+	// When false, the NoAAFiller (integer scanline, binary coverage) is used
+	// instead of AnalyticFiller/CoverageFiller. Reset to true after each call.
+	antiAlias bool
+
+	// noAAFiller is the non-anti-aliased filler (lazy-initialized).
+	noAAFiller *raster.NoAAFiller
+
+	// noAAEdgeBuilder is a separate EdgeBuilder with aaShift=0 for non-AA.
+	// Non-AA does not need sub-pixel edge coordinate shifting.
+	noAAEdgeBuilder *raster.EdgeBuilder
 }
 
 // NewSoftwareRenderer creates a new software renderer with analytic anti-aliasing.
@@ -40,6 +52,7 @@ func NewSoftwareRenderer(width, height int) *SoftwareRenderer {
 		width:          width,
 		height:         height,
 		deviceScale:    1.0,
+		antiAlias:      true,
 	}
 }
 
@@ -54,6 +67,9 @@ func (r *SoftwareRenderer) Resize(width, height int) {
 	}
 	r.edgeBuilder = eb
 	r.analyticFiller = raster.NewAnalyticFiller(width, height)
+	// Reset lazy no-AA resources so they pick up new dimensions.
+	r.noAAFiller = nil
+	r.noAAEdgeBuilder = nil
 }
 
 // SetDeviceScale sets the HiDPI device scale factor for the renderer.
@@ -313,6 +329,12 @@ func applyMaskCoverage(maskFn func(x, y int) uint8, px, py int, coverage uint8) 
 // When rasterizerMode is set (via Context.SetRasterizerMode), the forced
 // algorithm is used instead of auto-selection.
 func (r *SoftwareRenderer) Fill(pixmap *Pixmap, p *Path, paint *Paint) error {
+	// Non-AA path: completely separate code path (Skia/tiny-skia pattern).
+	// Integer scanline, binary coverage, no CoverageFiller/AnalyticFiller.
+	if !r.antiAlias {
+		return r.fillNoAA(pixmap, p, paint)
+	}
+
 	// Force mode: specific algorithm without auto-selection.
 	switch r.rasterizerMode {
 	case RasterizerAnalytic:
@@ -402,6 +424,121 @@ func (r *SoftwareRenderer) Fill(pixmap *Pixmap, p *Path, paint *Paint) error {
 	}
 
 	return nil
+}
+
+// fillNoAA renders a filled path without anti-aliasing.
+// Uses a dedicated NoAAFiller that produces solid horizontal spans with
+// binary coverage (0 or 255). This is a completely separate code path
+// from the AA rasterizer (Skia SkScan::FillPath / tiny-skia scan::path pattern).
+func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) error {
+	// Lazy-init the no-AA edge builder and filler.
+	if r.noAAEdgeBuilder == nil {
+		r.noAAEdgeBuilder = raster.NewEdgeBuilder(0) // aaShift=0: no sub-pixel
+		if r.deviceScale > 1.0 {
+			r.noAAEdgeBuilder.SetFlattenTolerance(0.1 / r.deviceScale)
+		}
+	}
+	if r.noAAFiller == nil {
+		r.noAAFiller = raster.NewNoAAFiller(r.width, r.height)
+	}
+
+	r.noAAEdgeBuilder.Reset()
+
+	clipMargin := float32(2)
+	clipRect := raster.Rect{
+		MinX: -clipMargin,
+		MinY: -clipMargin,
+		MaxX: float32(pixmap.Width()) + clipMargin,
+		MaxY: float32(pixmap.Height()) + clipMargin,
+	}
+	r.noAAEdgeBuilder.SetClipRect(&clipRect)
+
+	r.noAAEdgeBuilder.SetFlattenCurves(true)
+	defer r.noAAEdgeBuilder.SetFlattenCurves(false)
+
+	verbs := p.Verbs()
+	if len(verbs) > 0 {
+		verbBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(verbs))), len(verbs))
+		r.noAAEdgeBuilder.BuildFromPathF64(verbBytes, p.Coords())
+	}
+
+	if r.noAAEdgeBuilder.IsEmpty() {
+		return nil
+	}
+
+	coreFillRule := raster.FillRuleNonZero
+	if paint.FillRule == FillRuleEvenOdd {
+		coreFillRule = raster.FillRuleEvenOdd
+	}
+
+	clipFn := paint.ClipCoverage
+	maskFn := paint.MaskCoverage
+
+	if color, ok := solidColorFromPaint(paint); ok {
+		r.noAAFiller.Fill(r.noAAEdgeBuilder, coreFillRule, func(y, left, spanWidth int) {
+			r.blitNoAASolidSpan(pixmap, y, left, spanWidth, color, clipFn, maskFn)
+		})
+	} else {
+		r.noAAFiller.Fill(r.noAAEdgeBuilder, coreFillRule, func(y, left, spanWidth int) {
+			r.blitNoAAPaintSpan(pixmap, y, left, spanWidth, paint, clipFn, maskFn)
+		})
+	}
+
+	return nil
+}
+
+// blitNoAASolidSpan blits a solid-color span with optional clip and mask.
+func (r *SoftwareRenderer) blitNoAASolidSpan(
+	pixmap *Pixmap, y, left, spanWidth int, color RGBA,
+	clipFn func(float64, float64) byte, maskFn func(int, int) uint8,
+) {
+	for x := left; x < left+spanWidth; x++ {
+		cov := noaaPixelCoverage(x, y, clipFn, maskFn)
+		if cov == 0 {
+			continue
+		}
+		r.blendCoverageSolid(pixmap, x, y, cov, color)
+	}
+}
+
+// blitNoAAPaintSpan blits a paint-sampled span with optional clip and mask.
+func (r *SoftwareRenderer) blitNoAAPaintSpan(
+	pixmap *Pixmap, y, left, spanWidth int, paint *Paint,
+	clipFn func(float64, float64) byte, maskFn func(int, int) uint8,
+) {
+	for x := left; x < left+spanWidth; x++ {
+		cov := noaaPixelCoverage(x, y, clipFn, maskFn)
+		if cov == 0 {
+			continue
+		}
+		c := paint.ColorAt(float64(x)+0.5, float64(y)+0.5)
+		r.blendCoverageSolid(pixmap, x, y, cov, c)
+	}
+}
+
+// noaaPixelCoverage computes per-pixel coverage from clip and mask functions.
+// Returns 0 if the pixel is fully clipped/masked, 255 if no clip/mask is active.
+func noaaPixelCoverage(x, y int, clipFn func(float64, float64) byte, maskFn func(int, int) uint8) byte {
+	cov := byte(255)
+	if clipFn != nil {
+		clipCov := clipFn(float64(x)+0.5, float64(y)+0.5)
+		if clipCov == 0 {
+			return 0
+		}
+		cov = clipCov
+	}
+	if maskFn != nil {
+		mc := maskFn(x, y)
+		if mc == 0 {
+			return 0
+		}
+		if cov != 255 {
+			cov = uint8(uint16(cov) * uint16(mc) / 255)
+		} else {
+			cov = mc
+		}
+	}
+	return cov
 }
 
 // blendCoverageSolid blends a single pixel with solid color and coverage.

--- a/software.go
+++ b/software.go
@@ -72,6 +72,16 @@ func (r *SoftwareRenderer) Resize(width, height int) {
 	r.noAAEdgeBuilder = nil
 }
 
+// SetAntiAlias enables or disables anti-aliasing for subsequent Fill/Stroke calls.
+// When disabled, the NoAAFiller (integer scanline, binary coverage) is used
+// instead of the AnalyticFiller or CoverageFiller.
+//
+// This method is intended for use by the scene renderer which needs to
+// propagate per-draw AA state decoded from TagSetAntiAlias commands.
+func (r *SoftwareRenderer) SetAntiAlias(enabled bool) {
+	r.antiAlias = enabled
+}
+
 // SetDeviceScale sets the HiDPI device scale factor for the renderer.
 // When scale > 1.0, curve flattening tolerance is reduced for finer
 // subdivision on HiDPI displays (femtovg pattern: tol = baseTol / scale).


### PR DESCRIPTION
## Summary

- Add `dc.SetAntiAlias(false)` API for pixel-perfect rendering without anti-aliasing (#319, @rcarlier)
- Dedicated NoAAFiller integer scanline rasterizer (Skia/Cairo/tiny-skia enterprise pattern)
- GPU SDF binary step coverage via uniform flag
- Scene `TagSetAntiAlias` delta encoding + Vello compute pixel snapping
- 26 new tests + visual example

## What's Changed

**API:**
- `Context.SetAntiAlias(enabled bool)` / `Context.AntiAlias() bool` — participates in Push/Pop
- `Scene.SetAntiAlias()`, `SceneBuilder.SetAntiAlias()` — retained mode
- `Recorder.SetAntiAlias()` — recording/export
- Text AA independent (TextMode unchanged)

**CPU Rasterizer:**
- New `NoAAFiller` (`internal/raster/noaa_filler.go`) — integer scanline walker, `FixedRoundToInt` edge rounding, solid binary spans. Separate code path, ~2-3× faster than analytic AA.
- `SoftwareRenderer.Fill()` dispatches to `fillNoAA()` when AA=false, bypassing CoverageFiller/AnalyticFiller entirely.

**GPU:**
- SDF shader: `anti_alias: u32` uniform, naga-safe arithmetic blend between smoothstep and step coverage
- Vello compute: `snapPathToPixelGrid()` rounds path coords to integer pixels before encoding (Skia Graphite pattern)
- State propagated through GPURenderContext → RenderSession → VelloAccelerator

**Scene:**
- `TagSetAntiAlias` (0x02) delta-encoded — emitted only when AA state changes between draws
- Handled in both tile renderer and GPU scene renderer

**Architecture:** ADR-030 based on research of 5 enterprise 2D engines (Skia, Cairo, tiny-skia, Vello, femtovg).

## Test plan

- [x] 9 NoAAFiller unit tests (rect, circle, fill rules, edge cases)
- [x] 11 scene encoding/decoding tests (delta encoding, round-trip, builder, append)
- [x] 2 Vello pixel snap tests
- [x] 4 Context integration tests (binary pixels, gray check, Push/Pop, rect coverage)
- [x] Visual example `examples/pixel_perfect/` — AA vs no-AA side-by-side
- [x] All existing tests pass (0 regressions)
- [x] `golangci-lint` clean, `gofmt` clean
