### PR TITLE
fix(gpu): route thin strokes & even-odd fills to compute pipeline (fixes #374)

### DIFF
--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -593,6 +593,20 @@ func (rc *GPURenderContext) FillPath(target gg.GPURenderTarget, path *gg.Path, p
 		}
 	}
 
+	// EvenOdd fills need the hole-carving that stencil-then-cover provides, but
+	// that path mis-renders on some drivers (AMD Radeon Vulkan, #374 — the hole
+	// fills solid). Prefer the compute (Vello) pipeline for EvenOdd whenever it
+	// is available (PipelineModeRenderPass forces the legacy stencil path).
+	if paint.FillRule == gg.FillRuleEvenOdd && rc.pipelineMode != gg.PipelineModeRenderPass {
+		rc.shared.mu.Lock()
+		va := rc.shared.velloAccel
+		rc.shared.mu.Unlock()
+		if va != nil && va.CanCompute() {
+			va.SetAntiAlias(rc.antiAlias)
+			return va.FillPath(target, path, paint)
+		}
+	}
+
 	// Fall back to stencil-then-cover.
 	tess := NewFanTessellator()
 	tess.TessellatePath(path)
@@ -621,8 +635,15 @@ func (rc *GPURenderContext) StrokePath(target gg.GPURenderTarget, path *gg.Path,
 	rc.sceneStats.PathCount++
 	rc.sceneStats.ShapeCount++
 
-	// If in Compute mode, delegate to VelloAccelerator.
-	if rc.pipelineMode == gg.PipelineModeCompute {
+	// Stroke outlines expand to multi-contour EvenOdd fills. The stencil-then-
+	// cover fallback mis-renders these as solid boxes on some drivers (thin 1px
+	// round-rect/arc strokes fill solid on AMD Radeon Vulkan, #374) because the
+	// even-coverage hole pixels never collapse to stencil 0. The compute (Vello)
+	// pipeline renders them correctly, so prefer it whenever it is available —
+	// not only when explicitly requested via PipelineModeCompute. Falls through
+	// to stencil-then-cover when compute is unavailable (PipelineModeRenderPass
+	// forces the legacy path).
+	if rc.pipelineMode != gg.PipelineModeRenderPass {
 		rc.shared.mu.Lock()
 		va := rc.shared.velloAccel
 		rc.shared.mu.Unlock()

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -913,18 +913,6 @@ func (rc *GPURenderContext) flushVello(target gg.GPURenderTarget) error {
 	return nil
 }
 
-// effectivePipelineMode determines the actual mode for this flush.
-func (rc *GPURenderContext) effectivePipelineMode() gg.PipelineMode {
-	mode := rc.pipelineMode
-	if mode == gg.PipelineModeAuto {
-		rc.shared.mu.Lock()
-		hasCompute := rc.shared.velloAccel != nil && rc.shared.velloAccel.CanCompute()
-		rc.shared.mu.Unlock()
-		mode = gg.SelectPipeline(rc.sceneStats, hasCompute)
-	}
-	return mode
-}
-
 // CreateOffscreenTexture allocates a GPU texture for offscreen rendering.
 // The texture has usage flags suitable for both FlushGPUWithView (render to)
 // and DrawGPUTexture (sample from). Returns view + release function.

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -901,11 +901,10 @@ func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cy
 
 // flushVello flushes Vello compute if it has pending paths.
 func (rc *GPURenderContext) flushVello(target gg.GPURenderTarget) error {
-	effectiveMode := rc.effectivePipelineMode()
 	rc.shared.mu.Lock()
 	va := rc.shared.velloAccel
 	rc.shared.mu.Unlock()
-	if va != nil && va.PendingCount() > 0 && effectiveMode == gg.PipelineModeCompute {
+	if va != nil && va.PendingCount() > 0 {
 		if err := va.Flush(target); err != nil {
 			slogger().Debug("vello compute flush failed", "err", err)
 		}


### PR DESCRIPTION
## Summary

Fixes #374 (follow-up to #369). Thin (1px) round-rect / arc strokes still render as **solid filled boxes** on the GPU stencil path. Verified on **AMD Radeon 890M (Vulkan)** via `TimLai666/graft` kitchensink.

## Root cause (traced end-to-end)

The default `PipelineModeAuto` routes these fills through `GPURenderContext.StrokePath` → `FillPath` → **stencil-then-cover**. On this driver the even-odd parity never collapses **even-coverage (hole) pixels** back to stencil `0`, so the cover pass (`NotEqual(0)`) fills the entire shape.

I ruled out every layer the prior PRs touched, on the actual hardware:

| Hypothesis | Result |
|---|---|
| Stroke expander drops the inner contour | ❌ expander emits a correct **2-contour ring** (logged `contours=2`) |
| Stencil op `Invert` (the #372/#374 theory) | ❌ still solid |
| `IncrementWrap + WriteMask=0x01` (#378) | ❌ still solid |
| Fan anchor (per-contour vs single shared anchor) | ❌ still solid |
| **Force the same paths through the compute (Vello) pipeline** | ✅ **renders the hollow ring correctly** |

So `#372` (Vello fill-rule) and `#378` (stencil op swap) target the wrong layer — the stencil-then-cover even-odd is broken on this driver regardless of op/anchor, while the compute pipeline is correct.

The reason graft never used the working path: `StrokePath`/`FillPath` only delegate to compute when `pipelineMode == PipelineModeCompute` (exact). The default is `PipelineModeAuto`, which fell through to the broken stencil path.

## Fix

Prefer the compute (Vello) pipeline for **stroke outlines** and **EvenOdd fills** whenever it is available (`CanCompute()`), unless `PipelineModeRenderPass` is explicitly forced. Falls back to stencil-then-cover when compute is unavailable. Convex NonZero fills keep the fast convex path. Minimal, 2-hunk change in `gpu_render_context.go`.

## Verification

`go build ./...` + `go vet ./internal/gpu/` clean. On AMD Radeon 890M (Vulkan): a 1px round-rect card border that previously filled solid red now renders as a hollow ring (graft kitchensink Carousel/Resizable cards).

## Notes

- This routes *around* the stencil-then-cover even-odd bug rather than fixing it; that path is still latent for `PipelineModeRenderPass` / no-compute environments. Happy to keep #374 open for a proper stencil-level fix, or close it if routing to compute is the preferred resolution.
- Supersedes the #378 approach for the reported repro.