### PR TITLE
fix: stroke expander match Rust kurbo output (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.2] - 2026-05-22
+
+### Fixed
+
+- **Stroke expander: match Rust kurbo output** (#347) — root cause fix for stroke
+  rendering. Inner join handler emitted extra `lineTo(pivot+afterNorm)` and skip-threshold
+  path emitted connecting segments that Rust kurbo does not. Result: 397 elements (Go) vs
+  201 (Rust kurbo) with 196 duplicate points creating self-intersecting outlines. Fixed to
+  produce identical 201-element output matching Rust kurbo golden reference.
+
+- **Stroke fills routed through AnalyticFiller** — architectural routing matching Skia Ganesh
+  pattern (strokes → scanline renderer, not tile rasterizer). Multi-contour closed-path
+  strokes (e.g., glyph "O" → 4 contours) require per-scanline winding tracking.
+
+### Added
+
+- Golden test `TestStrokeExpander_SineWaveGolden` — verifies 201 elements, 0 duplicate
+  points, 0 self-intersections, key coordinates match Rust kurbo.
+
 ## [0.48.1] - 2026-05-22
 
 ### Fixed

--- a/internal/stroke/expander.go
+++ b/internal/stroke/expander.go
@@ -344,12 +344,11 @@ func (e *StrokeExpander) joinWithPrevious(p0 Point, norm, tan0 Vec2) {
 	dot := ab.Dot(cd)
 	hypot := math.Hypot(cross, dot)
 
-	// Skip join if angle change is insignificant, but still connect paths
-	// to maintain continuity. Without the lineTo calls, the forward/backward
-	// paths have a gap at circle cardinal points where tangents are identical.
+	// Skip join if angle change is insignificant (kurbo stroke.rs:428).
+	// Rust kurbo emits nothing here — the paths continue without explicit
+	// connecting segments. The connection happens implicitly from the next
+	// doLine() which adds lineTo for both forward and backward paths.
 	if dot > 0.0 && math.Abs(cross) < hypot*e.joinThresh {
-		e.forward.lineTo(p0.Add(norm.Neg()))
-		e.backward.lineTo(p0.Add(norm))
 		return
 	}
 
@@ -375,15 +374,12 @@ func (e *StrokeExpander) joinWithPrevious(p0 Point, norm, tan0 Vec2) {
 }
 
 // handleInnerJoin handles the concave (inner) side of a join.
-// Routes through the pivot point to prevent self-intersection artifacts.
-//
-// This follows Skia/tiny-skia's handle_inner_join pattern (stroker.rs:1370-1379):
-// In the degenerate case that the stroke radius is larger than our segments,
-// just connecting the two inner segments may "show through" as a funny diagonal.
-// To fix this, we go through the pivot point, creating a V-shape.
-func (e *StrokeExpander) handleInnerJoin(path *pathBuilder, pivot Point, afterNorm Vec2) {
+// Routes through the pivot point (kurbo stroke.rs:445/452).
+// Kurbo emits only lineTo(p0) for the inner side — the connection to the
+// new normal position comes from the unconditional lineTo in doLine(),
+// not from a second lineTo here.
+func (e *StrokeExpander) handleInnerJoin(path *pathBuilder, pivot Point, _ Vec2) {
 	path.lineTo(pivot)
-	path.lineTo(pivot.Add(afterNorm))
 }
 
 // applyOuterJoin applies the requested join type to the outer (convex) side of a join.

--- a/internal/stroke/expander_golden_test.go
+++ b/internal/stroke/expander_golden_test.go
@@ -1,0 +1,173 @@
+package stroke
+
+import (
+	"math"
+	"testing"
+)
+
+// TestStrokeExpander_SineWaveGolden verifies that stroke expansion of a
+// 100-segment damped sine wave matches the Rust kurbo reference output.
+// Golden values from: kurbo/examples/stroke_debug.rs (2px, butt cap, miter join, limit 10).
+//
+// This is the regression test for issue #347: extra inner join + skip-threshold
+// segments caused self-intersecting outlines that broke tile-based rasterizers.
+func TestStrokeExpander_SineWaveGolden(t *testing.T) {
+	path := buildSineWavePath(100)
+	style := Stroke{Width: 2.0, Cap: LineCapButt, Join: LineJoinMiter, MiterLimit: 10.0}
+	expander := NewStrokeExpander(style)
+	outVerbs, outCoords := expander.Expand(path.verbs, path.coords)
+
+	// Golden: Rust kurbo produces 201 elements (1 MoveTo + 199 LineTo + 1 Close)
+	wantElements := 201
+	if len(outVerbs) != wantElements {
+		t.Fatalf("element count: got %d, want %d (Rust kurbo golden)", len(outVerbs), wantElements)
+	}
+
+	// Verify verb composition
+	var moves, lines, closes int
+	for _, v := range outVerbs {
+		switch v {
+		case VerbMoveTo:
+			moves++
+		case VerbLineTo:
+			lines++
+		case VerbClose:
+			closes++
+		}
+	}
+	if moves != 1 || lines != 199 || closes != 1 {
+		t.Fatalf("verb counts: MoveTo=%d LineTo=%d Close=%d, want 1/199/1", moves, lines, closes)
+	}
+
+	// Verify no duplicate adjacent points (the #347 bug signature)
+	points := extractPoints(outVerbs, outCoords)
+	dups := 0
+	for i := 1; i < len(points); i++ {
+		if points[i][0] == points[i-1][0] && points[i][1] == points[i-1][1] {
+			dups++
+		}
+	}
+	if dups > 0 {
+		t.Errorf("found %d duplicate adjacent points (should be 0 after #347 fix)", dups)
+	}
+
+	// Verify key coordinates match Rust kurbo golden (±0.1 tolerance for float64 vs f64)
+	goldenFirst := [][2]float64{
+		{49.1, 249.7}, {56.1, 229.9}, {63.1, 210.7}, {70.1, 192.3}, {77.1, 174.8},
+	}
+	goldenLast := [][2]float64{
+		{78.9, 175.5}, {71.9, 193.0}, {64.9, 211.4}, {57.9, 230.6}, {50.9, 250.3},
+	}
+
+	for i, g := range goldenFirst {
+		if !closeEnough(points[i], g, 0.15) {
+			t.Errorf("point[%d]: got (%.1f,%.1f), want (%.1f,%.1f)", i, points[i][0], points[i][1], g[0], g[1])
+		}
+	}
+	for i, g := range goldenLast {
+		idx := len(points) - len(goldenLast) + i
+		if !closeEnough(points[idx], g, 0.15) {
+			t.Errorf("point[%d]: got (%.1f,%.1f), want (%.1f,%.1f)", idx, points[idx][0], points[idx][1], g[0], g[1])
+		}
+	}
+
+	// Verify no self-intersections (simple polygon)
+	crossings := countSelfIntersections(points)
+	if crossings > 0 {
+		t.Errorf("found %d self-intersections (should be 0 for simple polygon)", crossings)
+	}
+
+	t.Logf("OK: %d elements, %d points, 0 duplicates, 0 self-intersections (matches Rust kurbo)", len(outVerbs), len(points))
+}
+
+// TestStrokeExpander_ClosedRectGolden verifies stroke of a closed rectangle.
+func TestStrokeExpander_ClosedRectGolden(t *testing.T) {
+	p := &soaPath{}
+	p.moveTo(10, 10).lineTo(90, 10).lineTo(90, 90).lineTo(10, 90).close()
+
+	style := Stroke{Width: 4.0, Cap: LineCapButt, Join: LineJoinMiter, MiterLimit: 10.0}
+	expander := NewStrokeExpander(style)
+	outVerbs, _ := expander.Expand(p.verbs, p.coords)
+
+	// Closed rect stroke: 2 contours (forward ring + backward ring)
+	var moves, closes int
+	for _, v := range outVerbs {
+		switch v {
+		case VerbMoveTo:
+			moves++
+		case VerbClose:
+			closes++
+		}
+	}
+	if moves != 2 || closes != 2 {
+		t.Errorf("closed rect stroke: MoveTo=%d Close=%d, want 2/2 (two contours)", moves, closes)
+	}
+}
+
+func buildSineWavePath(n int) *soaPath {
+	p := &soaPath{}
+	for i := 0; i < n; i++ {
+		t := float64(i) * 0.1
+		x := 50 + t*70
+		y := 250 - math.Sin(t)*math.Exp(-t*0.1)*200
+		if i == 0 {
+			p.moveTo(x, y)
+		} else {
+			p.lineTo(x, y)
+		}
+	}
+	return p
+}
+
+func extractPoints(verbs []PathVerb, coords []float64) [][2]float64 {
+	var pts [][2]float64
+	ci := 0
+	for _, v := range verbs {
+		switch v {
+		case VerbMoveTo, VerbLineTo:
+			pts = append(pts, [2]float64{coords[ci], coords[ci+1]})
+			ci += 2
+		case VerbQuadTo:
+			ci += 4
+		case VerbCubicTo:
+			ci += 6
+		case VerbClose:
+		}
+	}
+	return pts
+}
+
+func closeEnough(a, b [2]float64, tol float64) bool {
+	return math.Abs(a[0]-b[0]) < tol && math.Abs(a[1]-b[1]) < tol
+}
+
+func countSelfIntersections(pts [][2]float64) int {
+	n := len(pts)
+	count := 0
+	for i := 0; i < n; i++ {
+		a1, a2 := pts[i], pts[(i+1)%n]
+		for j := i + 2; j < n; j++ {
+			if j == (i+n-1)%n {
+				continue
+			}
+			b1, b2 := pts[j], pts[(j+1)%n]
+			if segsCross(a1, a2, b1, b2) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func segsCross(a1, a2, b1, b2 [2]float64) bool {
+	d1 := crossPt(b1, b2, a1)
+	d2 := crossPt(b1, b2, a2)
+	d3 := crossPt(a1, a2, b1)
+	d4 := crossPt(a1, a2, b2)
+	return ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+		((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))
+}
+
+func crossPt(a, b, c [2]float64) float64 {
+	return (b[0]-a[0])*(c[1]-a[1]) - (b[1]-a[1])*(c[0]-a[0])
+}

--- a/software.go
+++ b/software.go
@@ -846,13 +846,13 @@ func (r *SoftwareRenderer) Stroke(pixmap *Pixmap, p *Path, paint *Paint) error {
 	}
 	strokeResultToPath(r.scratchStrokePath, outVerbs, outCoords)
 
-	// Force analytic (scanline) rasterizer for stroke-expanded fills.
-	// The tile-based SparseStripsFiller has a winding propagation bug
-	// (accumulated winding not carried between adjacent tiles) that causes
-	// self-intersecting stroke outlines to render 2.2x thicker than correct.
-	// The AnalyticFiller's per-scanline edge walk correctly handles winding
-	// cancellation at self-intersections. Fixes #347.
-	// See: BUG-SPARSE-STRIPS-001 for the underlying tile rasterizer issue.
+	// Route stroke fills through AnalyticFiller (Skia AAA scanline).
+	// Stroke-expanded multi-contour outlines (e.g., closed path → 4 contours)
+	// require per-scanline winding tracking that the tile-based SparseStripsFiller
+	// does not support (Vello's strip pipeline uses per-strip fill_gap flags).
+	// This matches Skia Ganesh which routes strokes through scanline renderers,
+	// not tile rasterizers. Single-contour strokes work with either filler after
+	// the expander.go fix (#347), but multi-contour needs scanline.
 	prevMode := r.rasterizerMode
 	r.rasterizerMode = RasterizerAnalytic
 	err := r.Fill(pixmap, r.scratchStrokePath, paint)


### PR DESCRIPTION
Root cause fix for #347. Stroke expander inner join + skip-threshold produced 397 elements vs kurbo's 201. Now matches Rust kurbo golden. Details in v0.48.1 PR.