### PR TITLE
fix: thin strokes render as solid fills on GPU compute (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.11] - 2026-06-15
+
+### Fixed
+
+- **Thin strokes render as solid fills on GPU compute path** (#369, ADR-043, @TimLai666) —
+  `VelloAccelerator.StrokePath` passed the original paint (NonZero fill rule) to `FillPath`
+  after stroke expansion. The expanded outline has two contours (outer + inner, opposite
+  winding) — NonZero fills both as solid, EvenOdd correctly cancels the inner to produce a
+  hollow ring. `GPURenderContext.StrokePath` already set EvenOdd; this makes the compute
+  path consistent. Affects all 1px+ strokes via Vello compute pipeline (default for
+  medium-complexity scenes). 2 regression tests added.
+
 ## [0.48.10] - 2026-06-15
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.48.10
+## Current State: v0.48.11
 
 ✅ **Production-ready** with GPU-accelerated rendering:
 - **Text stroke/outline** (ADR-033) — StrokeString + TextPath, Skia/Cairo/HTML5 pattern
@@ -92,7 +92,11 @@
 
 ## Current Release
 
-### v0.48.10 — Current
+### v0.48.11 — Current
+- [x] **Vello StrokePath EvenOdd fill rule** (#369, ADR-043, @TimLai666) — thin strokes solid fill on GPU compute
+- 2 regression tests (StrokePathUsesEvenOdd, StrokeShapeUsesEvenOdd)
+
+### v0.48.10 ✅ Released
 - [x] **Backdrop prefix sum boundary fix** (BUG-BACKDROP-001, ADR-042) — Vello backdrop_dyn pattern
 - [x] **wgpu v0.30.1 opaque handle migration** — DeviceFromHandle/AdapterFromHandle, zero unsafe.Pointer
 - [x] **Dependencies** — wgpu v0.30.1, gogpu v0.42.0, gpucontext v0.21.0
@@ -283,7 +287,8 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.48.10** | 2026-06 | Backdrop prefix sum fix (ADR-042), wgpu v0.30.1 opaque handles, gogpu v0.42.0 |
+| **v0.48.11** | 2026-06 | Vello StrokePath EvenOdd (#369 @TimLai666), thin strokes solid fill fix |
+| v0.48.10 | 2026-06 | Backdrop prefix sum fix (ADR-042), wgpu v0.30.1 opaque handles, gogpu v0.42.0 |
 | v0.48.9 | 2026-06 | Glyph mask quadOffset fix (BUG-GLYPHMASK-001, #365), deps v0.29.15/v0.17.15/v0.41.14 |
 | v0.48.8 | 2026-06 | HiDPI fix (#361 @TuSKan), OpenType font features (#362 @TuSKan) |
 | v0.48.7 | 2026-05 | Dependencies update |

--- a/internal/gpu/vello_accelerator.go
+++ b/internal/gpu/vello_accelerator.go
@@ -260,8 +260,14 @@ func (a *VelloAccelerator) StrokePath(target gg.GPURenderTarget, path *gg.Path, 
 	// Build a gg.Path from the expanded outline.
 	fillPath := strokeResultToPath(outVerbs, outCoords)
 
-	// Route through FillPath (accumulates into pending scene).
-	return a.FillPath(target, fillPath, paint)
+	// The expanded stroke is two closed contours (outer + inner, opposite winding).
+	// EvenOdd fill rule is required so the inner contour cancels the outer,
+	// producing a hollow ring. NonZero would fill solid because inner join
+	// pivot V-shapes create self-intersections. Matches GPURenderContext.StrokePath
+	// (gpu_render_context.go:667). ADR-043, #369.
+	strokePaint := *paint
+	strokePaint.FillRule = gg.FillRuleEvenOdd
+	return a.FillPath(target, fillPath, &strokePaint)
 }
 
 // FillShape converts a detected shape to a path and accumulates it for the next Flush.

--- a/internal/gpu/vello_accumulate_test.go
+++ b/internal/gpu/vello_accumulate_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/internal/gpu/tilecompute"
 )
 
 // TestVelloAccelerator_FillPathAccumulates verifies that FillPath accumulates
@@ -150,6 +151,70 @@ func TestVelloAccelerator_StrokePathAccumulates(t *testing.T) {
 	}
 	if a.PendingCount() != 1 {
 		t.Errorf("expected 1 pending after StrokePath, got %d", a.PendingCount())
+	}
+}
+
+// TestVelloAccelerator_StrokePathUsesEvenOdd is a regression test for #369:
+// expanded stroke outlines must use EvenOdd fill rule so the inner contour
+// cancels the outer (ring topology). Without EvenOdd, strokes render as
+// solid fills. ADR-043.
+func TestVelloAccelerator_StrokePathUsesEvenOdd(t *testing.T) {
+	a := &VelloAccelerator{gpuReady: true}
+	target := makeTestTarget(200, 200)
+
+	// Closed round-rect — the exact shape from #369.
+	path := gg.NewPath()
+	path.RoundedRectangle(40, 40, 120, 80, 12)
+
+	paint := gg.NewPaint()
+	paint.SetBrush(gg.Solid(gg.RGBA{R: 0.5, G: 0.5, B: 0.5, A: 1}))
+	s := gg.Stroke{Width: 1.0, Cap: gg.LineCapButt, Join: gg.LineJoinRound, MiterLimit: 10.0}
+	paint.SetStroke(s)
+
+	if err := a.StrokePath(target, path, paint); err != nil {
+		t.Fatalf("StrokePath: unexpected error: %v", err)
+	}
+	if a.PendingCount() != 1 {
+		t.Fatalf("expected 1 pending, got %d", a.PendingCount())
+	}
+
+	// The accumulated path MUST have EvenOdd fill rule.
+	pathDef := a.pendingPaths[0]
+	if pathDef.FillRule != tilecompute.FillRuleEvenOdd {
+		t.Errorf("StrokePath fill rule = %v, want EvenOdd (%v)",
+			pathDef.FillRule, tilecompute.FillRuleEvenOdd)
+	}
+}
+
+// TestVelloAccelerator_StrokeShapeUsesEvenOdd verifies that StrokeShape
+// (which delegates to StrokePath) also produces EvenOdd fill rule.
+func TestVelloAccelerator_StrokeShapeUsesEvenOdd(t *testing.T) {
+	a := &VelloAccelerator{gpuReady: true}
+	target := makeTestTarget(200, 200)
+
+	shape := gg.DetectedShape{
+		Kind:    gg.ShapeCircle,
+		CenterX: 100,
+		CenterY: 100,
+		RadiusX: 40,
+	}
+
+	paint := gg.NewPaint()
+	paint.SetBrush(gg.Solid(gg.Red))
+	s := gg.Stroke{Width: 2.0, Cap: gg.LineCapButt, Join: gg.LineJoinRound, MiterLimit: 10.0}
+	paint.SetStroke(s)
+
+	if err := a.StrokeShape(target, shape, paint); err != nil {
+		t.Fatalf("StrokeShape: unexpected error: %v", err)
+	}
+	if a.PendingCount() != 1 {
+		t.Fatalf("expected 1 pending, got %d", a.PendingCount())
+	}
+
+	pathDef := a.pendingPaths[0]
+	if pathDef.FillRule != tilecompute.FillRuleEvenOdd {
+		t.Errorf("StrokeShape fill rule = %v, want EvenOdd (%v)",
+			pathDef.FillRule, tilecompute.FillRuleEvenOdd)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Fix #369** (@TimLai666): `VelloAccelerator.StrokePath` passed original paint (NonZero fill rule) to `FillPath` after stroke expansion. Expanded outlines have two contours (outer + inner, opposite winding) — NonZero fills solid, EvenOdd produces correct hollow ring.
- `GPURenderContext.StrokePath` already set EvenOdd correctly. This makes the Vello compute path consistent.
- ADR-043 created. Verified against 3 enterprise references (Skia, tiny-skia, our expander).
- 2 regression tests: `TestVelloAccelerator_StrokePathUsesEvenOdd`, `TestVelloAccelerator_StrokeShapeUsesEvenOdd`

## Test plan

- [x] `go build ./...` — PASS
- [x] `golangci-lint run ./internal/gpu/` — 0 issues
- [x] `go test ./...` — ALL PASS (0 failures)
- [x] New regression tests verify `PathDef.FillRule == EvenOdd`
- [ ] Full CI (build + test + lint + format on ubuntu/macos/windows)
