### PR TITLE
Fix/374 : stencil_pipeline.go replaces Invert with a mathematically equivalent construct:  IncrementWrap + WriteMask=0x01

### DIFF
--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -672,19 +672,16 @@ func (rc *GPURenderContext) StrokePath(target gg.GPURenderTarget, path *gg.Path,
 
 	fillPath := strokeResultToPath(outVerbs, outCoords)
 
+	// EvenOdd correctly handles both stroke topologies:
+	//   - Smooth paths (round-rects, circles): 2-contour ring (outer CW + inner CCW).
+	//     Each pixel in the hollow center is toggled twice → stencil=0 → empty.
+	//   - Sharp paths (rectangles): inner-pivot V-shapes create self-intersections.
+	//     V-shape area is toggled twice → stencil=0 → correctly hollow.
+	// The stencil EvenOdd pipeline uses IncrementWrap+WriteMask=0x01 (parity toggle)
+	// instead of StencilOperationInvert, which has a driver bug on AMD D3D12 (#374).
+	// NonZero would miscount V-shape area as winding=2 → solid fill (wrong for sharp paths).
 	strokePaint := *paint
-	if expander.HadInnerJoin() {
-		// Inner-pivot V-shapes present (sharp corners): EvenOdd stencil (Invert op)
-		// cancels the self-intersections. NonZero would count V-shape area as winding=2
-		// and render it solid. Skia Ganesh pattern. Fixes ui#101 Thread F + issue #347.
-		strokePaint.FillRule = gg.FillRuleEvenOdd
-	} else {
-		// No V-shapes (all joins were skipped — smooth corners like round-rects, circles).
-		// The two contours from finishClosed are properly wound (outer CW, inner CCW),
-		// so NonZero correctly produces a hollow ring without relying on
-		// StencilOperationInvert, which has driver bugs on some AMD D3D12 GPUs (#374).
-		strokePaint.FillRule = gg.FillRuleNonZero
-	}
+	strokePaint.FillRule = gg.FillRuleEvenOdd
 	return rc.FillPath(target, fillPath, &strokePaint)
 }
 

--- a/internal/gpu/stencil_pipeline.go
+++ b/internal/gpu/stencil_pipeline.go
@@ -36,7 +36,9 @@ const vertexStride = 8
 //
 // Two stencil fill pipeline variants are created:
 //   - NonZero: front=IncrementWrap / back=DecrementWrap (winding number).
-//   - EvenOdd: front=Invert / back=Invert (parity count).
+//   - EvenOdd: front=IncrementWrap / back=IncrementWrap with WriteMask=0x01
+//     (parity via bit-0 toggle — equivalent to Invert but avoids the AMD D3D12
+//     StencilOperationInvert driver bug on Radeon 890M and similar GPUs, #374).
 //
 // The cover pipeline reads the stencil buffer with NotEqual(0) and resets
 // stencil values to zero via PassOp=Zero after writing the fill color.
@@ -183,9 +185,14 @@ func (sr *StencilRenderer) createPipelines() error { //nolint:funlen // GPU pipe
 
 	// --- Even-Odd Stencil Fill Pipeline ---
 	//
-	// Even-odd fill rule: both front and back faces invert the stencil value.
-	// A pixel with odd winding count has stencil != 0 (inside), even count
-	// wraps back to 0 (outside). Same shader and layout as the non-zero variant.
+	// Even-odd fill rule: both front and back faces toggle the stencil parity bit.
+	// WriteMask=0x01 restricts writes to bit 0 only. IncrementWrap on a 1-bit field
+	// is equivalent to XOR/Invert: 0→1→0→... This avoids StencilOperationInvert,
+	// which has a driver bug on AMD Radeon 890M D3D12 (and similar GPUs) that
+	// causes the stencil to not be toggled correctly, making strokes render as solid
+	// fills (#374). Pixels inside an odd number of crossings have stencil=1 (inside),
+	// pixels inside an even number have stencil=0 (outside). Same shader and layout
+	// as the non-zero variant.
 	evenOddStencilPipeline, err := sr.device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
 		Label:  "stencil_fill_even_odd_pipeline",
 		Layout: sr.stencilPipeLayout,
@@ -212,16 +219,16 @@ func (sr *StencilRenderer) createPipelines() error { //nolint:funlen // GPU pipe
 				Compare:     gputypes.CompareFunctionAlways,
 				FailOp:      wgpu.StencilOperationKeep,
 				DepthFailOp: wgpu.StencilOperationKeep,
-				PassOp:      wgpu.StencilOperationInvert,
+				PassOp:      wgpu.StencilOperationIncrementWrap,
 			},
 			StencilBack: wgpu.StencilFaceState{
 				Compare:     gputypes.CompareFunctionAlways,
 				FailOp:      wgpu.StencilOperationKeep,
 				DepthFailOp: wgpu.StencilOperationKeep,
-				PassOp:      wgpu.StencilOperationInvert,
+				PassOp:      wgpu.StencilOperationIncrementWrap,
 			},
 			StencilReadMask:  0xFF,
-			StencilWriteMask: 0xFF,
+			StencilWriteMask: 0x01,
 		},
 		Multisample: multisample,
 		Primitive:   primitive,
@@ -368,6 +375,8 @@ func (sr *StencilRenderer) ensureDepthClipPipelines() error { //nolint:funlen //
 	sr.pipelineWithDepthClipNZ = nzPipeline
 
 	// --- Even-odd stencil fill + depth clip ---
+	// Same IncrementWrap+WriteMask=0x01 approach as the base EvenOdd pipeline
+	// (avoids AMD D3D12 StencilOperationInvert bug, #374).
 	eoPipeline, err := sr.device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
 		Label:  "stencil_fill_even_odd_depth_clip_pipeline",
 		Layout: sr.stencilPipeLayout,
@@ -389,14 +398,14 @@ func (sr *StencilRenderer) ensureDepthClipPipelines() error { //nolint:funlen //
 			DepthCompare:      gputypes.CompareFunctionGreaterEqual,
 			StencilFront: wgpu.StencilFaceState{
 				Compare: gputypes.CompareFunctionAlways, FailOp: wgpu.StencilOperationKeep,
-				DepthFailOp: wgpu.StencilOperationKeep, PassOp: wgpu.StencilOperationInvert,
+				DepthFailOp: wgpu.StencilOperationKeep, PassOp: wgpu.StencilOperationIncrementWrap,
 			},
 			StencilBack: wgpu.StencilFaceState{
 				Compare: gputypes.CompareFunctionAlways, FailOp: wgpu.StencilOperationKeep,
-				DepthFailOp: wgpu.StencilOperationKeep, PassOp: wgpu.StencilOperationInvert,
+				DepthFailOp: wgpu.StencilOperationKeep, PassOp: wgpu.StencilOperationIncrementWrap,
 			},
 			StencilReadMask:  0xFF,
-			StencilWriteMask: 0xFF,
+			StencilWriteMask: 0x01,
 		},
 		Multisample: multisample,
 		Primitive:   primitive,

--- a/internal/gpu/vello_accelerator.go
+++ b/internal/gpu/vello_accelerator.go
@@ -260,19 +260,12 @@ func (a *VelloAccelerator) StrokePath(target gg.GPURenderTarget, path *gg.Path, 
 	// Build a gg.Path from the expanded outline.
 	fillPath := strokeResultToPath(outVerbs, outCoords)
 
+	// EvenOdd correctly handles both stroke topologies:
+	//   - Smooth paths: 2-contour ring, center toggled twice → empty.
+	//   - Sharp paths: V-shape intersections toggled twice → correctly hollow.
+	// Mirrors GPURenderContext.StrokePath. ADR-043, #369, #374.
 	strokePaint := *paint
-	if expander.HadInnerJoin() {
-		// Inner-pivot V-shapes present (sharp corners): EvenOdd cancels them.
-		// NonZero would count V-shape area as winding=2 and render solid.
-		// ADR-043, #369.
-		strokePaint.FillRule = gg.FillRuleEvenOdd
-	} else {
-		// No V-shapes (smooth corners — round-rects, circles, etc.).
-		// The two contours from finishClosed are properly wound (outer CW, inner CCW),
-		// so NonZero produces a hollow ring without StencilOperationInvert.
-		// Mirrors GPURenderContext.StrokePath. Fixes #374.
-		strokePaint.FillRule = gg.FillRuleNonZero
-	}
+	strokePaint.FillRule = gg.FillRuleEvenOdd
 	return a.FillPath(target, fillPath, &strokePaint)
 }
 

--- a/internal/gpu/vello_accumulate_test.go
+++ b/internal/gpu/vello_accumulate_test.go
@@ -154,15 +154,16 @@ func TestVelloAccelerator_StrokePathAccumulates(t *testing.T) {
 	}
 }
 
-// TestVelloAccelerator_StrokePathSmoothUsesNonZero verifies that smooth paths
-// (round-rects with cubic arcs, no inner-pivot V-shapes) use NonZero fill rule.
-// This avoids StencilOperationInvert which has driver bugs on AMD D3D12 (#374).
-// ADR-043, updated by PR #376.
-func TestVelloAccelerator_StrokePathSmoothUsesNonZero(t *testing.T) {
+// TestVelloAccelerator_StrokeSmoothPath_UsesNonZero verifies that smooth paths
+// (round-rects, circles — no inner-pivot V-shapes) use NonZero fill rule after
+// stroke expansion. The two contours (outer CW + inner CCW) are properly wound,
+// so NonZero correctly produces a hollow ring without StencilOperationInvert.
+// Regression test for #374 (AMD Radeon 890M D3D12 Invert bug).
+func TestVelloAccelerator_StrokeSmoothPath_UsesNonZero(t *testing.T) {
 	a := &VelloAccelerator{gpuReady: true}
 	target := makeTestTarget(200, 200)
 
-	// Closed round-rect — smooth cubic arcs, no handleInnerJoin triggered.
+	// Closed round-rect — smooth path, no inner-pivot V-shapes.
 	path := gg.NewPath()
 	path.RoundedRectangle(40, 40, 120, 80, 12)
 
@@ -180,24 +181,27 @@ func TestVelloAccelerator_StrokePathSmoothUsesNonZero(t *testing.T) {
 
 	pathDef := a.pendingPaths[0]
 	if pathDef.FillRule != tilecompute.FillRuleNonZero {
-		t.Errorf("smooth StrokePath fill rule = %v, want NonZero (%v)",
+		t.Errorf("StrokePath smooth path fill rule = %v, want NonZero (%v); "+
+			"smooth paths must not use EvenOdd+Invert stencil (AMD D3D12 bug #374)",
 			pathDef.FillRule, tilecompute.FillRuleNonZero)
 	}
 }
 
-// TestVelloAccelerator_StrokePathSharpUsesEvenOdd verifies that sharp-cornered
-// paths (rectangles with 90° corners, inner-pivot V-shapes) use EvenOdd fill rule.
-func TestVelloAccelerator_StrokePathSharpUsesEvenOdd(t *testing.T) {
+// TestVelloAccelerator_StrokeSharpPath_UsesEvenOdd verifies that sharp-cornered
+// paths (rectangles — with inner-pivot V-shapes) use EvenOdd fill rule.
+// The V-shapes from handleInnerJoin create self-intersections that EvenOdd
+// correctly cancels via XOR semantics. ADR-043, #369.
+func TestVelloAccelerator_StrokeSharpPath_UsesEvenOdd(t *testing.T) {
 	a := &VelloAccelerator{gpuReady: true}
 	target := makeTestTarget(200, 200)
 
-	// Sharp rectangle — 90° corners trigger handleInnerJoin.
+	// Sharp rectangle — no rounded corners, inner-pivot V-shapes at all 4 corners.
 	path := gg.NewPath()
 	path.Rectangle(40, 40, 120, 80)
 
 	paint := gg.NewPaint()
-	paint.SetBrush(gg.Solid(gg.Red))
-	s := gg.Stroke{Width: 2.0, Cap: gg.LineCapButt, Join: gg.LineJoinMiter, MiterLimit: 10.0}
+	paint.SetBrush(gg.Solid(gg.RGBA{R: 0.5, G: 0.5, B: 0.5, A: 1}))
+	s := gg.Stroke{Width: 1.0, Cap: gg.LineCapButt, Join: gg.LineJoinMiter, MiterLimit: 10.0}
 	paint.SetStroke(s)
 
 	if err := a.StrokePath(target, path, paint); err != nil {
@@ -209,14 +213,15 @@ func TestVelloAccelerator_StrokePathSharpUsesEvenOdd(t *testing.T) {
 
 	pathDef := a.pendingPaths[0]
 	if pathDef.FillRule != tilecompute.FillRuleEvenOdd {
-		t.Errorf("sharp StrokePath fill rule = %v, want EvenOdd (%v)",
+		t.Errorf("StrokePath sharp path fill rule = %v, want EvenOdd (%v); "+
+			"sharp corners produce V-shapes that require EvenOdd for correct hollow rendering",
 			pathDef.FillRule, tilecompute.FillRuleEvenOdd)
 	}
 }
 
-// TestVelloAccelerator_StrokeShapeSmoothUsesNonZero verifies that StrokeShape
-// for circles (smooth, no V-shapes) uses NonZero fill rule.
-func TestVelloAccelerator_StrokeShapeSmoothUsesNonZero(t *testing.T) {
+// TestVelloAccelerator_StrokeShape_SmoothUsesNonZero verifies that StrokeShape
+// for smooth shapes (circle) produces NonZero fill rule (#374).
+func TestVelloAccelerator_StrokeShape_SmoothUsesNonZero(t *testing.T) {
 	a := &VelloAccelerator{gpuReady: true}
 	target := makeTestTarget(200, 200)
 
@@ -241,7 +246,8 @@ func TestVelloAccelerator_StrokeShapeSmoothUsesNonZero(t *testing.T) {
 
 	pathDef := a.pendingPaths[0]
 	if pathDef.FillRule != tilecompute.FillRuleNonZero {
-		t.Errorf("smooth StrokeShape fill rule = %v, want NonZero (%v)",
+		t.Errorf("StrokeShape circle fill rule = %v, want NonZero (%v); "+
+			"smooth shapes must not use EvenOdd+Invert stencil (AMD D3D12 bug #374)",
 			pathDef.FillRule, tilecompute.FillRuleNonZero)
 	}
 }

--- a/internal/gpu/vello_accumulate_test.go
+++ b/internal/gpu/vello_accumulate_test.go
@@ -154,101 +154,74 @@ func TestVelloAccelerator_StrokePathAccumulates(t *testing.T) {
 	}
 }
 
-// TestVelloAccelerator_StrokeSmoothPath_UsesNonZero verifies that smooth paths
-// (round-rects, circles — no inner-pivot V-shapes) use NonZero fill rule after
-// stroke expansion. The two contours (outer CW + inner CCW) are properly wound,
-// so NonZero correctly produces a hollow ring without StencilOperationInvert.
-// Regression test for #374 (AMD Radeon 890M D3D12 Invert bug).
-func TestVelloAccelerator_StrokeSmoothPath_UsesNonZero(t *testing.T) {
-	a := &VelloAccelerator{gpuReady: true}
-	target := makeTestTarget(200, 200)
-
-	// Closed round-rect — smooth path, no inner-pivot V-shapes.
-	path := gg.NewPath()
-	path.RoundedRectangle(40, 40, 120, 80, 12)
-
-	paint := gg.NewPaint()
-	paint.SetBrush(gg.Solid(gg.RGBA{R: 0.5, G: 0.5, B: 0.5, A: 1}))
-	s := gg.Stroke{Width: 1.0, Cap: gg.LineCapButt, Join: gg.LineJoinRound, MiterLimit: 10.0}
-	paint.SetStroke(s)
-
-	if err := a.StrokePath(target, path, paint); err != nil {
-		t.Fatalf("StrokePath: unexpected error: %v", err)
-	}
-	if a.PendingCount() != 1 {
-		t.Fatalf("expected 1 pending, got %d", a.PendingCount())
-	}
-
-	pathDef := a.pendingPaths[0]
-	if pathDef.FillRule != tilecompute.FillRuleNonZero {
-		t.Errorf("StrokePath smooth path fill rule = %v, want NonZero (%v); "+
-			"smooth paths must not use EvenOdd+Invert stencil (AMD D3D12 bug #374)",
-			pathDef.FillRule, tilecompute.FillRuleNonZero)
-	}
-}
-
-// TestVelloAccelerator_StrokeSharpPath_UsesEvenOdd verifies that sharp-cornered
-// paths (rectangles — with inner-pivot V-shapes) use EvenOdd fill rule.
-// The V-shapes from handleInnerJoin create self-intersections that EvenOdd
-// correctly cancels via XOR semantics. ADR-043, #369.
-func TestVelloAccelerator_StrokeSharpPath_UsesEvenOdd(t *testing.T) {
-	a := &VelloAccelerator{gpuReady: true}
-	target := makeTestTarget(200, 200)
-
-	// Sharp rectangle — no rounded corners, inner-pivot V-shapes at all 4 corners.
-	path := gg.NewPath()
-	path.Rectangle(40, 40, 120, 80)
-
-	paint := gg.NewPaint()
-	paint.SetBrush(gg.Solid(gg.RGBA{R: 0.5, G: 0.5, B: 0.5, A: 1}))
-	s := gg.Stroke{Width: 1.0, Cap: gg.LineCapButt, Join: gg.LineJoinMiter, MiterLimit: 10.0}
-	paint.SetStroke(s)
-
-	if err := a.StrokePath(target, path, paint); err != nil {
-		t.Fatalf("StrokePath: unexpected error: %v", err)
-	}
-	if a.PendingCount() != 1 {
-		t.Fatalf("expected 1 pending, got %d", a.PendingCount())
+// TestVelloAccelerator_StrokeAlwaysUsesEvenOdd verifies that all stroke expansions
+// use EvenOdd fill rule regardless of path topology (smooth or sharp corners).
+// EvenOdd via IncrementWrap+WriteMask=0x01 correctly handles both topologies:
+//   - Smooth (round-rects, circles): 2-contour ring — center toggled twice → empty.
+//   - Sharp (rectangles): inner-pivot V-shapes — intersection toggled twice → empty.
+//
+// Using EvenOdd unconditionally also avoids any potential AMD D3D12 stencil issues
+// that may affect the NonZero IncrementWrap/DecrementWrap pipeline on ring paths (#374).
+// ADR-043, #369, #374.
+func TestVelloAccelerator_StrokeAlwaysUsesEvenOdd(t *testing.T) {
+	tests := []struct {
+		name string
+		path func() *gg.Path
+		join gg.LineJoin
+	}{
+		{
+			name: "smooth round-rect",
+			path: func() *gg.Path { p := gg.NewPath(); p.RoundedRectangle(40, 40, 120, 80, 12); return p },
+			join: gg.LineJoinRound,
+		},
+		{
+			name: "sharp rectangle",
+			path: func() *gg.Path { p := gg.NewPath(); p.Rectangle(40, 40, 120, 80); return p },
+			join: gg.LineJoinMiter,
+		},
 	}
 
-	pathDef := a.pendingPaths[0]
-	if pathDef.FillRule != tilecompute.FillRuleEvenOdd {
-		t.Errorf("StrokePath sharp path fill rule = %v, want EvenOdd (%v); "+
-			"sharp corners produce V-shapes that require EvenOdd for correct hollow rendering",
-			pathDef.FillRule, tilecompute.FillRuleEvenOdd)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &VelloAccelerator{gpuReady: true}
+			target := makeTestTarget(200, 200)
+
+			paint := gg.NewPaint()
+			paint.SetBrush(gg.Solid(gg.Red))
+			paint.SetStroke(gg.Stroke{Width: 2.0, Cap: gg.LineCapButt, Join: tc.join, MiterLimit: 10.0})
+
+			if err := a.StrokePath(target, tc.path(), paint); err != nil {
+				t.Fatalf("StrokePath: %v", err)
+			}
+			if a.PendingCount() != 1 {
+				t.Fatalf("expected 1 pending, got %d", a.PendingCount())
+			}
+			if got := a.pendingPaths[0].FillRule; got != tilecompute.FillRuleEvenOdd {
+				t.Errorf("%s: fill rule = %v, want EvenOdd", tc.name, got)
+			}
+		})
 	}
 }
 
-// TestVelloAccelerator_StrokeShape_SmoothUsesNonZero verifies that StrokeShape
-// for smooth shapes (circle) produces NonZero fill rule (#374).
-func TestVelloAccelerator_StrokeShape_SmoothUsesNonZero(t *testing.T) {
+// TestVelloAccelerator_StrokeShapeUsesEvenOdd verifies that StrokeShape (which
+// delegates to StrokePath) also produces EvenOdd fill rule. ADR-043, #369, #374.
+func TestVelloAccelerator_StrokeShapeUsesEvenOdd(t *testing.T) {
 	a := &VelloAccelerator{gpuReady: true}
 	target := makeTestTarget(200, 200)
 
-	shape := gg.DetectedShape{
-		Kind:    gg.ShapeCircle,
-		CenterX: 100,
-		CenterY: 100,
-		RadiusX: 40,
-	}
-
+	shape := gg.DetectedShape{Kind: gg.ShapeCircle, CenterX: 100, CenterY: 100, RadiusX: 40}
 	paint := gg.NewPaint()
 	paint.SetBrush(gg.Solid(gg.Red))
-	s := gg.Stroke{Width: 2.0, Cap: gg.LineCapButt, Join: gg.LineJoinRound, MiterLimit: 10.0}
-	paint.SetStroke(s)
+	paint.SetStroke(gg.Stroke{Width: 2.0, Cap: gg.LineCapButt, Join: gg.LineJoinRound, MiterLimit: 10.0})
 
 	if err := a.StrokeShape(target, shape, paint); err != nil {
-		t.Fatalf("StrokeShape: unexpected error: %v", err)
+		t.Fatalf("StrokeShape: %v", err)
 	}
 	if a.PendingCount() != 1 {
 		t.Fatalf("expected 1 pending, got %d", a.PendingCount())
 	}
-
-	pathDef := a.pendingPaths[0]
-	if pathDef.FillRule != tilecompute.FillRuleNonZero {
-		t.Errorf("StrokeShape circle fill rule = %v, want NonZero (%v); "+
-			"smooth shapes must not use EvenOdd+Invert stencil (AMD D3D12 bug #374)",
-			pathDef.FillRule, tilecompute.FillRuleNonZero)
+	if got := a.pendingPaths[0].FillRule; got != tilecompute.FillRuleEvenOdd {
+		t.Errorf("StrokeShape fill rule = %v, want EvenOdd", got)
 	}
 }
 


### PR DESCRIPTION
A fix in stencil_pipeline.go replaces Invert with a mathematically equivalent construct:

IncrementWrap + WriteMask=0x01

IncrementWrap on a single-bit field works like XOR/Invert: 0→1→0→1→... — but without calling the buggy instruction.



@TimLai666  Please check on the first equipment

cc @kolkov 