### PR TITLE
chore(examples): update gogpu v0.40.0 → v0.41.0

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 )
 
 require (

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.48.7 h1:a2Se9XgjP0VtJzHO62hRZCUlBIVLJDpO2MSfIIh2wkw=
 github.com/gogpu/gg v0.48.7/go.mod h1:KtMYgYxsSSNhKhia9vmOU9muvz9gROCTj8A7ZGxPwb8=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 	github.com/gogpu/gpucontext v0.19.0
 )
 

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.48.7 h1:a2Se9XgjP0VtJzHO62hRZCUlBIVLJDpO2MSfIIh2wkw=
 github.com/gogpu/gg v0.48.7/go.mod h1:KtMYgYxsSSNhKhia9vmOU9muvz9gROCTj8A7ZGxPwb8=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 )
 
 require (

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.48.7 h1:a2Se9XgjP0VtJzHO62hRZCUlBIVLJDpO2MSfIIh2wkw=
 github.com/gogpu/gg v0.48.7/go.mod h1:KtMYgYxsSSNhKhia9vmOU9muvz9gROCTj8A7ZGxPwb8=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 	github.com/gogpu/gpucontext v0.19.0
 )
 

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.48.7 h1:a2Se9XgjP0VtJzHO62hRZCUlBIVLJDpO2MSfIIh2wkw=
 github.com/gogpu/gg v0.48.7/go.mod h1:KtMYgYxsSSNhKhia9vmOU9muvz9gROCTj8A7ZGxPwb8=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 	github.com/gogpu/gpucontext v0.19.0
 )
 

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.48.7 h1:a2Se9XgjP0VtJzHO62hRZCUlBIVLJDpO2MSfIIh2wkw=
 github.com/gogpu/gg v0.48.7/go.mod h1:KtMYgYxsSSNhKhia9vmOU9muvz9gROCTj8A7ZGxPwb8=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 )
 
 require (

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.48.7 h1:a2Se9XgjP0VtJzHO62hRZCUlBIVLJDpO2MSfIIh2wkw=
 github.com/gogpu/gg v0.48.7/go.mod h1:KtMYgYxsSSNhKhia9vmOU9muvz9gROCTj8A7ZGxPwb8=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/multi_damage_demo/go.mod
+++ b/examples/multi_damage_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/gogpu/gg => ../..
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 	github.com/gogpu/gpucontext v0.19.0
 )
 

--- a/examples/multi_damage_demo/go.sum
+++ b/examples/multi_damage_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.2 h1:Kq2llPlA6IhkkmAffkM5CtsgaXuBQC4mBI0BOREwV04
 github.com/go-webgpu/goffi v0.5.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 )
 
 require (

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.48.7 h1:a2Se9XgjP0VtJzHO62hRZCUlBIVLJDpO2MSfIIh2wkw=
 github.com/gogpu/gg v0.48.7/go.mod h1:KtMYgYxsSSNhKhia9vmOU9muvz9gROCTj8A7ZGxPwb8=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 )
 
 require (

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.48.7 h1:a2Se9XgjP0VtJzHO62hRZCUlBIVLJDpO2MSfIIh2wkw=
 github.com/gogpu/gg v0.48.7/go.mod h1:KtMYgYxsSSNhKhia9vmOU9muvz9gROCTj8A7ZGxPwb8=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.48.7
-	github.com/gogpu/gogpu v0.40.0
+	github.com/gogpu/gogpu v0.41.0
 )
 
 require (

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.48.7 h1:a2Se9XgjP0VtJzHO62hRZCUlBIVLJDpO2MSfIIh2wkw=
 github.com/gogpu/gg v0.48.7/go.mod h1:KtMYgYxsSSNhKhia9vmOU9muvz9gROCTj8A7ZGxPwb8=
-github.com/gogpu/gogpu v0.40.0 h1:wOiTdaEtsc14xPuWg8tEfQLI8FnCVXtEKKeJu+VH0i8=
-github.com/gogpu/gogpu v0.40.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
+github.com/gogpu/gogpu v0.41.0 h1:iXmiGEJrFfUXfM35HuhTDhPF8lIQo6l0o1sFkib7hzY=
+github.com/gogpu/gogpu v0.41.0/go.mod h1:43kdkwva6U0rb0kaVJSTRv5ne7PGA1+5KmyGW+cl0PY=
 github.com/gogpu/gpucontext v0.19.0 h1:cVm5wUtK7F/anyYXc7vncrB/F9ujBQ2XUbi3oq4hBQ8=
 github.com/gogpu/gpucontext v0.19.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=


### PR DESCRIPTION
Update 9 examples to gogpu v0.41.0 (Win32 native menus, Linux file dialogs).