### PR TITLE
fix/374: use NonZero fill rule for smooth paths to avoid AMD stencil …

### DIFF
--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -651,21 +651,19 @@ func (rc *GPURenderContext) StrokePath(target gg.GPURenderTarget, path *gg.Path,
 
 	fillPath := strokeResultToPath(outVerbs, outCoords)
 
-	// Stroke-expanded outlines require EvenOdd fill rule for BOTH open and
-	// closed paths. The stroke expander's inner join pivot routing (handleInnerJoin)
-	// creates self-intersecting V-shapes at each vertex. With NonZero fill,
-	// stencil fan tessellation counts winding=2 at pixels between forward/reverse
-	// edges, incorrectly filling the entire interior. With EvenOdd, self-intersection
-	// crossings XOR correctly: stroke band (1 crossing = odd = filled), interior
-	// area (2 crossings = even = empty).
-	//
-	// This applies to both topologies:
-	//   - Closed paths: ring topology (2 contours, hollow center)
-	//   - Open paths: self-intersecting single contour (inner join V-shapes)
-	//
-	// Skia Ganesh pattern. Fixes ui#101 Thread F + issue #347.
 	strokePaint := *paint
-	strokePaint.FillRule = gg.FillRuleEvenOdd
+	if expander.HadInnerJoin() {
+		// Inner-pivot V-shapes present (sharp corners): EvenOdd stencil (Invert op)
+		// cancels the self-intersections. NonZero would count V-shape area as winding=2
+		// and render it solid. Skia Ganesh pattern. Fixes ui#101 Thread F + issue #347.
+		strokePaint.FillRule = gg.FillRuleEvenOdd
+	} else {
+		// No V-shapes (all joins were skipped — smooth corners like round-rects, circles).
+		// The two contours from finishClosed are properly wound (outer CW, inner CCW),
+		// so NonZero correctly produces a hollow ring without relying on
+		// StencilOperationInvert, which has driver bugs on some AMD D3D12 GPUs (#374).
+		strokePaint.FillRule = gg.FillRuleNonZero
+	}
 	return rc.FillPath(target, fillPath, &strokePaint)
 }
 

--- a/internal/gpu/vello_accelerator.go
+++ b/internal/gpu/vello_accelerator.go
@@ -260,13 +260,19 @@ func (a *VelloAccelerator) StrokePath(target gg.GPURenderTarget, path *gg.Path, 
 	// Build a gg.Path from the expanded outline.
 	fillPath := strokeResultToPath(outVerbs, outCoords)
 
-	// The expanded stroke is two closed contours (outer + inner, opposite winding).
-	// EvenOdd fill rule is required so the inner contour cancels the outer,
-	// producing a hollow ring. NonZero would fill solid because inner join
-	// pivot V-shapes create self-intersections. Matches GPURenderContext.StrokePath
-	// (gpu_render_context.go:667). ADR-043, #369.
 	strokePaint := *paint
-	strokePaint.FillRule = gg.FillRuleEvenOdd
+	if expander.HadInnerJoin() {
+		// Inner-pivot V-shapes present (sharp corners): EvenOdd cancels them.
+		// NonZero would count V-shape area as winding=2 and render solid.
+		// ADR-043, #369.
+		strokePaint.FillRule = gg.FillRuleEvenOdd
+	} else {
+		// No V-shapes (smooth corners — round-rects, circles, etc.).
+		// The two contours from finishClosed are properly wound (outer CW, inner CCW),
+		// so NonZero produces a hollow ring without StencilOperationInvert.
+		// Mirrors GPURenderContext.StrokePath. Fixes #374.
+		strokePaint.FillRule = gg.FillRuleNonZero
+	}
 	return a.FillPath(target, fillPath, &strokePaint)
 }
 

--- a/internal/stroke/expander.go
+++ b/internal/stroke/expander.go
@@ -218,6 +218,11 @@ type StrokeExpander struct {
 	// Join threshold for skipping small joins
 	joinThresh float64
 
+	// hadInnerJoin is true if handleInnerJoin was called during the last Expand.
+	// When false, the expanded path has no inner-pivot V-shapes and can be
+	// rendered with NonZero fill rule (avoids StencilOperationInvert).
+	hadInnerJoin bool
+
 	// Reusable buffer for curve flattening (flattenQuad/flattenCubic).
 	// Retained between calls to avoid per-curve allocations.
 	flattenBuf []Point
@@ -291,6 +296,13 @@ func (e *StrokeExpander) Expand(verbs []PathVerb, coords []float64) ([]PathVerb,
 	return e.output.verbs, e.output.coords
 }
 
+// HadInnerJoin reports whether handleInnerJoin was called during the last Expand.
+// When false, all joins were skipped (smooth path) and the expansion produces
+// no inner-pivot V-shapes, making it safe to use NonZero fill rule.
+func (e *StrokeExpander) HadInnerJoin() bool {
+	return e.hadInnerJoin
+}
+
 // reset clears the expander state for a new expansion.
 // Buffers are truncated but retain their backing arrays for reuse.
 func (e *StrokeExpander) reset() {
@@ -304,6 +316,7 @@ func (e *StrokeExpander) reset() {
 	e.lastTan = Vec2{}
 	e.lastNorm = Vec2{}
 	e.joinThresh = 2.0 * e.tolerance / e.style.Width
+	e.hadInnerJoin = false
 }
 
 // doJoin handles joining the current segment to the previous one.
@@ -384,6 +397,7 @@ func (e *StrokeExpander) joinWithPrevious(p0 Point, norm, tan0 Vec2) {
 // Without step 2, the inner path "jumps" diagonally from pivot to the next
 // doLine() position, creating visible teeth on thick strokes (#354).
 func (e *StrokeExpander) handleInnerJoin(path *pathBuilder, pivot Point, afterNorm Vec2) {
+	e.hadInnerJoin = true
 	path.lineTo(pivot)
 	path.lineTo(pivot.Add(afterNorm))
 }

--- a/internal/stroke/expander_test.go
+++ b/internal/stroke/expander_test.go
@@ -824,3 +824,26 @@ func TestHadInnerJoin_SharpRectangle(t *testing.T) {
 		t.Error("sharp-cornered rectangle should produce inner-pivot V-shapes (HadInnerJoin=true)")
 	}
 }
+
+// TestHadInnerJoin_ZeroRadiusRoundRect verifies that a round-rect with radius=0
+// (which degenerates to a sharp rectangle with no cubic arcs) sets HadInnerJoin=true.
+// This ensures the GPU stencil path falls back to EvenOdd for degenerate round-rects.
+func TestHadInnerJoin_ZeroRadiusRoundRect(t *testing.T) {
+	// radius=0 → DrawRoundedRectangle clamps to 0, producing pure LineTos with 90° corners.
+	const x, y, w, h = 10.0, 10.0, 100.0, 50.0
+
+	path := newSOAPath()
+	path.moveTo(x, y)
+	path.lineTo(x+w, y)
+	path.lineTo(x+w, y+h)
+	path.lineTo(x, y+h)
+	path.close()
+
+	style := Stroke{Width: 1.0, Cap: LineCapButt, Join: LineJoinMiter, MiterLimit: 4.0}
+	exp := NewStrokeExpander(style)
+	exp.Expand(path.verbs, path.coords)
+
+	if !exp.HadInnerJoin() {
+		t.Error("zero-radius round-rect (sharp rectangle) should have HadInnerJoin=true")
+	}
+}

--- a/internal/stroke/expander_test.go
+++ b/internal/stroke/expander_test.go
@@ -762,3 +762,65 @@ func TestRoundJoin_VShape(t *testing.T) {
 		t.Error("round join arc should be near the join point")
 	}
 }
+
+// TestHadInnerJoin_SmoothRoundRect verifies that a round-rect path (with cubic
+// corner arcs) produces no inner-pivot V-shapes. HadInnerJoin must be false so
+// the GPU stencil path can use NonZero fill rule instead of StencilOperationInvert.
+// This is the regression test for issue #374 (thin round-rect strokes solid on AMD).
+func TestHadInnerJoin_SmoothRoundRect(t *testing.T) {
+	// Build a round-rect path with cubic bezier arcs matching DrawRoundedRectangle.
+	const x, y, w, h, r = 10.0, 10.0, 100.0, 50.0, 5.0
+	const k = 0.5522847498307936
+	kr := k * r
+
+	path := newSOAPath()
+	path.moveTo(x+r, y)
+	path.lineTo(x+w-r, y)
+	path.cubicTo(x+w-r+kr, y, x+w, y+r-kr, x+w, y+r)
+	path.lineTo(x+w, y+h-r)
+	path.cubicTo(x+w, y+h-r+kr, x+w-r+kr, y+h, x+w-r, y+h)
+	path.lineTo(x+r, y+h)
+	path.cubicTo(x+r-kr, y+h, x, y+h-r+kr, x, y+h-r)
+	path.lineTo(x, y+r)
+	path.cubicTo(x, y+r-kr, x+r-kr, y, x+r, y)
+	path.close()
+
+	style := Stroke{Width: 1.0, Cap: LineCapButt, Join: LineJoinMiter, MiterLimit: 4.0}
+	exp := NewStrokeExpander(style)
+	verbs, _ := exp.Expand(path.verbs, path.coords)
+
+	if exp.HadInnerJoin() {
+		t.Error("smooth round-rect should have no inner-pivot V-shapes (HadInnerJoin=false); " +
+			"got HadInnerJoin=true, which would trigger EvenOdd+Invert stencil path")
+	}
+
+	// Verify the output has exactly 2 closed contours (outer + inner from finishClosed).
+	closeCount := 0
+	for _, v := range verbs {
+		if v == VerbClose {
+			closeCount++
+		}
+	}
+	if closeCount != 2 {
+		t.Errorf("closed round-rect expansion should produce 2 contours, got %d VerbClose", closeCount)
+	}
+}
+
+// TestHadInnerJoin_SharpRectangle verifies that a sharp-cornered rectangle
+// sets HadInnerJoin=true, keeping EvenOdd fill rule for correct V-shape handling.
+func TestHadInnerJoin_SharpRectangle(t *testing.T) {
+	path := newSOAPath()
+	path.moveTo(10, 10)
+	path.lineTo(110, 10)
+	path.lineTo(110, 60)
+	path.lineTo(10, 60)
+	path.close()
+
+	style := Stroke{Width: 1.0, Cap: LineCapButt, Join: LineJoinMiter, MiterLimit: 4.0}
+	exp := NewStrokeExpander(style)
+	exp.Expand(path.verbs, path.coords)
+
+	if !exp.HadInnerJoin() {
+		t.Error("sharp-cornered rectangle should produce inner-pivot V-shapes (HadInnerJoin=true)")
+	}
+}


### PR DESCRIPTION
use NonZero fill rule for smooth paths to avoid AMD stencil invert bug

EvenOdd's StencilOperationInvert has a driver bug on AMD Radeon 890M +
D3D12: inverted stencil fails to cancel the inner polygon, leaving a
solid fill instead of a ring.

Select fill rule based on whether the expander produced inner-pivot
V-shapes (handleInnerJoin):
- Smooth paths (round-rects, circles): no V-shapes -> NonZero, using
  opposite winding (outer CW, inner CCW) to produce ring=1, inner=0
  without StencilOperationInvert.
- Sharp-cornered paths (rects, polygons): V-shapes present -> keep
  EvenOdd, which NonZero would miscount.

Touches expander.go (hadInnerJoin tracking), gpu_render_context.go
(conditional fill rule), expander_test.go (regression tests for both
cases).