### PR TITLE
Fix HiDPI viewport mismatch by scaling damage rectangles to physical pixels

### DIFF
--- a/context.go
+++ b/context.go
@@ -532,6 +532,16 @@ func (c *Context) trackDamage(bounds image.Rectangle) {
 	if !c.damageTrackingEnabled || bounds.Empty() {
 		return
 	}
+
+	// HiDPI fix: scale logical damage rect to physical pixels for the OS compositor.
+	if c.deviceScale > 1.0 {
+		x0 := int(math.Floor(float64(bounds.Min.X) * c.deviceScale))
+		y0 := int(math.Floor(float64(bounds.Min.Y) * c.deviceScale))
+		x1 := int(math.Ceil(float64(bounds.Max.X) * c.deviceScale))
+		y1 := int(math.Ceil(float64(bounds.Max.Y) * c.deviceScale))
+		bounds = image.Rect(x0, y0, x1, y1)
+	}
+
 	c.frameDamageRects = append(c.frameDamageRects, bounds)
 	if len(c.frameDamageRects) > maxDamageRects {
 		merged := c.frameDamageRects[0]


### PR DESCRIPTION
This PR resolves a critical bug where rendering output was confined to the top-left quadrant on HiDPI screens, particularly noticeable on Linux/X11 with fractional or integer scaling. Although the rendering pipeline and swapchain correctly operated in physical pixels, the internal damage tracking system was recording dirty regions in logical units. This mismatch caused the OS compositor to only update a fraction of the window corresponding to the logical dimensions, leaving the rest of the physical surface unpainted or filled with artifacts. By scaling damage rectangles using the device scale factor, we ensure that the compositor receives accurate physical pixel coordinates for sub-region updates, fixing the restricted output issue for both GPU and software rendering backends.

Fixes #327