### PR TITLE
text: add OpenType font feature support (tnum, liga, etc.)

### DIFF
--- a/text/face.go
+++ b/text/face.go
@@ -37,6 +37,10 @@ type Face interface {
 	// Size returns the size of this face in points.
 	Size() float64
 
+	// Features returns the OpenType font features configured for this face.
+	// Features are set via [WithFeatures] when creating the face.
+	Features() []FontFeature
+
 	// private prevents external implementation
 	private()
 }
@@ -208,6 +212,11 @@ func (f *sourceFace) Source() *FontSource {
 // Size implements Face.Size.
 func (f *sourceFace) Size() float64 {
 	return f.size
+}
+
+// Features implements Face.Features.
+func (f *sourceFace) Features() []FontFeature {
+	return f.config.features
 }
 
 // private implements the Face interface.

--- a/text/face.go
+++ b/text/face.go
@@ -41,6 +41,12 @@ type Face interface {
 	// Features are set via [WithFeatures] when creating the face.
 	Features() []FontFeature
 
+	// Language returns the BCP 47 language tag for this face (e.g., "en", "ja", "ar").
+	// The language affects OpenType shaping: script-specific ligatures, localized
+	// forms, and language-dependent glyph selection.
+	// Language is set via [WithLanguage] when creating the face; defaults to "en".
+	Language() string
+
 	// private prevents external implementation
 	private()
 }
@@ -217,6 +223,11 @@ func (f *sourceFace) Size() float64 {
 // Features implements Face.Features.
 func (f *sourceFace) Features() []FontFeature {
 	return f.config.features
+}
+
+// Language implements Face.Language.
+func (f *sourceFace) Language() string {
+	return f.config.language
 }
 
 // private implements the Face interface.

--- a/text/filtered.go
+++ b/text/filtered.go
@@ -134,6 +134,11 @@ func (f *FilteredFace) Size() float64 {
 	return f.face.Size()
 }
 
+// Features implements Face.Features.
+func (f *FilteredFace) Features() []FontFeature {
+	return f.face.Features()
+}
+
 // private implements the Face interface.
 func (f *FilteredFace) private() {}
 

--- a/text/filtered.go
+++ b/text/filtered.go
@@ -139,6 +139,11 @@ func (f *FilteredFace) Features() []FontFeature {
 	return f.face.Features()
 }
 
+// Language implements Face.Language.
+func (f *FilteredFace) Language() string {
+	return f.face.Language()
+}
+
 // private implements the Face interface.
 func (f *FilteredFace) private() {}
 

--- a/text/filtered_test.go
+++ b/text/filtered_test.go
@@ -277,6 +277,15 @@ func TestFilteredFaceSize(t *testing.T) {
 	}
 }
 
+func TestFilteredFaceLanguage(t *testing.T) {
+	face := newMockFace(12, DirectionLTR, map[rune]float64{'a': 6})
+	ff := NewFilteredFace(face, RangeBasicLatin)
+
+	if ff.Language() != "en" {
+		t.Errorf("expected language \"en\", got %q", ff.Language())
+	}
+}
+
 func TestFilteredFaceWithMultiFace(t *testing.T) {
 	// Create a MultiFace with Latin and Cyrillic coverage
 	latinFace := newMockFace(12, DirectionLTR, map[rune]float64{

--- a/text/multi.go
+++ b/text/multi.go
@@ -151,6 +151,12 @@ func (m *MultiFace) Size() float64 {
 	return m.faces[0].Size()
 }
 
+// Features implements Face.Features.
+// Returns features from the first face.
+func (m *MultiFace) Features() []FontFeature {
+	return m.faces[0].Features()
+}
+
 // private implements the Face interface.
 func (m *MultiFace) private() {}
 

--- a/text/multi.go
+++ b/text/multi.go
@@ -157,6 +157,12 @@ func (m *MultiFace) Features() []FontFeature {
 	return m.faces[0].Features()
 }
 
+// Language implements Face.Language.
+// Returns the language from the first face.
+func (m *MultiFace) Language() string {
+	return m.faces[0].Language()
+}
+
 // private implements the Face interface.
 func (m *MultiFace) private() {}
 

--- a/text/multi_test.go
+++ b/text/multi_test.go
@@ -33,7 +33,7 @@ func (m *mockFace) Direction() Direction        { return m.direction }
 func (m *mockFace) Source() *FontSource         { return nil }
 func (m *mockFace) Size() float64               { return m.size }
 func (m *mockFace) Features() []FontFeature     { return nil }
-func (m *mockFace) Language() string             { return "en" }
+func (m *mockFace) Language() string            { return "en" }
 func (m *mockFace) private()                    {}
 func (m *mockFace) HasGlyph(r rune) bool        { _, ok := m.glyphs[r]; return ok }
 func (m *mockFace) Advance(text string) float64 { panic("not implemented") }

--- a/text/multi_test.go
+++ b/text/multi_test.go
@@ -33,6 +33,7 @@ func (m *mockFace) Direction() Direction        { return m.direction }
 func (m *mockFace) Source() *FontSource         { return nil }
 func (m *mockFace) Size() float64               { return m.size }
 func (m *mockFace) Features() []FontFeature     { return nil }
+func (m *mockFace) Language() string             { return "en" }
 func (m *mockFace) private()                    {}
 func (m *mockFace) HasGlyph(r rune) bool        { _, ok := m.glyphs[r]; return ok }
 func (m *mockFace) Advance(text string) float64 { panic("not implemented") }
@@ -271,5 +272,19 @@ func TestMultiFaceSize(t *testing.T) {
 
 	if mf.Size() != 12 {
 		t.Errorf("expected size 12, got %f", mf.Size())
+	}
+}
+
+func TestMultiFaceLanguage(t *testing.T) {
+	face1 := newMockFace(12, DirectionLTR, map[rune]float64{'a': 6})
+	face2 := newMockFace(12, DirectionLTR, map[rune]float64{'b': 7})
+
+	mf, err := NewMultiFace(face1, face2)
+	if err != nil {
+		t.Fatalf("NewMultiFace failed: %v", err)
+	}
+
+	if mf.Language() != "en" {
+		t.Errorf("expected language \"en\", got %q", mf.Language())
 	}
 }

--- a/text/multi_test.go
+++ b/text/multi_test.go
@@ -32,6 +32,7 @@ func (m *mockFace) Metrics() Metrics            { return m.metrics }
 func (m *mockFace) Direction() Direction        { return m.direction }
 func (m *mockFace) Source() *FontSource         { return nil }
 func (m *mockFace) Size() float64               { return m.size }
+func (m *mockFace) Features() []FontFeature     { return nil }
 func (m *mockFace) private()                    {}
 func (m *mockFace) HasGlyph(r rune) bool        { _, ok := m.glyphs[r]; return ok }
 func (m *mockFace) Advance(text string) float64 { panic("not implemented") }

--- a/text/options.go
+++ b/text/options.go
@@ -10,6 +10,24 @@ type FontFeature struct {
 	Value uint32  // 1 = enable, 0 = disable
 }
 
+// NewFontFeature creates a FontFeature from a 4-character OpenType tag string
+// and a value. The tag must be exactly 4 ASCII characters (e.g., "tnum", "liga",
+// "smcp"). Panics if the tag is not exactly 4 bytes.
+//
+// Example:
+//
+//	tnum := text.NewFontFeature("tnum", 1)  // enable tabular nums
+//	liga := text.NewFontFeature("liga", 0)  // disable ligatures
+func NewFontFeature(tag string, value uint32) FontFeature {
+	if len(tag) != 4 {
+		panic("text.NewFontFeature: tag must be exactly 4 bytes, got " + tag)
+	}
+	return FontFeature{
+		Tag:   [4]byte{tag[0], tag[1], tag[2], tag[3]},
+		Value: value,
+	}
+}
+
 // Predefined font feature constants for common use cases.
 var (
 	// TabularNums enables tabular (monospaced) digit widths.
@@ -24,6 +42,23 @@ var (
 
 	// NoLigatures disables standard ligatures (fi, fl, ffi, etc.).
 	NoLigatures = FontFeature{Tag: [4]byte{'l', 'i', 'g', 'a'}, Value: 0}
+
+	// Kerning enables kerning (pair-wise glyph spacing adjustment).
+	// Kerning is enabled by default in most OpenType fonts; this constant
+	// is useful for explicitly requesting it when combined with other features.
+	Kerning = FontFeature{Tag: [4]byte{'k', 'e', 'r', 'n'}, Value: 1}
+
+	// NoKerning disables kerning.
+	NoKerning = FontFeature{Tag: [4]byte{'k', 'e', 'r', 'n'}, Value: 0}
+
+	// SmallCaps enables small capitals substitution.
+	// Lowercase letters are replaced with small capital forms.
+	SmallCaps = FontFeature{Tag: [4]byte{'s', 'm', 'c', 'p'}, Value: 1}
+
+	// OldstyleNums enables oldstyle (text) figures.
+	// Digits have varying heights and descenders (3, 4, 5, 7, 9 descend),
+	// matching the visual rhythm of body text.
+	OldstyleNums = FontFeature{Tag: [4]byte{'o', 'n', 'u', 'm'}, Value: 1}
 )
 
 // SourceOption configures FontSource creation.
@@ -119,6 +154,9 @@ func WithLanguage(lang string) FaceOption {
 // Features are applied during shaping when using [GoTextShaper].
 // The [BuiltinShaper] ignores features since it does not perform
 // OpenType shaping.
+//
+// Note: Features affect shaped output via [GoTextShaper] only. Methods like
+// [Face.Advance] and [Face.Glyphs] use raw glyph metrics without shaping.
 //
 // Example — enable tabular figures for aligned numeric columns:
 //

--- a/text/options.go
+++ b/text/options.go
@@ -1,5 +1,31 @@
 package text
 
+// FontFeature enables or disables an OpenType font feature.
+// Features are identified by a 4-byte tag (e.g., "tnum" for tabular figures)
+// and controlled by a uint32 value (1 = enable, 0 = disable).
+//
+// See https://learn.microsoft.com/en-us/typography/opentype/spec/featurelist
+type FontFeature struct {
+	Tag   [4]byte // e.g., [4]byte{'t','n','u','m'}
+	Value uint32  // 1 = enable, 0 = disable
+}
+
+// Predefined font feature constants for common use cases.
+var (
+	// TabularNums enables tabular (monospaced) digit widths.
+	// This ensures that digits like 1 and 0 occupy the same horizontal space,
+	// which is essential for aligned numeric columns (e.g., axis tick labels).
+	TabularNums = FontFeature{Tag: [4]byte{'t', 'n', 'u', 'm'}, Value: 1}
+
+	// ProportionalNums explicitly requests proportional (variable-width) digit widths.
+	// This is the default for most fonts, but can be used to override a face
+	// that was configured with TabularNums.
+	ProportionalNums = FontFeature{Tag: [4]byte{'p', 'n', 'u', 'm'}, Value: 1}
+
+	// NoLigatures disables standard ligatures (fi, fl, ffi, etc.).
+	NoLigatures = FontFeature{Tag: [4]byte{'l', 'i', 'g', 'a'}, Value: 0}
+)
+
 // SourceOption configures FontSource creation.
 type SourceOption func(*sourceConfig)
 
@@ -56,6 +82,7 @@ type faceConfig struct {
 	direction Direction
 	hinting   Hinting
 	language  string
+	features  []FontFeature // OpenType features (tnum, liga, etc.)
 }
 
 // defaultFaceConfig returns the default face configuration.
@@ -85,5 +112,19 @@ func WithHinting(h Hinting) FaceOption {
 func WithLanguage(lang string) FaceOption {
 	return func(c *faceConfig) {
 		c.language = lang
+	}
+}
+
+// WithFeatures sets OpenType font features for the face.
+// Features are applied during shaping when using [GoTextShaper].
+// The [BuiltinShaper] ignores features since it does not perform
+// OpenType shaping.
+//
+// Example — enable tabular figures for aligned numeric columns:
+//
+//	face := source.Face(12, text.WithFeatures(text.TabularNums))
+func WithFeatures(features ...FontFeature) FaceOption {
+	return func(c *faceConfig) {
+		c.features = features
 	}
 }

--- a/text/options_test.go
+++ b/text/options_test.go
@@ -373,4 +373,3 @@ func TestFaceLanguage_IndependentPerFace(t *testing.T) {
 		t.Errorf("faceAR.Language() = %q, want \"ar\"", faceAR.Language())
 	}
 }
-

--- a/text/options_test.go
+++ b/text/options_test.go
@@ -1,0 +1,376 @@
+package text
+
+import (
+	"testing"
+
+	ot "github.com/go-text/typesetting/font/opentype"
+	"golang.org/x/image/font/gofont/goregular"
+)
+
+// TestWithFeatures verifies that WithFeatures correctly stores features on a face.
+func TestWithFeatures(t *testing.T) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load test font: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(16, WithFeatures(TabularNums, NoLigatures))
+	features := face.Features()
+
+	if len(features) != 2 {
+		t.Fatalf("Features() returned %d features, want 2", len(features))
+	}
+
+	if features[0] != TabularNums {
+		t.Errorf("features[0] = %+v, want TabularNums %+v", features[0], TabularNums)
+	}
+	if features[1] != NoLigatures {
+		t.Errorf("features[1] = %+v, want NoLigatures %+v", features[1], NoLigatures)
+	}
+}
+
+// TestWithFeatures_Single verifies a single feature.
+func TestWithFeatures_Single(t *testing.T) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load test font: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(12, WithFeatures(ProportionalNums))
+	features := face.Features()
+
+	if len(features) != 1 {
+		t.Fatalf("Features() returned %d features, want 1", len(features))
+	}
+	if features[0] != ProportionalNums {
+		t.Errorf("features[0] = %+v, want ProportionalNums %+v", features[0], ProportionalNums)
+	}
+}
+
+// TestWithFeatures_None verifies that no features is the default.
+func TestWithFeatures_None(t *testing.T) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load test font: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(16)
+	features := face.Features()
+
+	if len(features) != 0 {
+		t.Errorf("Features() returned %d features, want 0 (default)", len(features))
+	}
+}
+
+// TestWithFeatures_Empty verifies that WithFeatures() with no args clears features.
+func TestWithFeatures_Empty(t *testing.T) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load test font: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(16, WithFeatures())
+	features := face.Features()
+
+	if len(features) != 0 {
+		t.Errorf("Features() returned %d features, want 0 for empty WithFeatures()", len(features))
+	}
+}
+
+// TestConvertFeatures_Nil verifies nil input → nil output.
+func TestConvertFeatures_Nil(t *testing.T) {
+	got := convertFeatures(nil)
+	if got != nil {
+		t.Errorf("convertFeatures(nil) = %v, want nil", got)
+	}
+}
+
+// TestConvertFeatures_Empty verifies empty input → nil output.
+func TestConvertFeatures_Empty(t *testing.T) {
+	got := convertFeatures([]FontFeature{})
+	if got != nil {
+		t.Errorf("convertFeatures([]) = %v, want nil", got)
+	}
+}
+
+// TestConvertFeatures_Single verifies correct tag and value mapping.
+func TestConvertFeatures_Single(t *testing.T) {
+	out := convertFeatures([]FontFeature{TabularNums})
+	if len(out) != 1 {
+		t.Fatalf("convertFeatures(TabularNums) returned %d features, want 1", len(out))
+	}
+
+	// Verify tag bytes match: "tnum" → ot.NewTag('t','n','u','m').
+	wantTag := ot.NewTag('t', 'n', 'u', 'm')
+	if out[0].Tag != wantTag {
+		t.Errorf("tag = 0x%08X, want 0x%08X (tnum)", out[0].Tag, wantTag)
+	}
+	if out[0].Value != 1 {
+		t.Errorf("value = %d, want 1", out[0].Value)
+	}
+}
+
+// TestConvertFeatures_Multiple verifies multiple features are mapped correctly.
+func TestConvertFeatures_Multiple(t *testing.T) {
+	out := convertFeatures([]FontFeature{TabularNums, NoLigatures, ProportionalNums})
+	if len(out) != 3 {
+		t.Fatalf("convertFeatures returned %d features, want 3", len(out))
+	}
+
+	// Verify each feature's tag.
+	tests := []struct {
+		name    string
+		feature FontFeature
+		wantTag ot.Tag
+		wantVal uint32
+	}{
+		{"tnum", TabularNums, ot.NewTag('t', 'n', 'u', 'm'), 1},
+		{"liga off", NoLigatures, ot.NewTag('l', 'i', 'g', 'a'), 0},
+		{"pnum", ProportionalNums, ot.NewTag('p', 'n', 'u', 'm'), 1},
+	}
+
+	for i, tt := range tests {
+		if out[i].Tag != tt.wantTag {
+			t.Errorf("feature[%d] (%s): tag = 0x%08X, want 0x%08X",
+				i, tt.name, out[i].Tag, tt.wantTag)
+		}
+		if out[i].Value != tt.wantVal {
+			t.Errorf("feature[%d] (%s): value = %d, want %d",
+				i, tt.name, out[i].Value, tt.wantVal)
+		}
+	}
+}
+
+// TestConvertFeatures_CustomTag verifies conversion of an arbitrary custom tag.
+func TestConvertFeatures_CustomTag(t *testing.T) {
+	custom := FontFeature{Tag: [4]byte{'s', 'm', 'c', 'p'}, Value: 1}
+	out := convertFeatures([]FontFeature{custom})
+	if len(out) != 1 {
+		t.Fatalf("convertFeatures returned %d features, want 1", len(out))
+	}
+
+	wantTag := ot.NewTag('s', 'm', 'c', 'p')
+	if out[0].Tag != wantTag {
+		t.Errorf("custom tag = 0x%08X, want 0x%08X (smcp)", out[0].Tag, wantTag)
+	}
+	if out[0].Value != 1 {
+		t.Errorf("custom value = %d, want 1", out[0].Value)
+	}
+}
+
+// TestWithFeatures_PreservedBySource verifies features survive face creation
+// and are independent per face from the same source.
+func TestWithFeatures_PreservedBySource(t *testing.T) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load test font: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	face1 := source.Face(16, WithFeatures(TabularNums))
+	face2 := source.Face(16, WithFeatures(NoLigatures))
+	face3 := source.Face(16) // No features.
+
+	if len(face1.Features()) != 1 || face1.Features()[0] != TabularNums {
+		t.Errorf("face1 features: got %+v, want [TabularNums]", face1.Features())
+	}
+	if len(face2.Features()) != 1 || face2.Features()[0] != NoLigatures {
+		t.Errorf("face2 features: got %+v, want [NoLigatures]", face2.Features())
+	}
+	if len(face3.Features()) != 0 {
+		t.Errorf("face3 features: got %+v, want []", face3.Features())
+	}
+}
+
+// --------------------------------------------------------------------------
+// NewFontFeature string constructor
+// --------------------------------------------------------------------------
+
+// TestNewFontFeature verifies the string-based constructor produces correct tags.
+func TestNewFontFeature(t *testing.T) {
+	tests := []struct {
+		tag     string
+		value   uint32
+		wantTag [4]byte
+	}{
+		{"tnum", 1, [4]byte{'t', 'n', 'u', 'm'}},
+		{"liga", 0, [4]byte{'l', 'i', 'g', 'a'}},
+		{"smcp", 1, [4]byte{'s', 'm', 'c', 'p'}},
+		{"kern", 1, [4]byte{'k', 'e', 'r', 'n'}},
+		{"onum", 1, [4]byte{'o', 'n', 'u', 'm'}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			f := NewFontFeature(tt.tag, tt.value)
+			if f.Tag != tt.wantTag {
+				t.Errorf("NewFontFeature(%q, %d).Tag = %v, want %v", tt.tag, tt.value, f.Tag, tt.wantTag)
+			}
+			if f.Value != tt.value {
+				t.Errorf("NewFontFeature(%q, %d).Value = %d, want %d", tt.tag, tt.value, f.Value, tt.value)
+			}
+		})
+	}
+}
+
+// TestNewFontFeature_EquivalentToConstant verifies NewFontFeature produces
+// the same value as the predefined constants.
+func TestNewFontFeature_EquivalentToConstant(t *testing.T) {
+	if NewFontFeature("tnum", 1) != TabularNums {
+		t.Error("NewFontFeature(\"tnum\", 1) != TabularNums")
+	}
+	if NewFontFeature("pnum", 1) != ProportionalNums {
+		t.Error("NewFontFeature(\"pnum\", 1) != ProportionalNums")
+	}
+	if NewFontFeature("liga", 0) != NoLigatures {
+		t.Error("NewFontFeature(\"liga\", 0) != NoLigatures")
+	}
+	if NewFontFeature("kern", 1) != Kerning {
+		t.Error("NewFontFeature(\"kern\", 1) != Kerning")
+	}
+	if NewFontFeature("kern", 0) != NoKerning {
+		t.Error("NewFontFeature(\"kern\", 0) != NoKerning")
+	}
+	if NewFontFeature("smcp", 1) != SmallCaps {
+		t.Error("NewFontFeature(\"smcp\", 1) != SmallCaps")
+	}
+	if NewFontFeature("onum", 1) != OldstyleNums {
+		t.Error("NewFontFeature(\"onum\", 1) != OldstyleNums")
+	}
+}
+
+// TestNewFontFeature_PanicShortTag verifies panic on too-short tag.
+func TestNewFontFeature_PanicShortTag(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewFontFeature(\"ab\", 1) did not panic")
+		}
+	}()
+	NewFontFeature("ab", 1)
+}
+
+// TestNewFontFeature_PanicLongTag verifies panic on too-long tag.
+func TestNewFontFeature_PanicLongTag(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewFontFeature(\"abcde\", 1) did not panic")
+		}
+	}()
+	NewFontFeature("abcde", 1)
+}
+
+// TestNewFontFeature_PanicEmptyTag verifies panic on empty tag.
+func TestNewFontFeature_PanicEmptyTag(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewFontFeature(\"\", 1) did not panic")
+		}
+	}()
+	NewFontFeature("", 1)
+}
+
+// --------------------------------------------------------------------------
+// Predefined constant tag verification
+// --------------------------------------------------------------------------
+
+// TestPredefinedConstants_Tags verifies all predefined constants have correct tags.
+func TestPredefinedConstants_Tags(t *testing.T) {
+	tests := []struct {
+		name    string
+		feature FontFeature
+		wantTag [4]byte
+		wantVal uint32
+	}{
+		{"TabularNums", TabularNums, [4]byte{'t', 'n', 'u', 'm'}, 1},
+		{"ProportionalNums", ProportionalNums, [4]byte{'p', 'n', 'u', 'm'}, 1},
+		{"NoLigatures", NoLigatures, [4]byte{'l', 'i', 'g', 'a'}, 0},
+		{"Kerning", Kerning, [4]byte{'k', 'e', 'r', 'n'}, 1},
+		{"NoKerning", NoKerning, [4]byte{'k', 'e', 'r', 'n'}, 0},
+		{"SmallCaps", SmallCaps, [4]byte{'s', 'm', 'c', 'p'}, 1},
+		{"OldstyleNums", OldstyleNums, [4]byte{'o', 'n', 'u', 'm'}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.feature.Tag != tt.wantTag {
+				t.Errorf("%s.Tag = %v, want %v", tt.name, tt.feature.Tag, tt.wantTag)
+			}
+			if tt.feature.Value != tt.wantVal {
+				t.Errorf("%s.Value = %d, want %d", tt.name, tt.feature.Value, tt.wantVal)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// Language
+// --------------------------------------------------------------------------
+
+// TestFaceLanguage_Default verifies the default language is "en".
+func TestFaceLanguage_Default(t *testing.T) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load test font: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(16)
+	if face.Language() != "en" {
+		t.Errorf("Language() = %q, want \"en\"", face.Language())
+	}
+}
+
+// TestFaceLanguage_WithLanguage verifies WithLanguage sets the language tag.
+func TestFaceLanguage_WithLanguage(t *testing.T) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load test font: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	tests := []struct {
+		lang string
+	}{
+		{"ja"},
+		{"ar"},
+		{"de"},
+		{"zh-Hans"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.lang, func(t *testing.T) {
+			face := source.Face(16, WithLanguage(tt.lang))
+			if face.Language() != tt.lang {
+				t.Errorf("Language() = %q, want %q", face.Language(), tt.lang)
+			}
+		})
+	}
+}
+
+// TestFaceLanguage_IndependentPerFace verifies language is independent per face.
+func TestFaceLanguage_IndependentPerFace(t *testing.T) {
+	source, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("failed to load test font: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	faceEN := source.Face(16)
+	faceJA := source.Face(16, WithLanguage("ja"))
+	faceAR := source.Face(16, WithLanguage("ar"))
+
+	if faceEN.Language() != "en" {
+		t.Errorf("faceEN.Language() = %q, want \"en\"", faceEN.Language())
+	}
+	if faceJA.Language() != "ja" {
+		t.Errorf("faceJA.Language() = %q, want \"ja\"", faceJA.Language())
+	}
+	if faceAR.Language() != "ar" {
+		t.Errorf("faceAR.Language() = %q, want \"ar\"", faceAR.Language())
+	}
+}
+

--- a/text/shaper_gotext.go
+++ b/text/shaper_gotext.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-text/typesetting/di"
 	"github.com/go-text/typesetting/font"
+	ot "github.com/go-text/typesetting/font/opentype"
 	"github.com/go-text/typesetting/language"
 	"github.com/go-text/typesetting/shaping"
 	"golang.org/x/image/math/fixed"
@@ -97,14 +98,15 @@ func (s *GoTextShaper) Shape(text string, face Face) []ShapedGlyph {
 
 	// Build shaping input.
 	input := shaping.Input{
-		Text:      runes,
-		RunStart:  0,
-		RunEnd:    len(runes),
-		Direction: dir,
-		Face:      goTextFace,
-		Size:      floatToFixed(size),
-		Script:    script,
-		Language:  language.NewLanguage("en"),
+		Text:         runes,
+		RunStart:     0,
+		RunEnd:       len(runes),
+		Direction:    dir,
+		Face:         goTextFace,
+		Size:         floatToFixed(size),
+		Script:       script,
+		Language:     language.NewLanguage("en"),
+		FontFeatures: convertFeatures(face.Features()),
 	}
 
 	// Get a HarfbuzzShaper from the pool (not concurrent-safe, so each
@@ -253,4 +255,22 @@ func convertGlyphs(glyphs []shaping.Glyph, dir di.Direction, sourceText string) 
 	}
 
 	return result
+}
+
+// convertFeatures converts text.FontFeature to shaping.FontFeature.
+func convertFeatures(features []FontFeature) []shaping.FontFeature {
+	if len(features) == 0 {
+		return nil
+	}
+
+	out := make([]shaping.FontFeature, len(features))
+
+	for i, f := range features {
+		out[i] = shaping.FontFeature{
+			Tag:   ot.NewTag(f.Tag[0], f.Tag[1], f.Tag[2], f.Tag[3]),
+			Value: f.Value,
+		}
+	}
+
+	return out
 }

--- a/text/shaper_gotext.go
+++ b/text/shaper_gotext.go
@@ -105,7 +105,7 @@ func (s *GoTextShaper) Shape(text string, face Face) []ShapedGlyph {
 		Face:         goTextFace,
 		Size:         floatToFixed(size),
 		Script:       script,
-		Language:     language.NewLanguage("en"),
+		Language:     language.NewLanguage(face.Language()),
 		FontFeatures: convertFeatures(face.Features()),
 	}
 


### PR DESCRIPTION
## Summary

Add OpenType font feature support to the `text` package, enabling control over
shaping features like tabular figures (`tnum`), ligature suppression (`liga=0`),
and proportional numbers (`pnum`) via `GoTextShaper`.

## Motivation

Plotting libraries need tabular (monospaced) digits for aligned axis tick labels.
Without `tnum`, proportional fonts render digits with varying widths, causing
misaligned columns in charts.

## API

```go
// New type
type FontFeature struct {
    Tag   [4]byte
    Value uint32
}

// Predefined constants
var TabularNums      = FontFeature{Tag: [4]byte{'t','n','u','m'}, Value: 1}
var ProportionalNums = FontFeature{Tag: [4]byte{'p','n','u','m'}, Value: 1}
var NoLigatures      = FontFeature{Tag: [4]byte{'l','i','g','a'}, Value: 0}

// New FaceOption
func WithFeatures(features ...FontFeature) FaceOption

// New method on Face interface
Features() []FontFeature
```
## Usage
```go

face := source.Face(12, text.WithFeatures(text.TabularNums))
```

## How it works
`WithFeatures()` stores features in `faceConfig`. `GoTextShaper.Shape()` reads `face.Features()`, converts to `shaping.FontFeature` via `convertFeatures()`, and passes them to `shaping.Input.FontFeatures` for HarfBuzz shaping. `BuiltinShaper` ignores features (no OpenType shaping).