### PR TITLE
feat(pixmap): add NewPixmapFromBuffer and ImageView for zero-copy use

### DIFF
--- a/pixmap.go
+++ b/pixmap.go
@@ -42,6 +42,26 @@ func NewPixmap(width, height int) *Pixmap {
 	}
 }
 
+// NewPixmapFromBuffer wraps an existing premultiplied-RGBA buffer as a Pixmap
+// without allocating. The Pixmap aliases buf[:width*height*4]; the caller
+// keeps ownership and must not reuse buf until the Pixmap is done.
+// Panics on non-positive dimensions or undersized buf.
+func NewPixmapFromBuffer(buf []uint8, width, height int) *Pixmap {
+	if width <= 0 || height <= 0 {
+		panic("gg: NewPixmapFromBuffer: width and height must be > 0")
+	}
+	need := width * height * 4
+	if len(buf) < need {
+		panic("gg: NewPixmapFromBuffer: buffer too small")
+	}
+	return &Pixmap{
+		width:  width,
+		height: height,
+		data:   buf[:need],
+		genID:  nextPixmapGenID.Add(1),
+	}
+}
+
 // GenerationID returns the unique identifier for this pixmap's current content.
 // Used by GPU texture cache to avoid stale texture reuse (ADR-014).
 // The ID changes when NotifyPixelsChanged() is called.
@@ -206,6 +226,17 @@ func (p *Pixmap) ToImage() *image.RGBA {
 	img := image.NewRGBA(image.Rect(0, 0, p.width, p.height))
 	copy(img.Pix, p.data)
 	return img
+}
+
+// ImageView returns an *image.RGBA whose Pix aliases the pixmap's buffer
+// (zero-copy alternative to ToImage). External writes through the returned
+// image must be followed by NotifyPixelsChanged for GPU cache correctness.
+func (p *Pixmap) ImageView() *image.RGBA {
+	return &image.RGBA{
+		Pix:    p.data,
+		Stride: p.width * 4,
+		Rect:   image.Rect(0, 0, p.width, p.height),
+	}
 }
 
 // FromImage creates a pixmap from an image.

--- a/pixmap.go
+++ b/pixmap.go
@@ -45,12 +45,33 @@ func NewPixmap(width, height int) *Pixmap {
 // NewPixmapFromBuffer wraps an existing premultiplied-RGBA buffer as a Pixmap
 // without allocating. The Pixmap aliases buf[:width*height*4]; the caller
 // keeps ownership and must not reuse buf until the Pixmap is done.
-// Panics on non-positive dimensions or undersized buf.
+// Panics on non-positive dimensions, dimensions that overflow int, or undersized buf.
+//
+// After modifying the buffer externally, call NotifyPixelsChanged() to
+// invalidate cached GPU textures (ADR-014).
+//
+// The Pixmap holds a reference to buf's backing array; the garbage collector
+// will not free the array while the Pixmap exists.
+//
+// The Pixmap is not safe for concurrent use. External writes to buf must
+// not overlap with gg drawing operations on this Pixmap.
 func NewPixmapFromBuffer(buf []uint8, width, height int) *Pixmap {
 	if width <= 0 || height <= 0 {
 		panic("gg: NewPixmapFromBuffer: width and height must be > 0")
 	}
-	need := width * height * 4
+	// Guard against silent overflow on 32-bit platforms (GOARCH=386/arm):
+	// e.g. 32768*32768*4 wraps to 0 in a 32-bit int, defeating the size check.
+	// Capping each dimension at 2^30 keeps width*height*4 within int64 range
+	// (max 2^62 < 2^63-1) before the int conversion check below.
+	const maxDim = 1 << 30
+	if width > maxDim || height > maxDim {
+		panic("gg: NewPixmapFromBuffer: width or height too large")
+	}
+	need64 := int64(width) * int64(height) * 4
+	if need64 > int64(^uint(0)>>1) {
+		panic("gg: NewPixmapFromBuffer: width*height*4 overflows int")
+	}
+	need := int(need64)
 	if len(buf) < need {
 		panic("gg: NewPixmapFromBuffer: buffer too small")
 	}

--- a/pixmap_test.go
+++ b/pixmap_test.go
@@ -646,6 +646,20 @@ func TestNewPixmapFromBuffer_PanicBadDims(t *testing.T) {
 	}
 }
 
+func TestNewPixmapFromBuffer_PanicOverflow(t *testing.T) {
+	// Dimensions that would silently wrap width*height*4 to 0 on 32-bit int
+	// (GOARCH=386/arm) must panic on every platform — otherwise the size
+	// check passes with need=0 and subsequent pixel writes go out of bounds.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for oversized dimensions")
+		}
+	}()
+	// 32768*32768*4 = 2^32 which wraps to 0 in 32-bit int.
+	// On 64-bit this is also rejected by the maxDim (2^30) guard.
+	NewPixmapFromBuffer(make([]uint8, 16), 32768, 32768)
+}
+
 func TestPixmap_ImageView(t *testing.T) {
 	const w, h = 5, 4
 	pm := NewPixmap(w, h)

--- a/pixmap_test.go
+++ b/pixmap_test.go
@@ -584,3 +584,105 @@ func TestPixmap_FillRect_GenID(t *testing.T) {
 		t.Error("genID should change after FillRect")
 	}
 }
+
+func TestNewPixmapFromBuffer(t *testing.T) {
+	const w, h = 4, 3
+	buf := make([]uint8, w*h*4)
+	pm := NewPixmapFromBuffer(buf, w, h)
+
+	if pm.Width() != w || pm.Height() != h {
+		t.Fatalf("dims got (%d,%d) want (%d,%d)", pm.Width(), pm.Height(), w, h)
+	}
+
+	// Write through pixmap → expect to read back via buffer.
+	pm.SetPixelPremul(1, 2, 10, 20, 30, 40)
+	i := (2*w + 1) * 4
+	if buf[i] != 10 || buf[i+1] != 20 || buf[i+2] != 30 || buf[i+3] != 40 {
+		t.Errorf("buffer not aliased: got (%d,%d,%d,%d)", buf[i], buf[i+1], buf[i+2], buf[i+3])
+	}
+
+	// Write through buffer → expect to read back via pixmap.At().
+	j := (0*w + 0) * 4
+	buf[j+0], buf[j+1], buf[j+2], buf[j+3] = 1, 2, 3, 4
+	r, g, b, a := pm.At(0, 0).RGBA()
+	if r/257 != 1 || g/257 != 2 || b/257 != 3 || a/257 != 4 {
+		t.Errorf("pixmap did not see external write: At got (%d,%d,%d,%d)/257", r/257, g/257, b/257, a/257)
+	}
+
+	// Data() should return the exact same backing array.
+	if &pm.Data()[0] != &buf[0] {
+		t.Error("Data() returned a copy instead of aliasing")
+	}
+}
+
+func TestNewPixmapFromBuffer_OverSizedBuffer(t *testing.T) {
+	const w, h = 2, 2
+	buf := make([]uint8, w*h*4*4) // 4x oversize
+	pm := NewPixmapFromBuffer(buf, w, h)
+	if len(pm.Data()) != w*h*4 {
+		t.Errorf("pixmap data length got %d, want %d", len(pm.Data()), w*h*4)
+	}
+}
+
+func TestNewPixmapFromBuffer_PanicSmallBuffer(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for undersized buffer")
+		}
+	}()
+	NewPixmapFromBuffer(make([]uint8, 4), 10, 10)
+}
+
+func TestNewPixmapFromBuffer_PanicBadDims(t *testing.T) {
+	for _, dims := range [][2]int{{0, 10}, {10, 0}, {-1, 10}, {10, -1}} {
+		func() {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic for dims %v", dims)
+				}
+			}()
+			NewPixmapFromBuffer(make([]uint8, 4096), dims[0], dims[1])
+		}()
+	}
+}
+
+func TestPixmap_ImageView(t *testing.T) {
+	const w, h = 5, 4
+	pm := NewPixmap(w, h)
+	pm.SetPixelPremul(2, 1, 90, 80, 70, 60)
+
+	img := pm.ImageView()
+	if img.Bounds() != image.Rect(0, 0, w, h) {
+		t.Errorf("bounds got %v, want %v", img.Bounds(), image.Rect(0, 0, w, h))
+	}
+	if img.Stride != w*4 {
+		t.Errorf("stride got %d, want %d", img.Stride, w*4)
+	}
+	if &img.Pix[0] != &pm.Data()[0] {
+		t.Error("ImageView did not alias pixmap data")
+	}
+
+	// Read via image.RGBA.
+	i := img.PixOffset(2, 1)
+	if img.Pix[i] != 90 || img.Pix[i+1] != 80 || img.Pix[i+2] != 70 || img.Pix[i+3] != 60 {
+		t.Errorf("image view pixel mismatch")
+	}
+
+	// Mutating via the image must reflect in the pixmap.
+	img.Pix[i] = 200
+	if pm.Data()[(1*w+2)*4] != 200 {
+		t.Error("write through image view not visible in pixmap")
+	}
+}
+
+func TestPixmap_ImageView_ExternalBuffer(t *testing.T) {
+	const w, h = 8, 8
+	buf := make([]uint8, w*h*4)
+	pm := NewPixmapFromBuffer(buf, w, h)
+	img := pm.ImageView()
+
+	// Same backing array all three ways.
+	if &img.Pix[0] != &buf[0] || &pm.Data()[0] != &buf[0] {
+		t.Fatal("buffer / pixmap.Data() / image.Pix must share storage")
+	}
+}


### PR DESCRIPTION

## Motivation

In hot rendering loops, `gg.NewContext(w, h)` allocates a fresh pixmap buffer (`w*h*4` bytes) every call, and `dc.Image()` allocates a new `image.RGBA` and copies the entire
buffer. For a software IME drawing a candidate window on every keystroke, this dominates GC pressure — a pprof from my project showed `gg.NewPixmap` + `image.NewRGBA` accounting
 for ~2.3 GB of cumulative allocation over a ~12 GB total run.

The root cause is that there is currently no way for callers to reuse their own backing buffers across frames: `NewPixmap` always allocates internally, and `ToImage` always
copies.

## Changes

Two purely additive APIs on `Pixmap`:

- **`NewPixmapFromBuffer(buf []uint8, w, h int) *Pixmap`** — wrap a caller-owned premultiplied-RGBA buffer as a Pixmap without allocating. The Pixmap aliases `buf[:w*h*4]`;
ownership stays with the caller.
- **`(*Pixmap).ImageView() *image.RGBA`** — zero-copy alternative to `ToImage`. Returns an `*image.RGBA` whose `Pix` aliases the pixmap's buffer.

Together they enable an external buffer to flow through `gg` drawing and `image.RGBA`-consuming APIs (e.g. `golang.org/x/image/font`) with **zero per-frame allocations**:

```go
// caller pools buf across frames
buf := pool.Get().([]byte) // cap >= w*h*4
pm := gg.NewPixmapFromBuffer(buf, w, h)
dc := gg.NewContextForPixmap(pm)
// ... drawing ...
img := pm.ImageView()      // no copy
fontDrawer.Dst = img        // share buffer
// ... font rendering ...
pool.Put(buf)
```

## Compatibility

Purely additive — no existing API is touched. The premultiplied-RGBA layout used by `Pixmap` is identical to `image.RGBA.Pix` (which is why the existing `ToImage` works as a
simple `copy`), so the alias is byte-equivalent. GPU texture cache invariants (ADR-014) are preserved: external writes through `ImageView` require an explicit
`NotifyPixelsChanged()` from the caller, same as other direct-write paths.

## Tests

6 new tests in `pixmap_test.go` cover:
- Aliasing semantics (write-via-pixmap visible in buffer, write-via-buffer visible via `At()`)
- Three-way shared storage (buf / `Data()` / `ImageView().Pix`)
- Oversized buffer tolerance (buffer pool use case)
- Panic paths (undersized buffer, non-positive dimensions)
- `ImageView` write-through to pixmap

All existing `Pixmap*` tests continue to pass.