### PR TITLE
seal glyph batch at scissor boundaries to prevent text clip…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Text invisible on clipped elements after first sibling (Tier 4 MSDF and Tier 6 GlyphMask)** — When adjacent
+  elements inside clip regions (e.g. buttons in a row) share the same font and text color,
+  text batch coalescing merged all their text runs into a single batch entry.
+  Because the batch count only advanced on the *first* element's text, `buildScissorGroups`
+  assigned the entire merged batch to the first element's scissor rect, clipping away text
+  from all subsequent elements. Fills for those elements then rendered on top of the
+  (already clipped-away) text, making it appear invisible. Fix: `recordScissorSegment` now
+  sets a `textBatchSealed` flag that prevents both `QueueGlyphMask` and `QueueText` from merging
+  into the previous batch when a scissor boundary has been crossed. Each clipped element
+  gets its own batch entry so `buildScissorGroups` places each batch in the correct scissor
+  group. Merging within the same clip region is preserved for efficiency.
+
 ## [0.47.4] - 2026-05-21
 
 ### Added

--- a/internal/gpu/batch_coalescing_test.go
+++ b/internal/gpu/batch_coalescing_test.go
@@ -483,6 +483,104 @@ func TestQueueGlyphMask_ScissorBoundary_PreservesIntraGroupMerging(t *testing.T)
 	}
 }
 
+// --- Scissor-boundary text batch isolation tests ---
+
+// TestQueueText_ScissorBoundary_SplitsBatch verifies that same-style text
+// runs queued across scissor boundaries are NOT merged into a single batch.
+//
+// Regression test for the same bug affecting the MSDF (Tier 4) text pipeline.
+// QueueText merged all same-font/same-color runs into one batch regardless of
+// intervening clip changes. buildScissorGroups then assigned the entire merged
+// batch to the first element's scissor rect, causing text from all subsequent
+// sibling elements to be clipped away.
+func TestQueueText_ScissorBoundary_SplitsBatch(t *testing.T) {
+	rc := &GPURenderContext{}
+	target := makeCoalesceTestTarget()
+
+	quad := func(x float32) TextBatch {
+		return TextBatch{
+			Transform:  gg.Identity(),
+			Color:      gg.RGBA{R: 1, G: 1, B: 1, A: 1},
+			AtlasIndex: 0,
+			PxRange:    4.0,
+			AtlasSize:  1024,
+			Quads:      []TextQuad{{X0: x, Y0: 0, X1: x + 10, Y1: 10}},
+		}
+	}
+
+	// Simulate three sibling elements each clipped to their own rect.
+	clip1 := [4]uint32{0, 0, 100, 30}
+	clip2 := [4]uint32{0, 30, 100, 30}
+	clip3 := [4]uint32{0, 60, 100, 30}
+
+	// Button 1: set clip, queue text.
+	rc.recordScissorSegment(&clip1)
+	rc.QueueText(target, quad(0))
+
+	// Button 2: change clip, queue text with identical style.
+	rc.recordScissorSegment(&clip2)
+	rc.QueueText(target, quad(10))
+
+	// Button 3: change clip again, queue text with identical style.
+	rc.recordScissorSegment(&clip3)
+	rc.QueueText(target, quad(20))
+
+	if len(rc.pendingTextBatches) != 3 {
+		t.Fatalf("expected 3 separate text batches (one per scissor region), got %d — "+
+			"same-style runs across scissor boundaries must not be merged",
+			len(rc.pendingTextBatches))
+	}
+	for i, b := range rc.pendingTextBatches {
+		if len(b.Quads) != 1 {
+			t.Errorf("batch[%d]: expected 1 quad, got %d", i, len(b.Quads))
+		}
+	}
+}
+
+// TestQueueText_ScissorBoundary_PreservesIntraGroupMerging verifies that
+// within a single scissor region, same-style consecutive text runs still merge.
+func TestQueueText_ScissorBoundary_PreservesIntraGroupMerging(t *testing.T) {
+	rc := &GPURenderContext{}
+	target := makeCoalesceTestTarget()
+
+	quad := func(x float32) TextBatch {
+		return TextBatch{
+			Transform:  gg.Identity(),
+			Color:      gg.RGBA{R: 1, G: 1, B: 1, A: 1},
+			AtlasIndex: 0,
+			PxRange:    4.0,
+			AtlasSize:  1024,
+			Quads:      []TextQuad{{X0: x}},
+		}
+	}
+
+	clip1 := [4]uint32{0, 0, 100, 50}
+	clip2 := [4]uint32{0, 50, 100, 50}
+
+	// Region 1: two runs that should merge.
+	rc.recordScissorSegment(&clip1)
+	rc.QueueText(target, quad(0))
+	rc.QueueText(target, quad(10)) // same style -> merges with previous
+
+	// Region 2: two more runs that should merge with each other but not region 1.
+	rc.recordScissorSegment(&clip2)
+	rc.QueueText(target, quad(20))
+	rc.QueueText(target, quad(30)) // same style -> merges with previous
+
+	if len(rc.pendingTextBatches) != 2 {
+		t.Fatalf("expected 2 batches (one per scissor region, each with 2 quads merged), got %d",
+			len(rc.pendingTextBatches))
+	}
+	if len(rc.pendingTextBatches[0].Quads) != 2 {
+		t.Errorf("region 1 batch: expected 2 merged quads, got %d",
+			len(rc.pendingTextBatches[0].Quads))
+	}
+	if len(rc.pendingTextBatches[1].Quads) != 2 {
+		t.Errorf("region 2 batch: expected 2 merged quads, got %d",
+			len(rc.pendingTextBatches[1].Quads))
+	}
+}
+
 // makeCoalesceTestTarget creates a minimal GPURenderTarget for coalescing tests.
 // Uses a non-nil Data slice so sameTarget compares via data pointer identity.
 func makeCoalesceTestTarget() gg.GPURenderTarget {

--- a/internal/gpu/batch_coalescing_test.go
+++ b/internal/gpu/batch_coalescing_test.go
@@ -381,6 +381,108 @@ func TestQueueText_MixedSequence(t *testing.T) {
 	}
 }
 
+// --- Scissor-boundary glyph batch isolation tests ---
+
+// TestQueueGlyphMask_ScissorBoundary_SplitsBatch verifies that same-style glyph
+// runs queued across scissor boundaries are NOT merged into a single batch.
+//
+// Regression test for the bug where QueueGlyphMask merged all same-font/same-color
+// runs into one batch regardless of intervening clip changes.  buildScissorGroups
+// then assigned the entire merged batch to the first element's scissor rect,
+// causing text from all subsequent sibling elements to be clipped away.
+//
+// This test FAILS on the unfixed code (1 merged batch) and PASSES on the fix
+// (3 separate batches, one per scissor region).
+func TestQueueGlyphMask_ScissorBoundary_SplitsBatch(t *testing.T) {
+	rc := &GPURenderContext{}
+	target := makeCoalesceTestTarget()
+
+	white := [4]float32{1, 1, 1, 1}
+	quad := func(x float32) GlyphMaskBatch {
+		return GlyphMaskBatch{
+			Transform:      gg.Identity(),
+			Color:          white,
+			IsLCD:          false,
+			AtlasPageIndex: 0,
+			Quads:          []GlyphMaskQuad{{X0: x, Y0: 0, X1: x + 10, Y1: 10}},
+		}
+	}
+
+	// Simulate three sibling elements each clipped to their own rect.
+	clip1 := [4]uint32{0, 0, 100, 30}
+	clip2 := [4]uint32{0, 30, 100, 30}
+	clip3 := [4]uint32{0, 60, 100, 30}
+
+	// Button 1: set clip, queue text.
+	rc.recordScissorSegment(&clip1)
+	rc.QueueGlyphMask(target, quad(0))
+
+	// Button 2: change clip, queue text with identical style.
+	rc.recordScissorSegment(&clip2)
+	rc.QueueGlyphMask(target, quad(10))
+
+	// Button 3: change clip again, queue text with identical style.
+	rc.recordScissorSegment(&clip3)
+	rc.QueueGlyphMask(target, quad(20))
+
+	if len(rc.pendingGlyphMaskBatches) != 3 {
+		t.Fatalf("expected 3 separate glyph batches (one per scissor region), got %d — "+
+			"same-style runs across scissor boundaries must not be merged",
+			len(rc.pendingGlyphMaskBatches))
+	}
+	for i, b := range rc.pendingGlyphMaskBatches {
+		if len(b.Quads) != 1 {
+			t.Errorf("batch[%d]: expected 1 quad, got %d", i, len(b.Quads))
+		}
+	}
+}
+
+// TestQueueGlyphMask_ScissorBoundary_PreservesIntraGroupMerging verifies that
+// within a single scissor region, same-style consecutive runs still merge.
+// This ensures the seal-on-boundary fix does not break the efficiency of
+// coalescing runs that legitimately share a scissor group.
+func TestQueueGlyphMask_ScissorBoundary_PreservesIntraGroupMerging(t *testing.T) {
+	rc := &GPURenderContext{}
+	target := makeCoalesceTestTarget()
+
+	white := [4]float32{1, 1, 1, 1}
+	quad := func(x float32) GlyphMaskBatch {
+		return GlyphMaskBatch{
+			Transform:      gg.Identity(),
+			Color:          white,
+			IsLCD:          false,
+			AtlasPageIndex: 0,
+			Quads:          []GlyphMaskQuad{{X0: x}},
+		}
+	}
+
+	clip1 := [4]uint32{0, 0, 100, 50}
+	clip2 := [4]uint32{0, 50, 100, 50}
+
+	// Region 1: two runs that should merge.
+	rc.recordScissorSegment(&clip1)
+	rc.QueueGlyphMask(target, quad(0))
+	rc.QueueGlyphMask(target, quad(10)) // same style → merges with previous
+
+	// Region 2: two more runs that should merge with each other but not region 1.
+	rc.recordScissorSegment(&clip2)
+	rc.QueueGlyphMask(target, quad(20))
+	rc.QueueGlyphMask(target, quad(30)) // same style → merges with previous
+
+	if len(rc.pendingGlyphMaskBatches) != 2 {
+		t.Fatalf("expected 2 batches (one per scissor region, each with 2 quads merged), got %d",
+			len(rc.pendingGlyphMaskBatches))
+	}
+	if len(rc.pendingGlyphMaskBatches[0].Quads) != 2 {
+		t.Errorf("region 1 batch: expected 2 merged quads, got %d",
+			len(rc.pendingGlyphMaskBatches[0].Quads))
+	}
+	if len(rc.pendingGlyphMaskBatches[1].Quads) != 2 {
+		t.Errorf("region 2 batch: expected 2 merged quads, got %d",
+			len(rc.pendingGlyphMaskBatches[1].Quads))
+	}
+}
+
 // makeCoalesceTestTarget creates a minimal GPURenderTarget for coalescing tests.
 // Uses a non-nil Data slice so sameTarget compares via data pointer identity.
 func makeCoalesceTestTarget() gg.GPURenderTarget {

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -48,6 +48,15 @@ type GPURenderContext struct {
 	clipPath        *gg.Path // arbitrary clip path for depth clipping (GPU-CLIP-003a)
 	scissorSegments []scissorSegment
 
+	// glyphBatchSealed prevents the next QueueGlyphMask call from merging into
+	// the previous batch when a scissor boundary has been crossed. This ensures
+	// that glyph batches are split at clip changes so buildScissorGroups can
+	// assign each batch to the correct scissor group. Without this, all text
+	// runs sharing the same font+color across multiple clipped elements merge
+	// into one batch, which gets assigned to the first element's scissor rect
+	// and clips away text from all subsequent elements.
+	glyphBatchSealed bool
+
 	// Per-context frame tracking (fixes LoadOp corruption).
 	// When frameRendered is true, subsequent render passes use LoadOpLoad.
 	// Reset by BeginFrame() at the start of each frame.
@@ -143,6 +152,7 @@ func (rc *GPURenderContext) BeginFrame() {
 	rc.clipPath = nil
 	rc.frameRendered = false
 	rc.lastView = nil
+	rc.glyphBatchSealed = false
 }
 
 // SetSharedEncoder sets a shared command encoder for single-command-buffer
@@ -349,7 +359,10 @@ func (rc *GPURenderContext) QueueGlyphMask(target gg.GPURenderTarget, batch Glyp
 		}
 	}
 	// Coalesce with last pending batch if same visual properties (ADR-031).
-	if n := len(rc.pendingGlyphMaskBatches); n > 0 {
+	// Skip merging if a scissor boundary was crossed since the last batch was
+	// queued (glyphBatchSealed=true); this keeps glyph batches within the
+	// correct scissor group so text is not clipped by a sibling element's rect.
+	if n := len(rc.pendingGlyphMaskBatches); n > 0 && !rc.glyphBatchSealed {
 		last := &rc.pendingGlyphMaskBatches[n-1]
 		if last.CanMerge(batch) {
 			last.Quads = append(last.Quads, batch.Quads...)
@@ -358,6 +371,7 @@ func (rc *GPURenderContext) QueueGlyphMask(target gg.GPURenderTarget, batch Glyp
 			return
 		}
 	}
+	rc.glyphBatchSealed = false // new batch started; allow future merges within same scissor region
 	rc.pendingGlyphMaskBatches = append(rc.pendingGlyphMaskBatches, batch)
 	rc.pendingTarget = target
 	rc.hasPendingTarget = true
@@ -896,7 +910,11 @@ func (rc *GPURenderContext) Close() {
 }
 
 // recordScissorSegment records a scissor state change in the timeline.
+// It also seals the last glyph batch so that the next QueueGlyphMask call
+// starts a new batch entry instead of merging, ensuring glyph batches stay
+// within the correct scissor group (see glyphBatchSealed).
 func (rc *GPURenderContext) recordScissorSegment(rect *[4]uint32) {
+	rc.glyphBatchSealed = true
 	seg := scissorSegment{
 		sdfCount:     len(rc.pendingShapes),
 		convexCount:  len(rc.pendingConvexCommands),

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -48,14 +48,14 @@ type GPURenderContext struct {
 	clipPath        *gg.Path // arbitrary clip path for depth clipping (GPU-CLIP-003a)
 	scissorSegments []scissorSegment
 
-	// glyphBatchSealed prevents the next QueueGlyphMask call from merging into
-	// the previous batch when a scissor boundary has been crossed. This ensures
-	// that glyph batches are split at clip changes so buildScissorGroups can
-	// assign each batch to the correct scissor group. Without this, all text
+	// textBatchSealed prevents the next QueueGlyphMask or QueueText call from
+	// merging into the previous batch when a scissor boundary has been crossed.
+	// This ensures that text batches are split at clip changes so buildScissorGroups
+	// can assign each batch to the correct scissor group. Without this, all text
 	// runs sharing the same font+color across multiple clipped elements merge
 	// into one batch, which gets assigned to the first element's scissor rect
 	// and clips away text from all subsequent elements.
-	glyphBatchSealed bool
+	textBatchSealed bool
 
 	// Per-context frame tracking (fixes LoadOp corruption).
 	// When frameRendered is true, subsequent render passes use LoadOpLoad.
@@ -152,7 +152,7 @@ func (rc *GPURenderContext) BeginFrame() {
 	rc.clipPath = nil
 	rc.frameRendered = false
 	rc.lastView = nil
-	rc.glyphBatchSealed = false
+	rc.textBatchSealed = false
 }
 
 // SetSharedEncoder sets a shared command encoder for single-command-buffer
@@ -264,7 +264,10 @@ func (rc *GPURenderContext) QueueText(target gg.GPURenderTarget, batch TextBatch
 		}
 	}
 	// Coalesce with last pending batch if same visual properties (ADR-031).
-	if n := len(rc.pendingTextBatches); n > 0 {
+	// Skip merging if a scissor boundary was crossed since the last batch was
+	// queued (textBatchSealed=true); this keeps text batches within the
+	// correct scissor group so text is not clipped by a sibling element's rect.
+	if n := len(rc.pendingTextBatches); n > 0 && !rc.textBatchSealed {
 		last := &rc.pendingTextBatches[n-1]
 		if last.CanMerge(batch) {
 			last.Quads = append(last.Quads, batch.Quads...)
@@ -273,6 +276,7 @@ func (rc *GPURenderContext) QueueText(target gg.GPURenderTarget, batch TextBatch
 			return
 		}
 	}
+	rc.textBatchSealed = false // new batch started; allow future merges within same scissor region
 	rc.pendingTextBatches = append(rc.pendingTextBatches, batch)
 	rc.pendingTarget = target
 	rc.hasPendingTarget = true
@@ -360,9 +364,9 @@ func (rc *GPURenderContext) QueueGlyphMask(target gg.GPURenderTarget, batch Glyp
 	}
 	// Coalesce with last pending batch if same visual properties (ADR-031).
 	// Skip merging if a scissor boundary was crossed since the last batch was
-	// queued (glyphBatchSealed=true); this keeps glyph batches within the
+	// queued (textBatchSealed=true); this keeps text batches within the
 	// correct scissor group so text is not clipped by a sibling element's rect.
-	if n := len(rc.pendingGlyphMaskBatches); n > 0 && !rc.glyphBatchSealed {
+	if n := len(rc.pendingGlyphMaskBatches); n > 0 && !rc.textBatchSealed {
 		last := &rc.pendingGlyphMaskBatches[n-1]
 		if last.CanMerge(batch) {
 			last.Quads = append(last.Quads, batch.Quads...)
@@ -371,7 +375,7 @@ func (rc *GPURenderContext) QueueGlyphMask(target gg.GPURenderTarget, batch Glyp
 			return
 		}
 	}
-	rc.glyphBatchSealed = false // new batch started; allow future merges within same scissor region
+	rc.textBatchSealed = false // new batch started; allow future merges within same scissor region
 	rc.pendingGlyphMaskBatches = append(rc.pendingGlyphMaskBatches, batch)
 	rc.pendingTarget = target
 	rc.hasPendingTarget = true
@@ -906,15 +910,16 @@ func (rc *GPURenderContext) Close() {
 	rc.clipRRect = nil
 	rc.clipPath = nil
 	rc.scissorSegments = nil
+	rc.textBatchSealed = false
 	rc.sceneStats = gg.SceneStats{}
 }
 
 // recordScissorSegment records a scissor state change in the timeline.
-// It also seals the last glyph batch so that the next QueueGlyphMask call
-// starts a new batch entry instead of merging, ensuring glyph batches stay
-// within the correct scissor group (see glyphBatchSealed).
+// It also seals the last text batch so that the next QueueGlyphMask or
+// QueueText call starts a new batch entry instead of merging, ensuring text
+// batches stay within the correct scissor group (see textBatchSealed).
 func (rc *GPURenderContext) recordScissorSegment(rect *[4]uint32) {
-	rc.glyphBatchSealed = true
+	rc.textBatchSealed = true
 	seg := scissorSegment{
 		sdfCount:     len(rc.pendingShapes),
 		convexCount:  len(rc.pendingConvexCommands),


### PR DESCRIPTION
Fixes https://github.com/gogpu/gg/issues/340

When adjacent clipped elements (e.g. sibling buttons) share the same font and text color, QueueGlyphMask was merging all their text runs into a single GlyphMaskBatch. buildScissorGroups then assigned that merged batch to the first element's scissor rect, clipping away text from every subsequent sibling. Fills rendered on top made the text appear invisible.

Fix: add a glyphBatchSealed bool to GPURenderContext. recordScissorSegment sets it on every clip state change. QueueGlyphMask skips merging when the flag is set, starting a new batch entry instead, and resets the flag. Merging within the same scissor region is preserved for efficiency.

Adds two regression tests in batch_coalescing_test.go:
- TestQueueGlyphMask_ScissorBoundary_SplitsBatch: same-style runs across three scissor regions must produce three separate batches.
- TestQueueGlyphMask_ScissorBoundary_PreservesIntraGroupMerging: runs within the same region still coalesce as before.