### PR TITLE
fix: SDF thin stroke fallback + winding propagation (#346, BUG-SPARSE-STRIPS-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.6] - 2026-05-26
+
+### Fixed
+
+- **SDF thin stroke invisible on GPU** (#346, ADR-040) — SDF stroke with `lineWidth < 2.0`
+  now falls back to geometric expansion. The SDF annular ring at sub-2px widths is thinner
+  than the smoothstep AA zone, producing near-zero coverage. Affects both CPU SDF accelerator
+  and GPU render context. M3 Outlined button (lineWidth=1.5) now renders correctly.
+
+- **Present damage union** (TASK-GG-PRESENT-DAMAGE-UNION) — `forwardDamageRects` now unions
+  explicit rects from `SetPresentDamage()` with immediate-mode `FrameDamage`, never letting
+  caller understate actual damage. Previously explicit rects overrode frame damage, causing
+  DWM flickering when debug overlay drew outside declared damage region.
+
 ## [0.48.5] - 2026-05-25
 
 ### Fixed
@@ -19,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on CPU-only contexts (`gg.NewContext()` + `SavePNG()`). Uses per-glyph `NoAAFiller`
   rasterization (binary 0/255 coverage), matching Skia `SkFont::Edging::kAlias` and
   GPU Tier 6 path. Previously fell back to `x/image/font.Drawer` which always anti-aliases.
+
+- **SDF thin stroke invisible on GPU** (#346, ADR-040) — SDF stroke with `lineWidth < 2.0`
+  now falls back to geometric expansion. The SDF annular ring at sub-2px widths is thinner
+  than the smoothstep AA zone, producing near-zero coverage. Affects both CPU SDF accelerator
+  and GPU render context. M3 Outlined button (lineWidth=1.5) now renders correctly.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **SparseStripsFiller winding propagation** (BUG-SPARSE-STRIPS-001) — interior tiles
+  between shape edges rendered as empty gaps. Fixed backdrop calculation to use Vello
+  `backdrop.wgsl` prefix-sum pattern, added `windingDelta` propagation between non-adjacent
+  tiles (Rust Vello `strip.rs:259-263`), and backdrop-only tile emission for filled interiors.
+
 - **SDF thin stroke invisible on GPU** (#346, ADR-040) — SDF stroke with `lineWidth < 2.0`
   now falls back to geometric expansion. The SDF annular ring at sub-2px widths is thinner
   than the smoothstep AA zone, producing near-zero coverage. Affects both CPU SDF accelerator

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 |----------|--------------|
 | **Rendering** | Immediate and retained mode, seven-tier GPU acceleration (SDF, Convex, Stencil+Cover, Textured Quad, MSDF Text, Compute, Glyph Mask), per-context GPU isolation (Skia GrContext pattern), scene GPU auto-select, Skia AAA pixel-perfect rasterizer, **pixel-perfect mode** (`SetAntiAlias(false)` — dedicated NoAAFiller, Skia/Cairo/tiny-skia pattern), CPU fallback |
 | **Shapes** | Rectangles, circles, ellipses, arcs, bezier curves, polygons, stars |
-| **Text** | TrueType fonts, MSDF + glyph mask dual-strategy rendering, TextMode auto-selection, **text stroke/outline** (StrokeString + TextPath, Skia/Cairo/HTML5 pattern), **aliased text** (TextModeAliased, Skia kAlias binary masks), DPI-aware HiDPI text, **ClearType LCD auto-detection** (Windows SPI + registry, macOS grayscale, Linux Xft/Wayland), **CJK script-aware rendering** (ADR-027: per-script hinting, exact-size rasterization, dual MSDF atlas 64/128px), font hinting (auto-hinter + CJK vertical-only), transform-aware CPU text (scale/rotate/shear), glyph outline caching, emoji support, bidirectional text, HarfBuzz shaping, scene text via TagText glyph references (shape-once, Skia drawTextBlob pattern), atlas zoom resilience (size buckets + frame-based compaction) |
+| **Text** | TrueType fonts, MSDF + glyph mask dual-strategy rendering, TextMode auto-selection, **text stroke/outline** (StrokeString + TextPath, Skia/Cairo/HTML5 pattern), **aliased text** (TextModeAliased, Skia kAlias binary masks — GPU + CPU), **per-glyph rendering** (fractional advances, Skia linearMetrics pattern), DPI-aware HiDPI text, **ClearType LCD auto-detection** (Windows SPI + registry, macOS grayscale, Linux Xft/Wayland), **CJK script-aware rendering** (ADR-027: per-script hinting, exact-size rasterization, dual MSDF atlas 64/128px), font hinting (auto-hinter + CJK vertical-only), transform-aware CPU text (scale/rotate/shear), glyph outline caching, emoji support, bidirectional text, HarfBuzz shaping, scene text via TagText glyph references (shape-once, Skia drawTextBlob pattern), atlas zoom resilience (size buckets + frame-based compaction) |
 | **Compositing** | 29 blend modes (Porter-Duff, Advanced, HSL), layer isolation, alpha masks, zero-readback compositor (non-MSAA blit fast path, **HiDPI-aware damage tracking** (logical→physical scaling for OS compositor), damage-aware multi-rect sub-region updates, per-draw dynamic scissor ADR-028) |
 | **Images** | 7 pixel formats, PNG/JPEG/WebP I/O, mipmaps, affine transforms |
 | **SVG** | Full SVG renderer (`gg/svg`): parse + render SVG XML with color override for theming, SVG path data parser (`ParseSVGPath`), transform-aware `FillPath`/`StrokePath` |
@@ -154,11 +154,13 @@ path := dc.TextPath("Hello", x, y)
 
 ### Aliased Text
 
-Pixel-perfect text with binary coverage (Skia `SkFont::Edging::kAlias`):
+Pixel-perfect text with binary coverage (Skia `SkFont::Edging::kAlias`).
+Works on both GPU and CPU — no GPU required:
 
 ```go
 dc.SetTextMode(gg.TextModeAliased)  // no gray edge pixels on text
 dc.DrawString("Pixel Perfect", x, y)
+dc.SavePNG("aliased.png")           // works standalone, no import _ "gg/gpu" needed
 ```
 
 Geometry AA (`SetAntiAlias`) and text AA (`SetTextMode`) are independent — matching

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,90 +19,60 @@
 
 ---
 
-## Current State: v0.46.9
+## Current State: v0.48.6
 
 ✅ **Production-ready** with GPU-accelerated rendering:
-- **CJK text rendering** (ADR-027) — script-aware hinting, exact-size rasterization, dual MSDF atlas 64/128px, TTC collection support. Enterprise patterns: Skia, FreeType, DirectWrite, Core Text
-- **Damage-aware compositing** (ADR-026) — LoadOpLoad + scissor, TrackDamageRect, debug overlay dedup. Enterprise patterns: Chrome Viz, Flutter Impeller, Android SurfaceFlinger
+- **Text stroke/outline** (ADR-033) — StrokeString + TextPath, Skia/Cairo/HTML5 pattern
+- **Aliased text** (ADR-034) — TextModeAliased on GPU (Tier 6 NoAAFiller) AND CPU (per-glyph binary rasterization), Skia kAlias parity
+- **Per-glyph text rendering** (ADR-039) — fractional glyph advances (Skia linearMetrics), hinted outlines + fractional positioning
+- **Stroke inner join** (ADR-038) — tiny-skia parity, no teeth on thick strokes
+- **SparseStripsFiller winding** — Vello backdrop.wgsl prefix-sum, windingDelta propagation
+- **SDF thin stroke fallback** (ADR-040) — lineWidth < 2.0 → geometric expansion
+- **NaN safety** (ADR-035) — depth guards on all 12 recursive flatten functions
+- **Damage union** — forwardDamageRects unions explicit + frame damage
+- **CJK text rendering** (ADR-027) — script-aware hinting, exact-size rasterization, dual MSDF atlas 64/128px
+- **Damage-aware compositing** (ADR-026) — LoadOpLoad + scissor, TrackDamageRect, debug overlay dedup
 - **Scene text TagText** (ADR-022) — glyph references, shape-once, DrawShapedGlyphs (Skia drawTextBlob)
-- **Atlas zoom resilience** — Skia size buckets, page reclamation, frame-based compact (ui#94)
 - **ClearType LCD auto-detection** (ADR-024) — Windows SPI, macOS None, Linux Xft/Wayland
-- **Deferred ortho projection** (ADR-025) — Skia sk_RTAdjust, correct offscreen text
 - **Four-level damage pipeline** (ADR-021) — Object Diff → Tile Dirty → GPU Scissor → OS Present
-- **Adapter-aware render mode** (`GOGPU_RENDER_MODE=auto|cpu|gpu`, ADR-020)
-- Canvas API, Text, Images, Clipping, Layers
-- **Seven-tier GPU render pipeline** (SDF + Convex + Stencil-then-Cover + Textured Quad + GPU Texture Composite + MSDF Text + Compute + Glyph Mask)
-- **Zero-readback compositor pipeline** (ADR-015/016)
+- Seven-tier GPU render pipeline (SDF + Convex + Stencil+Cover + Textured Quad + MSDF Text + Compute + Glyph Mask)
+- Zero-readback compositor pipeline (ADR-015/016), single command buffer (ADR-017)
 - All 5 backends: Vulkan, DX12, DX12+DXIL, GLES, Software
-- **Single command buffer compositor** (ADR-017, Flutter Impeller pattern) — CreateSharedEncoder + SetSharedEncoder + SubmitSharedEncoder for multi-context frames
-- **GPU-to-GPU texture compositing** — DrawGPUTexture + CreateOffscreenTexture (Flutter pattern, zero readback)
-- **Bullet-proof encoder lifecycle** — defer-based safety, no silently swallowed errors
-- **Per-context GPU accelerator** (ADR-013) — Skia GrContext pattern, multi-context isolation
-- **Skia AAA pixel-perfect rasterizer** — trapezoid decomposition, diff=0 vs C++ Skia
-- **GPU DrawImage** — Tier 3 textured quad, zero mid-frame CPU flush
-- **Scene GPU auto-select** — GPU rendering for retained-mode scenes
-- **Smart multi-engine rasterizer** — 5 algorithms with per-path auto-selection
-- **Zero-alloc hot path** — QueueShape 26ns/0allocs, ScissorSegment 13ns/0allocs
-- **TexturePool** — Flutter RenderTargetCache pattern, per-frame lifecycle
-- **Path SOA representation** — `[]PathVerb` + `[]float64` (ADR-010, enterprise standard)
-- **Vello compute clip pipeline** — BeginClip/EndClip with packed blend stack (ADR-012)
-- **Alpha mask API** — per-shape, per-layer, luminance masks, GPU interface
-- Vello 9-stage compute pipeline for full-scene GPU rasterization
-- GPU MSDF text + Glyph mask dual-strategy text rendering
-- GPU stroke rendering, RenderDirect zero-copy GPU surface rendering
-- **GPU RRect clip** — analytic SDF in fragment shaders (GPU-CLIP-002)
-- **GPU scissor rect clip** — hardware scissor for rectangular clips (GPU-CLIP-001)
-- **Separated deviceMatrix/userMatrix** — Cairo/Skia/Blend2D pattern for correct HiDPI
-- **SVG renderer** (`gg/svg` package) — parse + render SVG XML for JB-quality icons
-- Recording System for vector export (PDF, SVG)
-- Font hinting, ClearType LCD subpixel rendering
-- Premultiplied alpha, 29 blend modes, structured logging
+- Skia AAA pixel-perfect rasterizer, Vello 9-stage compute pipeline
+- Smart multi-engine rasterizer — 6 algorithms with per-path auto-selection
+- SVG renderer, Recording System (PDF/SVG export), premultiplied alpha, 29 blend modes
 
 ---
 
 ## Upcoming
 
-### v0.47.0 — Next
+### v0.49.0 — Next
 - [ ] Gradient support — BrushLinearGradient/BrushRadialGradient in scene
-- [ ] MSDF reference size increase for CJK display text validation (visual QA)
-- [ ] Integration test: full damage blit pipeline via software backend (CI)
-- [x] HiDPI damage coordinate validation (DeviceScale != 1.0) — done in v0.46.9
+- [ ] GPU-CLIP-003d — stencil-based arbitrary path clip for remaining shapes
 
-### v0.46.11 — Preparing
-- [x] **GPU stroke EvenOdd fill** (ui#101 Thread F, @AnyCPU) — ring-shaped outlines with EvenOdd rule (Skia Ganesh pattern)
-- [x] **Nil texture barrier guard** (ui#101) — prevents Vulkan crash on concurrent resize
-- [x] **SA5011 staticcheck fixes** — 11 `return` after `t.Fatal` in 5 test files
-- [x] Dependencies: wgpu v0.27.5, gogpu v0.34.4
+### v0.48.6 — Current
+- [x] **SparseStripsFiller winding propagation** (BUG-SPARSE-STRIPS-001) — Vello backdrop.wgsl parity
+- [x] **SDF thin stroke fallback** (#346, ADR-040) — lineWidth < 2.0 → geometric expansion
+- [x] **Present damage union** — forwardDamageRects unions explicit + frame damage
 
-### v0.46.10 ✅ Released
-- [x] **GPU scene image affine scale** (ui#101 Thread C, @AnyCPU) — `resolveImage` honors scale components
-- [x] **GPU curved stroke HasCurves** — CPU fallback for curves (superseded by v0.46.11 EvenOdd)
-- [x] Dependencies: wgpu v0.27.4, gogpu v0.34.4, x/image v0.40.0, x/text v0.37.0
+### v0.48.5 ✅ Released
+- [x] **TextModeAliased CPU fallback** (#353) — per-glyph NoAAFiller, works without GPU
+- [x] **Fractional glyph advances** (ADR-039) — Skia linearMetrics, letters no longer merge at 10-12px
+- [x] **Per-glyph text rendering** — text.Draw replaced font.Drawer with RasterizeHinted
 
-### v0.46.9 ✅ Released
-- [x] **Mac Retina quadrant fix** (gg#308, @sverrehu) — `MarkDirty()` logical→physical pixel dimensions
-- [x] **HiDPI regression tests** — `mockHiDPIProvider` (scale=2.0), 3 tests
-- [x] HiDPI damage coordinate validation (DeviceScale != 1.0)
+### v0.48.4 ✅ Released
+- [x] **Stroke inner join teeth** (#354, #353, ADR-038) — tiny-skia stroker.rs parity
 
-### v0.46.8 ✅ Released
-- [x] **CJK IsCJK propagation** — fixed in 6 locations (shaper, scene encoding/decoding)
+### v0.48.0–v0.48.3 ✅ Released
+- [x] Text stroke (ADR-033), TextModeAliased GPU (ADR-034), zero-alloc paint (ADR-036)
+- [x] Scissor coalescing (#335 @celer), NaN safety (ADR-035), polygon rotation (#334 @rcarlier)
+- [x] GPU stroke polyline fix (#347 @TuSKan), stroke expander kurbo parity, BUG-SDF-001
 
-### v0.46.7 ✅ Released
-- [x] **Multi-rect damage** (ADR-028) — per-draw dynamic scissor, 97% tile savings for distant widgets
-- [x] **multi_damage_demo example** — visual validation of per-draw scissor
-- [x] Dependencies: wgpu v0.27.3, gogpu v0.34.3
+### v0.47.0–v0.47.4 ✅ Released
+- [x] Pixel-Perfect Mode (ADR-030), text batch coalescing (ADR-031)
+- [x] HiDPI damage scaling, NewPixmapFromBuffer zero-copy
 
-### v0.46.5–v0.46.6 ✅ Released
-- [x] **Damage-aware compositing** (ADR-026) — RenderDirectWithDamage, LoadOpLoad + scissor
-- [x] **TrackDamageRect** — compositor damage reporting (Chrome Viz / Flutter DiffContext pattern)
-- [x] **Damage scissor intersection** — applyGroupScissorWithDamage, both encode paths
-- [x] **Debug overlay feedback loop fix** — refresh-on-match dedup (Android SurfaceFlinger)
-- [x] **CJK text rendering** (ADR-027) — script-aware hinting, bucket bypass, Tier 6 force, dual MSDF 128px
-- [x] **TTC collection support** — automatic .ttc/.otc detection, WithCollectionIndex option
-- [x] **E2E software backend tests** — pixel-exact LoadOpLoad + scissor verification
-- [x] **computeDamageScissor** — pure function, 10 table-driven tests, CI-ready without GPU
-
-### v0.46.0–v0.46.4 ✅ Released
+### v0.46.0–v0.46.11 ✅ Released
 
 ### v0.45.2–v0.45.3 ✅ Released
 - [x] GPU scene clip: transform Push/Pop fix (BUG-GG-GPU-SCENE-CLIP-001)
@@ -259,6 +229,13 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.48.6** | 2026-05 | SparseStripsFiller winding (Vello parity), SDF thin stroke fallback (#346), damage union |
+| v0.48.5 | 2026-05 | TextModeAliased CPU (#353), fractional advances (ADR-039), per-glyph rendering |
+| v0.48.4 | 2026-05 | Stroke inner join teeth (#354, ADR-038, tiny-skia parity) |
+| v0.48.0–3 | 2026-05 | Text stroke (ADR-033), aliased text GPU (ADR-034), GPU stroke fix (#347) |
+| v0.47.0–4 | 2026-05 | Pixel-Perfect Mode (ADR-030), text batch coalescing, HiDPI damage |
+| v0.46.0–11 | 2026-05 | CJK (ADR-027), damage pipeline (ADR-026), scene text (ADR-022), LCD auto-detect |
+| v0.43.0–v0.45.4 | 2026-04 | Compositor APIs, single command buffer, damage pipeline, GPU clips |
 | **v0.42.0** | 2026-04 | GPU texture compositing (DrawGPUTexture + CreateOffscreenTexture), Flutter pattern |
 | v0.41.0–2 | 2026-04 | Per-context GPU (ADR-013), Tier 3 textured quad, Skia AAA, ImageCache genID, text kerning |
 | v0.40.1 | 2026-04 | Adreno fix (#252), Vello compute clip, Buffer.Map, deps update |

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -342,8 +342,8 @@ func (c *Canvas) SetPresentDamage(rects []image.Rectangle) {
 }
 
 // forwardDamageRects sends damage rects to the OS compositor via SetDamageRects
-// (ADR-021 Level 4). Uses explicit rects from SetPresentDamage if available,
-// otherwise falls back to immediate-mode FrameDamage rects.
+// (ADR-021 Level 4). Unions explicit rects from SetPresentDamage with
+// immediate-mode FrameDamage — never lets caller understate actual damage.
 // Clears presentDamageRects after forwarding (one-shot per frame).
 func (c *Canvas) forwardDamageRects(dc RenderTarget, frameDamage []image.Rectangle) {
 	setter, ok := dc.(DamageRectSetter)
@@ -354,6 +354,8 @@ func (c *Canvas) forwardDamageRects(dc RenderTarget, frameDamage []image.Rectang
 	rects := c.presentDamageRects
 	if len(rects) == 0 {
 		rects = frameDamage
+	} else if len(frameDamage) > 0 {
+		rects = append(rects, frameDamage...)
 	}
 	if len(rects) > 0 {
 		setter.SetDamageRects(rects)

--- a/integration/ggcanvas/canvas_test.go
+++ b/integration/ggcanvas/canvas_test.go
@@ -1172,7 +1172,7 @@ func TestSetPresentDamage_FallbackToFrameDamage(t *testing.T) {
 	}
 }
 
-func TestSetPresentDamage_ExplicitOverridesFrameDamage(t *testing.T) {
+func TestSetPresentDamage_UnionsWithFrameDamage(t *testing.T) {
 	provider := newMockProvider()
 	c, err := New(provider, 50, 50)
 	if err != nil {
@@ -1187,8 +1187,14 @@ func TestSetPresentDamage_ExplicitOverridesFrameDamage(t *testing.T) {
 	dc := &mockRenderTarget{}
 	c.forwardDamageRects(dc, frameDamage)
 
-	if len(dc.damageRects) != 1 || dc.damageRects[0] != explicit[0] {
-		t.Errorf("damageRects = %v, want explicit %v", dc.damageRects, explicit)
+	if len(dc.damageRects) != 2 {
+		t.Fatalf("damageRects count = %d, want 2 (union of explicit + frame)", len(dc.damageRects))
+	}
+	if dc.damageRects[0] != explicit[0] {
+		t.Errorf("damageRects[0] = %v, want explicit %v", dc.damageRects[0], explicit[0])
+	}
+	if dc.damageRects[1] != frameDamage[0] {
+		t.Errorf("damageRects[1] = %v, want frameDamage %v", dc.damageRects[1], frameDamage[0])
 	}
 }
 

--- a/internal/gpu/coarse.go
+++ b/internal/gpu/coarse.go
@@ -334,39 +334,69 @@ func (cr *CoarseRasterizer) TileRows() uint16 {
 
 // CalculateBackdrop calculates the backdrop winding for fine rasterization.
 // Returns a slice of backdrop values indexed by [y * columns + x].
+//
+// Backdrop represents the accumulated winding number from the left edge of
+// the viewport to each tile. This is computed in two passes:
+//  1. Accumulate winding deltas at tiles that have segment entries.
+//  2. Propagate (prefix-sum) left-to-right across ALL tiles in each row,
+//     filling interior tiles that have no segments but are inside a filled
+//     region.
+//
+// This matches the Vello backdrop compute shader (backdrop.wgsl) which performs
+// a left-to-right prefix sum per row. Without this propagation, interior tiles
+// of wide shapes (e.g. a rectangle spanning many tiles) would have zero backdrop
+// and render as empty gaps.
+//
+// Reference: Vello tilecompute/shaders/backdrop.wgsl, Rust Vello strip.rs:259-263
 func (cr *CoarseRasterizer) CalculateBackdrop() []int32 {
 	if cr.segments == nil || len(cr.entries) == 0 {
 		return nil
 	}
 
-	backdrop := make([]int32, int(cr.tileColumns)*int(cr.tileRows))
+	cols := int(cr.tileColumns)
+	rows := int(cr.tileRows)
+	backdrop := make([]int32, cols*rows)
 
 	// Ensure entries are sorted
 	cr.SortEntries()
 
 	lines := cr.segments.Segments()
 
-	// Process each row
-	currentY := uint16(0xFFFF)
-	rowWinding := int32(0)
-
+	// Pass 1: Record winding deltas at tiles that have segment entries.
+	// A winding delta at tile (x,y) means segments in that tile contribute
+	// a net winding change that affects all tiles to the right on the same row.
 	for _, entry := range cr.entries {
-		// New row?
-		if entry.Y != currentY {
-			currentY = entry.Y
-			rowWinding = 0
-		}
-
-		// Get backdrop for this tile position
-		idx := int(entry.Y)*int(cr.tileColumns) + int(entry.X)
-		if idx < len(backdrop) {
-			backdrop[idx] = rowWinding
-		}
-
-		// Update winding based on segment direction
 		if entry.Winding && int(entry.LineIdx) < len(lines) {
 			line := lines[entry.LineIdx]
-			rowWinding += int32(line.Winding)
+			idx := int(entry.Y)*cols + int(entry.X)
+			if idx >= 0 && idx < len(backdrop) {
+				backdrop[idx] += int32(line.Winding)
+			}
+		}
+	}
+
+	// Pass 2: Left-to-right prefix sum per row (Vello backdrop pattern).
+	// After this, backdrop[y*cols+x] contains the total winding from the
+	// left edge of the viewport to tile (x,y), inclusive of all segments
+	// in tiles 0..x on row y.
+	for y := 0; y < rows; y++ {
+		rowBase := y * cols
+		sum := int32(0)
+		for x := 0; x < cols; x++ {
+			sum += backdrop[rowBase+x]
+			backdrop[rowBase+x] = sum
+		}
+	}
+
+	// Pass 3: Shift right — backdrop for tile X should be the accumulated
+	// winding from segments strictly to the LEFT of X (tiles 0..X-1), not
+	// including X itself. This matches the Vello convention where backdrop
+	// represents the winding state BEFORE processing local segments.
+	for y := 0; y < rows; y++ {
+		rowBase := y * cols
+		prev := int32(0)
+		for x := 0; x < cols; x++ {
+			backdrop[rowBase+x], prev = prev, backdrop[rowBase+x]
 		}
 	}
 

--- a/internal/gpu/fine.go
+++ b/internal/gpu/fine.go
@@ -57,6 +57,15 @@ func (fr *FineRasterizer) FillRule() scene.FillStyle {
 
 // Rasterize performs fine rasterization on coarse tile entries.
 // It calculates analytic anti-aliased coverage for each pixel.
+//
+// After processing all coarse entries (tiles with segments), this method
+// also emits solid tiles for backdrop-only positions — tiles that have
+// non-zero backdrop winding but no segment entries. These are the interior
+// tiles of filled shapes (e.g., the middle of a wide rectangle).
+//
+// Reference: Vello backdrop.wgsl prefix sum + fine.wgsl backdrop fill.
+//
+//nolint:gocognit // Complexity inherent to tile iteration + backdrop-only emission
 func (fr *FineRasterizer) Rasterize(
 	coarse *CoarseRasterizer,
 	segments *SegmentList,
@@ -67,6 +76,12 @@ func (fr *FineRasterizer) Rasterize(
 	fr.grid.Reset()
 
 	if segments == nil || len(coarse.Entries()) == 0 {
+		// Even with no entries, backdrop may contain non-zero values
+		// from a prior CalculateBackdrop() — but if entries is empty,
+		// backdrop should also be nil per CalculateBackdrop contract.
+		if backdrop != nil {
+			fr.emitBackdropOnlyTiles(backdrop, coarse)
+		}
 		return
 	}
 
@@ -76,9 +91,18 @@ func (fr *FineRasterizer) Rasterize(
 	// Process tiles in sorted order, grouping by location
 	coarse.SortEntries()
 
+	// Track which tiles were visited via coarse entries so we can emit
+	// backdrop-only tiles afterward.
+	visited := make(map[uint32]bool, len(entries))
+
 	var currentX, currentY uint16 = 0xFFFF, 0xFFFF
 	var tileWinding [TileSize][TileSize]float32
 	var accumulatedWinding [TileSize]float32
+	// windingDelta tracks net integer winding from processed segments on the
+	// current row. When jumping to a non-adjacent tile on the same row, we
+	// propagate this delta into accumulatedWinding so that sub-pixel area
+	// contributions are not lost. Matches Rust Vello strip.rs:259-263.
+	var windingDelta int32
 
 	for i, entry := range entries {
 		// Check if we're at a new tile location
@@ -88,15 +112,42 @@ func (fr *FineRasterizer) Rasterize(
 				fr.finalizeTile(currentX, currentY, &tileWinding, &accumulatedWinding)
 			}
 
+			// Detect row change vs same-row tile gap
+			if currentY != 0xFFFF && entry.Y != currentY {
+				// New row — reset winding delta
+				windingDelta = 0
+			}
+
 			// Start new tile
 			currentX, currentY = entry.X, entry.Y
+			visited[tileKey32(currentX, currentY)] = true
 			fr.initTileWinding(&tileWinding, &accumulatedWinding, currentX, currentY)
+
+			// When jumping to a non-adjacent tile on the same row,
+			// propagate windingDelta into accumulatedWinding.
+			// Rust Vello strip.rs:263: accumulated_winding = f32x4::splat(s, winding_delta as f32)
+			// The backdrop provides coarse integer winding; windingDelta adds the
+			// net contribution from segments processed in previous tiles on this row.
+			if windingDelta != 0 {
+				wdF := float32(windingDelta)
+				for y := 0; y < TileSize; y++ {
+					accumulatedWinding[y] += wdF
+					for x := 0; x < TileSize; x++ {
+						tileWinding[y][x] += wdF
+					}
+				}
+			}
 		}
 
 		// Process segment contribution to this tile
 		if int(entry.LineIdx) < len(lines) {
 			line := lines[entry.LineIdx]
 			fr.processSegment(line, currentX, currentY, &tileWinding, &accumulatedWinding)
+
+			// Update winding delta from segments that contribute winding at this tile
+			if entry.Winding {
+				windingDelta += int32(line.Winding)
+			}
 		}
 
 		// Check if next entry is at different location (or this is last)
@@ -106,6 +157,59 @@ func (fr *FineRasterizer) Rasterize(
 			if !isLast {
 				currentX, currentY = 0xFFFF, 0xFFFF
 			}
+		}
+	}
+
+	// Emit solid tiles for backdrop-only positions (interior tiles with no segments).
+	// These tiles have non-zero backdrop from the prefix sum but were never visited
+	// because no segments cross them.
+	fr.emitBackdropOnlyTilesWithVisited(backdrop, coarse, visited)
+}
+
+// tileKey32 packs tile coordinates into a single uint32 for map lookup.
+func tileKey32(x, y uint16) uint32 {
+	return uint32(y)<<16 | uint32(x)
+}
+
+// emitBackdropOnlyTiles fills tiles that have non-zero backdrop but no coarse entries.
+// This is the fallback path when there are no coarse entries at all.
+func (fr *FineRasterizer) emitBackdropOnlyTiles(backdrop []int32, coarse *CoarseRasterizer) {
+	fr.emitBackdropOnlyTilesWithVisited(backdrop, coarse, nil)
+}
+
+// emitBackdropOnlyTilesWithVisited fills tiles that have non-zero backdrop but
+// were not visited during coarse entry processing. These are the interior tiles
+// of filled shapes — they have no segments crossing them but should be solid
+// because the winding number (from edges to the left) is non-zero.
+func (fr *FineRasterizer) emitBackdropOnlyTilesWithVisited(
+	backdrop []int32,
+	coarse *CoarseRasterizer,
+	visited map[uint32]bool,
+) {
+	if backdrop == nil {
+		return
+	}
+
+	cols := int(coarse.TileColumns())
+	rows := int(coarse.TileRows())
+
+	for ty := 0; ty < rows; ty++ {
+		for tx := 0; tx < cols; tx++ {
+			idx := ty*cols + tx
+			if idx >= len(backdrop) || backdrop[idx] == 0 {
+				continue
+			}
+
+			//nolint:gosec // tx, ty bounded by viewport tile dimensions
+			key := tileKey32(uint16(tx), uint16(ty))
+			if visited != nil && visited[key] {
+				continue // Already processed via coarse entries
+			}
+
+			// This tile has non-zero backdrop and no segments — fill solid.
+			//nolint:gosec // tx, ty bounded by viewport tile dimensions
+			tile := fr.grid.GetOrCreate(int32(tx), int32(ty))
+			fr.fillTileWithBackdrop(tile, backdrop[idx])
 		}
 	}
 }
@@ -734,6 +838,22 @@ func (sr *StripRenderer) RenderTiles(
 			// Initialize new tile
 			currentX, currentY = entry.X, entry.Y
 			sr.initTileWindingForStrip(&tileWinding, &accumulatedWinding, backdrop, currentX, currentY, int(coarse.TileColumns()))
+
+			// When jumping to a non-adjacent tile on the same row, propagate
+			// windingDelta into accumulatedWinding so that sub-pixel area
+			// contributions from prior tiles are not lost.
+			// Matches Rust Vello strip.rs:259-263:
+			//   accumulated_winding = f32x4::splat(s, winding_delta as f32)
+			if !prevLocation && windingDelta != 0 {
+				wdF := float32(windingDelta)
+				for y := 0; y < TileSize; y++ {
+					accumulatedWinding[y] += wdF
+					for x := 0; x < TileSize; x++ {
+						tileWinding[y][x] += wdF
+					}
+				}
+			}
+
 			prevTile = entry
 		}
 

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -699,6 +699,12 @@ func (rc *GPURenderContext) StrokeShape(target gg.GPURenderTarget, shape gg.Dete
 		return rc.shared.cpuFallback.StrokeShape(target, shape, paint)
 	}
 
+	// Thin strokes (< 2px) fall back to geometric expansion — SDF annular ring
+	// is thinner than smoothstep AA zone, producing near-zero coverage (ADR-040).
+	if paint.EffectiveLineWidth() < 2.0 {
+		return gg.ErrFallbackToCPU
+	}
+
 	if rc.pipelineMode == gg.PipelineModeCompute {
 		rc.shared.mu.Lock()
 		va := rc.shared.velloAccel

--- a/internal/gpu/sparse_strips_test.go
+++ b/internal/gpu/sparse_strips_test.go
@@ -1040,3 +1040,183 @@ func BenchmarkSparseStripsPool(b *testing.B) {
 		pool.Put(ssr)
 	}
 }
+
+// =============================================================================
+// Winding Propagation Tests (BUG-SPARSE-STRIPS-001)
+// =============================================================================
+
+// TestWindingPropagationBetweenTiles verifies that winding is correctly
+// propagated between non-adjacent tiles on the same row. A wide rectangle
+// has its left edge in tile 0 and right edge in tile 9; tiles between
+// them must be fully filled via backdrop prefix-sum propagation.
+//
+// Before the fix (BUG-SPARSE-STRIPS-001), interior tiles that had no
+// segment entries and zero backdrop would render empty because
+// CalculateBackdrop only wrote values at tiles with coarse entries,
+// not for the entire row. The fix implements a Vello-style left-to-right
+// prefix sum (backdrop.wgsl pattern) so interior tiles inherit the
+// accumulated winding from edges to their left.
+//
+// The rectangle uses tile-aligned Y coordinates (y=0 to y=8) so that
+// edge segments cross tile TOP boundaries, setting winding=true in the
+// coarse entries. This ensures backdrop propagation covers all tile rows.
+//
+// Reference: Vello tilecompute/shaders/backdrop.wgsl, strip.rs:259-263
+func TestWindingPropagationBetweenTiles(t *testing.T) {
+	// Canvas: 40x8 pixels = 10x2 tiles (TileSize=4)
+	// Rectangle from (1,0) to (39,8) — left edge in tile col 0,
+	// right edge in tile col 9. Y range covers full canvas height
+	// so backdrop propagation works on all tile rows.
+	const (
+		canvasW = 40
+		canvasH = 8
+	)
+
+	path := scene.NewPath().Rectangle(1, 0, 38, 8) // x, y, w, h
+	config := DefaultConfig(canvasW, canvasH)
+	config.FillRule = scene.FillNonZero
+	ssr := NewSparseStripsRasterizer(config)
+
+	ssr.RasterizePath(path, scene.IdentityAffine(), FlattenTolerance)
+	grid := ssr.Grid()
+
+	// Check interior tiles (columns 1 through 8) — these are between
+	// the left and right edges and should be fully filled (alpha=255).
+	for tileCol := int32(1); tileCol <= 8; tileCol++ {
+		for tileRow := int32(0); tileRow < 2; tileRow++ {
+			tile := grid.Get(tileCol, tileRow)
+
+			for py := 0; py < TileSize; py++ {
+				pixelY := int(tileRow)*TileSize + py
+				if pixelY >= canvasH {
+					continue
+				}
+				for px := 0; px < TileSize; px++ {
+					pixelX := int(tileCol)*TileSize + px
+					if pixelX < 2 || pixelX >= 38 {
+						continue // Near edges, may have partial coverage
+					}
+
+					if tile == nil {
+						t.Errorf("Interior pixel (%d,%d) in tile(%d,%d): tile is nil, want alpha=255",
+							pixelX, pixelY, tileCol, tileRow)
+						continue
+					}
+
+					alpha := tile.GetCoverage(px, py)
+					if alpha < 250 {
+						t.Errorf("Interior pixel (%d,%d) in tile(%d,%d): alpha=%d, want >=250 (fully filled)",
+							pixelX, pixelY, tileCol, tileRow, alpha)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestWindingPropagation_FineRasterizer verifies backdrop propagation
+// in the FineRasterizer code path (non-strip), which is used for
+// tile-grid based rendering.
+func TestWindingPropagation_FineRasterizer(t *testing.T) {
+	const (
+		canvasW = 40
+		canvasH = 8
+	)
+
+	// Tile-aligned rectangle: y=0 to y=8 fills full tile rows,
+	// ensuring backdrop propagation works for all rows.
+	path := scene.NewPath().Rectangle(1, 0, 38, 8)
+	segments := FlattenPath(path, scene.IdentityAffine(), FlattenTolerance)
+
+	cr := NewCoarseRasterizer(canvasW, canvasH)
+	cr.Rasterize(segments)
+	cr.SortEntries()
+	backdrop := cr.CalculateBackdrop()
+
+	fr := NewFineRasterizer(canvasW, canvasH)
+	fr.Rasterize(cr, segments, backdrop)
+	grid := fr.Grid()
+
+	// Interior tiles (columns 1-8) must be fully filled via backdrop.
+	for tileCol := int32(1); tileCol <= 8; tileCol++ {
+		for tileRow := int32(0); tileRow < 2; tileRow++ {
+			tile := grid.Get(tileCol, tileRow)
+
+			for py := 0; py < TileSize; py++ {
+				pixelY := int(tileRow)*TileSize + py
+				if pixelY >= canvasH {
+					continue
+				}
+				for px := 0; px < TileSize; px++ {
+					pixelX := int(tileCol)*TileSize + px
+					if pixelX < 2 || pixelX >= 38 {
+						continue
+					}
+
+					if tile == nil {
+						t.Errorf("FineRasterizer: interior pixel (%d,%d) in tile(%d,%d): tile is nil",
+							pixelX, pixelY, tileCol, tileRow)
+						continue
+					}
+
+					alpha := tile.GetCoverage(px, py)
+					if alpha < 250 {
+						t.Errorf("FineRasterizer: interior pixel (%d,%d) in tile(%d,%d): alpha=%d, want >=250",
+							pixelX, pixelY, tileCol, tileRow, alpha)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestWindingPropagation_EvenOddFillRule verifies winding propagation
+// works correctly with EvenOdd fill rule. A simple rectangle should
+// render identically regardless of fill rule.
+func TestWindingPropagation_EvenOddFillRule(t *testing.T) {
+	const (
+		canvasW = 24
+		canvasH = 8
+	)
+
+	// Tile-aligned Y: y=0 to y=8 fills full tile rows.
+	path := scene.NewPath().Rectangle(1, 0, 22, 8)
+	config := DefaultConfig(canvasW, canvasH)
+	config.FillRule = scene.FillEvenOdd
+	ssr := NewSparseStripsRasterizer(config)
+
+	ssr.RasterizePath(path, scene.IdentityAffine(), FlattenTolerance)
+	grid := ssr.Grid()
+
+	// Interior tiles (columns 1 through 4) should be fully filled
+	for tileCol := int32(1); tileCol <= 4; tileCol++ {
+		for tileRow := int32(0); tileRow < 2; tileRow++ {
+			tile := grid.Get(tileCol, tileRow)
+
+			for py := 0; py < TileSize; py++ {
+				pixelY := int(tileRow)*TileSize + py
+				if pixelY >= canvasH {
+					continue
+				}
+				for px := 0; px < TileSize; px++ {
+					pixelX := int(tileCol)*TileSize + px
+					if pixelX < 2 || pixelX >= 22 {
+						continue
+					}
+
+					if tile == nil {
+						t.Errorf("EvenOdd: interior pixel (%d,%d) in tile(%d,%d): tile is nil",
+							pixelX, pixelY, tileCol, tileRow)
+						continue
+					}
+
+					alpha := tile.GetCoverage(px, py)
+					if alpha < 250 {
+						t.Errorf("EvenOdd: interior pixel (%d,%d) in tile(%d,%d): alpha=%d, want >=250",
+							pixelX, pixelY, tileCol, tileRow, alpha)
+					}
+				}
+			}
+		}
+	}
+}

--- a/sdf_accelerator.go
+++ b/sdf_accelerator.go
@@ -8,6 +8,12 @@ const (
 	// per-pixel SDF evaluation cost exceeds the benefit for tiny shapes where
 	// the total pixel count is low (e.g., a 10x10 circle = 100 pixels).
 	sdfMinSize = 16
+
+	// sdfMinStrokeWidth is the minimum stroke width for SDF stroke rendering.
+	// Below this, the annular ring (half_stroke) is thinner than the smoothstep
+	// AA zone, producing near-zero coverage. Geometric stroke expansion (CPU
+	// scanline) handles thin strokes correctly. ADR-040.
+	sdfMinStrokeWidth = 2.0
 )
 
 // SDFAccelerator is a CPU-based SDF accelerator for simple geometric shapes.
@@ -90,6 +96,9 @@ func (a *SDFAccelerator) Flush(_ GPURenderTarget) error { return nil }
 // unless forceSDF is enabled (RasterizerSDF mode).
 func (a *SDFAccelerator) StrokeShape(target GPURenderTarget, shape DetectedShape, paint *Paint) error {
 	if !a.forceSDF && shapeTooSmallForSDF(shape) {
+		return ErrFallbackToCPU
+	}
+	if !a.forceSDF && paint.EffectiveLineWidth() < sdfMinStrokeWidth {
 		return ErrFallbackToCPU
 	}
 	switch shape.Kind {

--- a/sdf_accelerator_coverage_test.go
+++ b/sdf_accelerator_coverage_test.go
@@ -333,6 +333,52 @@ func TestShapeTooSmallForSDF(t *testing.T) {
 	}
 }
 
+// --- sdfMinStrokeWidth tests ---
+
+func TestSDFAccelerator_ThinStrokeFallback(t *testing.T) {
+	accel := &SDFAccelerator{}
+	target := GPURenderTarget{
+		Data:   make([]uint8, 100*100*4),
+		Width:  100,
+		Height: 100,
+		Stride: 400,
+	}
+	shape := DetectedShape{
+		Kind:    ShapeRRect,
+		CenterX: 50, CenterY: 50,
+		Width: 80, Height: 40,
+		CornerRadius: 5,
+	}
+
+	tests := []struct {
+		name      string
+		lineWidth float64
+		wantErr   bool
+	}{
+		{"lineWidth=1.0 fallback", 1.0, true},
+		{"lineWidth=1.5 fallback", 1.5, true},
+		{"lineWidth=1.99 fallback", 1.99, true},
+		{"lineWidth=2.0 renders", 2.0, false},
+		{"lineWidth=3.0 renders", 3.0, false},
+		{"lineWidth=10.0 renders", 10.0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paint := NewPaint()
+			paint.SetBrush(Solid(Red))
+			paint.LineWidth = tt.lineWidth
+			err := accel.StrokeShape(target, shape, paint)
+			if tt.wantErr && err == nil {
+				t.Errorf("lineWidth=%.1f: expected ErrFallbackToCPU, got nil", tt.lineWidth)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("lineWidth=%.1f: unexpected error: %v", tt.lineWidth, err)
+			}
+		})
+	}
+}
+
 // --- getColorFromPaint tests ---
 
 func TestGetColorFromPaint(t *testing.T) {

--- a/text_mode.go
+++ b/text_mode.go
@@ -53,9 +53,12 @@ const (
 	// and geometry AA are orthogonal — you can have aliased text on
 	// anti-aliased shapes, or vice versa.
 	//
-	// Uses the same Tier 6 glyph mask pipeline (R8 atlas + GPU textured
-	// quads) but rasterizes with the NoAAFiller (integer scanline, binary
-	// spans) instead of the AnalyticFiller (256-level AA).
+	// Works on both GPU and CPU paths:
+	//   - GPU: Tier 6 glyph mask pipeline (R8 atlas + textured quads)
+	//   - CPU: per-glyph [DrawAliased] via [GlyphMaskRasterizer.RasterizeAliased]
+	//
+	// Both paths use NoAAFiller (integer scanline, binary spans) for
+	// pixel-identical output regardless of GPU availability.
 	//
 	// Best for: retro/pixel-art aesthetics, terminal emulators, bitmap
 	// font emulation, development tools where crisp edges are preferred.


### PR DESCRIPTION
## Summary

- **SparseStripsFiller winding propagation** (BUG-SPARSE-STRIPS-001) — interior tiles between shape edges rendered as empty gaps. Fixed backdrop calculation to Vello `backdrop.wgsl` prefix-sum, added `windingDelta` propagation between non-adjacent tiles (`strip.rs:259-263`), backdrop-only tile emission.
- **SDF thin stroke fallback** (#346, ADR-040) — `lineWidth < 2.0` falls back to geometric expansion. SDF annular ring thinner than smoothstep AA zone → near-zero coverage.
- **Present damage union** — `forwardDamageRects` unions explicit + frame damage, never understating actual damage.

## Test plan

- [x] 3 winding propagation tests (NonZero, FineRasterizer, EvenOdd)
- [x] `TestSDFAccelerator_ThinStrokeFallback` — 6 lineWidth values
- [x] `TestSetPresentDamage_UnionsWithFrameDamage` — replaces override test
- [x] All 43 GPU tests pass
- [x] Full suite 28/29 pass (tmp/repro pre-existing)
- [x] golangci-lint 0 issues