### PR TITLE
fix: Draw() per-frame state reset — ADR-032 (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.47.2] - 2026-05-16
+
+### Fixed
+
+- **ggcanvas.Draw() per-frame state reset** (#328, @unxed) — `Draw()` now wraps
+  the user closure with `Push()/Identity()/ClearPath()/Pop()` (Skia SkAutoCanvasRestore
+  pattern, ADR-032). Matrix transforms, paths, and clips no longer accumulate across
+  frames. Configuration state (font, paint color, textMode) persists as expected.
+
+### Added
+
+- **Draw state reset tests** — 5 tests: matrix reset, path clear, font persistence,
+  Push unwind, multi-frame stability (10 frames with drift detection).
+
 ## [0.47.1] - 2026-05-16
 
 ### Fixed

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -373,12 +373,21 @@ func (c *Canvas) MarkDirtyRegion(r image.Rectangle) {
 // This ensures the first render pass clears the surface while mid-frame
 // CPU fallback flushes (bitmap text, gradient fill) use LoadOpLoad to
 // preserve previously drawn content. See RENDER-DIRECT-003.
+//
+// Per-frame state (matrix, path, clip, mask) is automatically reset via
+// Push/Pop wrapper (Skia SkAutoCanvasRestore pattern, ADR-032). Configuration
+// state (font, paint color, textMode) persists across frames.
 func (c *Canvas) Draw(fn func(*gg.Context)) error {
 	if c.closed {
 		return ErrCanvasClosed
 	}
 	gg.BeginAcceleratorFrame()
+	c.ctx.Push()
+	c.ctx.Identity()
+	c.ctx.ClearPath()
+	c.ctx.ResetFrameDamage()
 	fn(c.ctx)
+	c.ctx.Pop()
 	c.MarkDirty()
 	return nil
 }

--- a/integration/ggcanvas/canvas_test.go
+++ b/integration/ggcanvas/canvas_test.go
@@ -1498,3 +1498,115 @@ func (h *warningDetector) WithAttrs(attrs []slog.Attr) slog.Handler {
 func (h *warningDetector) WithGroup(name string) slog.Handler {
 	return h
 }
+
+// --- Draw() per-frame state reset tests (ADR-032, gg#328) ---
+
+func TestDraw_ResetsMatrix(t *testing.T) {
+	provider := newMockProvider()
+	canvas, err := New(provider, 50, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer canvas.Close()
+
+	_ = canvas.Draw(func(dc *gg.Context) {
+		dc.Translate(25, 25)
+		dc.Scale(0.5, 0.5)
+	})
+
+	_ = canvas.Draw(func(dc *gg.Context) {
+		m := dc.GetTransform()
+		if m != gg.Identity() {
+			t.Errorf("matrix should reset to Identity between Draw() calls, got %v", m)
+		}
+	})
+}
+
+func TestDraw_ResetsPath(t *testing.T) {
+	provider := newMockProvider()
+	canvas, err := New(provider, 50, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer canvas.Close()
+
+	_ = canvas.Draw(func(dc *gg.Context) {
+		dc.MoveTo(0, 0)
+		dc.LineTo(50, 50)
+	})
+
+	_ = canvas.Draw(func(dc *gg.Context) {
+		if _, _, ok := dc.GetCurrentPoint(); ok {
+			t.Error("path should be cleared between Draw() calls")
+		}
+	})
+}
+
+func TestDraw_PreservesFont(t *testing.T) {
+	provider := newMockProvider()
+	canvas, err := New(provider, 50, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer canvas.Close()
+
+	var fontSet bool
+	_ = canvas.Draw(func(dc *gg.Context) {
+		if dc.Font() != nil {
+			fontSet = true
+		}
+	})
+
+	_ = canvas.Draw(func(dc *gg.Context) {
+		if fontSet && dc.Font() == nil {
+			t.Error("font should persist between Draw() calls")
+		}
+	})
+}
+
+func TestDraw_UnwindsPush(t *testing.T) {
+	provider := newMockProvider()
+	canvas, err := New(provider, 50, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer canvas.Close()
+
+	_ = canvas.Draw(func(dc *gg.Context) {
+		dc.Push()
+		dc.Translate(10, 10)
+	})
+
+	_ = canvas.Draw(func(dc *gg.Context) {
+		m := dc.GetTransform()
+		if m != gg.Identity() {
+			t.Errorf("leaked Push() should be unwound by Draw(), got matrix %v", m)
+		}
+	})
+}
+
+func TestDraw_MultipleFramesStable(t *testing.T) {
+	provider := newMockProvider()
+	canvas, err := New(provider, 100, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer canvas.Close()
+
+	for i := range 10 {
+		_ = canvas.Draw(func(dc *gg.Context) {
+			dc.Translate(0.5, 0.5)
+			dc.Scale(0.995, 0.995)
+			dc.SetRGB(1, 0, 0)
+			dc.DrawRectangle(10, 10, 30, 30)
+			dc.Fill()
+		})
+
+		_ = canvas.Draw(func(dc *gg.Context) {
+			m := dc.GetTransform()
+			if m != gg.Identity() {
+				t.Fatalf("frame %d: matrix drifted to %v", i, m)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `canvas.Draw()` now resets per-frame state (matrix, path, clip, mask) via Push/Pop wrapper
- Configuration state (font, paint color, textMode) persists across frames
- Skia SkAutoCanvasRestore / Flutter fresh-canvas-per-frame pattern (ADR-032)
- Closes #328 (@unxed)

## What's Changed

`Draw()` wraps the user closure with `Push()/Identity()/ClearPath()/ResetFrameDamage()/Pop()`:
- **Matrix** resets to Identity each frame (no transform drift)
- **Path** cleared (no stale path segments)
- **Clip/Mask** unwound via Pop (no leaked clips)
- **Font, paint, textMode** persist naturally (not in Push/Pop scope)

ui/desktop uses `Context()` directly — **unaffected**.

## Test plan

- [x] TestDraw_ResetsMatrix — Translate+Scale in frame 1, verify Identity in frame 2
- [x] TestDraw_ResetsPath — MoveTo/LineTo in frame 1, verify empty in frame 2
- [x] TestDraw_PreservesFont — font set in frame 1 persists to frame 2
- [x] TestDraw_UnwindsPush — Push without Pop, verify matrix clean in frame 2
- [x] TestDraw_MultipleFramesStable — 10 frames with drift detection
- [x] All existing tests pass, golangci-lint clean