### PR TITLE
test: update Vello stroke tests for dynamic fill rule (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.12] - 2026-06-18
+
+### Fixed
+
+- **AMD stencil invert driver bug workaround** (#374, @lkmavi) — `StencilOperationInvert`
+  fails on AMD Radeon 890M D3D12, causing thin round-rect strokes to render as solid fills.
+  Fix: select fill rule dynamically based on path topology via `HadInnerJoin()`. Smooth paths
+  (round-rects, circles with cubic arcs) use NonZero (opposite winding cancels without Invert).
+  Sharp-cornered paths (rectangles, polygons) keep EvenOdd for correct V-shape handling.
+  Applied to both `GPURenderContext.StrokePath` and `VelloAccelerator.StrokePath`.
+  3 regression tests added in `expander_test.go`.
+
 ## [0.48.11] - 2026-06-15
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.48.11
+## Current State: v0.48.12
 
 ✅ **Production-ready** with GPU-accelerated rendering:
 - **Text stroke/outline** (ADR-033) — StrokeString + TextPath, Skia/Cairo/HTML5 pattern
@@ -92,9 +92,14 @@
 
 ## Current Release
 
-### v0.48.11 — Current
+### v0.48.12 — Current
+- [x] **AMD stencil invert workaround** (#374, @lkmavi) — dynamic fill rule via `HadInnerJoin()`
+- [x] Smooth paths → NonZero (avoids buggy StencilOperationInvert on AMD D3D12)
+- [x] Sharp paths → EvenOdd (correct V-shape handling)
+- [x] 3 regression tests + 4 Vello accumulator tests updated
+
+### v0.48.11 ✅ Released
 - [x] **Vello StrokePath EvenOdd fill rule** (#369, ADR-043, @TimLai666) — thin strokes solid fill on GPU compute
-- 2 regression tests (StrokePathUsesEvenOdd, StrokeShapeUsesEvenOdd)
 
 ### v0.48.10 ✅ Released
 - [x] **Backdrop prefix sum boundary fix** (BUG-BACKDROP-001, ADR-042) — Vello backdrop_dyn pattern
@@ -287,7 +292,8 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.48.11** | 2026-06 | Vello StrokePath EvenOdd (#369 @TimLai666), thin strokes solid fill fix |
+| **v0.48.12** | 2026-06 | AMD stencil invert workaround (#374 @lkmavi), dynamic fill rule HadInnerJoin |
+| v0.48.11 | 2026-06 | Vello StrokePath EvenOdd (#369 @TimLai666), thin strokes solid fill fix |
 | v0.48.10 | 2026-06 | Backdrop prefix sum fix (ADR-042), wgpu v0.30.1 opaque handles, gogpu v0.42.0 |
 | v0.48.9 | 2026-06 | Glyph mask quadOffset fix (BUG-GLYPHMASK-001, #365), deps v0.29.15/v0.17.15/v0.41.14 |
 | v0.48.8 | 2026-06 | HiDPI fix (#361 @TuSKan), OpenType font features (#362 @TuSKan) |

--- a/internal/gpu/vello_accumulate_test.go
+++ b/internal/gpu/vello_accumulate_test.go
@@ -154,15 +154,15 @@ func TestVelloAccelerator_StrokePathAccumulates(t *testing.T) {
 	}
 }
 
-// TestVelloAccelerator_StrokePathUsesEvenOdd is a regression test for #369:
-// expanded stroke outlines must use EvenOdd fill rule so the inner contour
-// cancels the outer (ring topology). Without EvenOdd, strokes render as
-// solid fills. ADR-043.
-func TestVelloAccelerator_StrokePathUsesEvenOdd(t *testing.T) {
+// TestVelloAccelerator_StrokePathSmoothUsesNonZero verifies that smooth paths
+// (round-rects with cubic arcs, no inner-pivot V-shapes) use NonZero fill rule.
+// This avoids StencilOperationInvert which has driver bugs on AMD D3D12 (#374).
+// ADR-043, updated by PR #376.
+func TestVelloAccelerator_StrokePathSmoothUsesNonZero(t *testing.T) {
 	a := &VelloAccelerator{gpuReady: true}
 	target := makeTestTarget(200, 200)
 
-	// Closed round-rect — the exact shape from #369.
+	// Closed round-rect — smooth cubic arcs, no handleInnerJoin triggered.
 	path := gg.NewPath()
 	path.RoundedRectangle(40, 40, 120, 80, 12)
 
@@ -178,17 +178,45 @@ func TestVelloAccelerator_StrokePathUsesEvenOdd(t *testing.T) {
 		t.Fatalf("expected 1 pending, got %d", a.PendingCount())
 	}
 
-	// The accumulated path MUST have EvenOdd fill rule.
+	pathDef := a.pendingPaths[0]
+	if pathDef.FillRule != tilecompute.FillRuleNonZero {
+		t.Errorf("smooth StrokePath fill rule = %v, want NonZero (%v)",
+			pathDef.FillRule, tilecompute.FillRuleNonZero)
+	}
+}
+
+// TestVelloAccelerator_StrokePathSharpUsesEvenOdd verifies that sharp-cornered
+// paths (rectangles with 90° corners, inner-pivot V-shapes) use EvenOdd fill rule.
+func TestVelloAccelerator_StrokePathSharpUsesEvenOdd(t *testing.T) {
+	a := &VelloAccelerator{gpuReady: true}
+	target := makeTestTarget(200, 200)
+
+	// Sharp rectangle — 90° corners trigger handleInnerJoin.
+	path := gg.NewPath()
+	path.Rectangle(40, 40, 120, 80)
+
+	paint := gg.NewPaint()
+	paint.SetBrush(gg.Solid(gg.Red))
+	s := gg.Stroke{Width: 2.0, Cap: gg.LineCapButt, Join: gg.LineJoinMiter, MiterLimit: 10.0}
+	paint.SetStroke(s)
+
+	if err := a.StrokePath(target, path, paint); err != nil {
+		t.Fatalf("StrokePath: unexpected error: %v", err)
+	}
+	if a.PendingCount() != 1 {
+		t.Fatalf("expected 1 pending, got %d", a.PendingCount())
+	}
+
 	pathDef := a.pendingPaths[0]
 	if pathDef.FillRule != tilecompute.FillRuleEvenOdd {
-		t.Errorf("StrokePath fill rule = %v, want EvenOdd (%v)",
+		t.Errorf("sharp StrokePath fill rule = %v, want EvenOdd (%v)",
 			pathDef.FillRule, tilecompute.FillRuleEvenOdd)
 	}
 }
 
-// TestVelloAccelerator_StrokeShapeUsesEvenOdd verifies that StrokeShape
-// (which delegates to StrokePath) also produces EvenOdd fill rule.
-func TestVelloAccelerator_StrokeShapeUsesEvenOdd(t *testing.T) {
+// TestVelloAccelerator_StrokeShapeSmoothUsesNonZero verifies that StrokeShape
+// for circles (smooth, no V-shapes) uses NonZero fill rule.
+func TestVelloAccelerator_StrokeShapeSmoothUsesNonZero(t *testing.T) {
 	a := &VelloAccelerator{gpuReady: true}
 	target := makeTestTarget(200, 200)
 
@@ -212,9 +240,9 @@ func TestVelloAccelerator_StrokeShapeUsesEvenOdd(t *testing.T) {
 	}
 
 	pathDef := a.pendingPaths[0]
-	if pathDef.FillRule != tilecompute.FillRuleEvenOdd {
-		t.Errorf("StrokeShape fill rule = %v, want EvenOdd (%v)",
-			pathDef.FillRule, tilecompute.FillRuleEvenOdd)
+	if pathDef.FillRule != tilecompute.FillRuleNonZero {
+		t.Errorf("smooth StrokeShape fill rule = %v, want NonZero (%v)",
+			pathDef.FillRule, tilecompute.FillRuleNonZero)
 	}
 }
 


### PR DESCRIPTION
Tests from v0.48.11 expected unconditional EvenOdd. PR #376 made it conditional. Updated: smooth→NonZero, sharp→EvenOdd.