### PR TITLE
chore(examples): update gg v0.48.11 → v0.48.13

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/blit_only
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 )
 

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
 github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=

--- a/examples/cjk_text/go.mod
+++ b/examples/cjk_text/go.mod
@@ -2,7 +2,7 @@ module cjk_text
 
 go 1.25.5
 
-require github.com/gogpu/gg v0.48.11
+require github.com/gogpu/gg v0.48.13
 
 require (
 	github.com/go-text/typesetting v0.3.4 // indirect

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 	github.com/gogpu/gpucontext v0.21.0
 )

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
 github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_path
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 )
 

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
 github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/damage_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 	github.com/gogpu/gpucontext v0.21.0
 )

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
 github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 	github.com/gogpu/gpucontext v0.21.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
 github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/lcd_text
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 )
 

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
 github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=

--- a/examples/multi_damage_demo/go.mod
+++ b/examples/multi_damage_demo/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 replace github.com/gogpu/gg => ../..
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 	github.com/gogpu/gpucontext v0.21.0
 )

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/scene_gpu_visual
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 )
 

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
 github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.48.11
+require github.com/gogpu/gg v0.48.13
 
 require (
 	github.com/go-text/typesetting v0.3.4 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.3 h1:Ckc94SdHO42bIb0oEapRIcv+jKjhjGJfb9zPEvNKC7U
 github.com/go-webgpu/goffi v0.5.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 )
 

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
 github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback_manual
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.48.11
+	github.com/gogpu/gg v0.48.13
 	github.com/gogpu/gogpu v0.42.1
 )
 

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
-github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
+github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
 github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=


### PR DESCRIPTION
Skip v0.48.12 (AMD stencil workaround), update to v0.48.13 (gogpu v0.42.1).