### PR TITLE
fix(gpu): revert Vello routing — GPU-direct stroke regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.16] - 2026-06-25
+
+### Fixed
+
+- **GPU-direct stroke rendering regression** — v0.48.15 routed ALL strokes and
+  EvenOdd fills through Vello compute in `PipelineModeAuto`. Vello's `compositeOver()`
+  writes to `target.Data` (CPU pixmap), ignoring `target.View` (GPU texture). This
+  made strokes invisible when using `FlushGPUWithView()` — the primary rendering
+  path for ui RepaintBoundary textures. Affected: spinner arcs, chart lines,
+  dropdown borders/chevrons, any stroke through SceneCanvas replay.
+  Fix: revert routing to explicit `PipelineModeCompute` only. Stencil-then-cover
+  (with v0.48.15 IncrementWrap+WriteMask=0x01 hardening) handles `target.View`
+  correctly via render session `resolveActiveView()`. Proper GPU-direct Vello
+  output (storage texture + blit, Rust Vello pattern) tracked for v0.49.0.
+
 ## [0.48.15] - 2026-06-25
 
 ### Fixed

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -593,20 +593,6 @@ func (rc *GPURenderContext) FillPath(target gg.GPURenderTarget, path *gg.Path, p
 		}
 	}
 
-	// EvenOdd fills need the hole-carving that stencil-then-cover provides, but
-	// that path mis-renders on some drivers (AMD Radeon Vulkan, #374 — the hole
-	// fills solid). Prefer the compute (Vello) pipeline for EvenOdd whenever it
-	// is available (PipelineModeRenderPass forces the legacy stencil path).
-	if paint.FillRule == gg.FillRuleEvenOdd && rc.pipelineMode != gg.PipelineModeRenderPass {
-		rc.shared.mu.Lock()
-		va := rc.shared.velloAccel
-		rc.shared.mu.Unlock()
-		if va != nil && va.CanCompute() {
-			va.SetAntiAlias(rc.antiAlias)
-			return va.FillPath(target, path, paint)
-		}
-	}
-
 	// Fall back to stencil-then-cover.
 	tess := NewFanTessellator()
 	tess.TessellatePath(path)
@@ -635,15 +621,11 @@ func (rc *GPURenderContext) StrokePath(target gg.GPURenderTarget, path *gg.Path,
 	rc.sceneStats.PathCount++
 	rc.sceneStats.ShapeCount++
 
-	// Stroke outlines expand to multi-contour EvenOdd fills. The stencil-then-
-	// cover fallback mis-renders these as solid boxes on some drivers (thin 1px
-	// round-rect/arc strokes fill solid on AMD Radeon Vulkan, #374) because the
-	// even-coverage hole pixels never collapse to stencil 0. The compute (Vello)
-	// pipeline renders them correctly, so prefer it whenever it is available —
-	// not only when explicitly requested via PipelineModeCompute. Falls through
-	// to stencil-then-cover when compute is unavailable (PipelineModeRenderPass
-	// forces the legacy path).
-	if rc.pipelineMode != gg.PipelineModeRenderPass {
+	// In PipelineModeCompute, delegate strokes to Vello compute pipeline.
+	// Default (Auto) uses stencil-then-cover which handles target.View correctly.
+	// Vello compute currently lacks GPU-direct output (writes to CPU pixmap only),
+	// so broad routing breaks FlushGPUWithView — see TASK-GG-STROKE-REGRESSION-374.
+	if rc.pipelineMode == gg.PipelineModeCompute {
 		rc.shared.mu.Lock()
 		va := rc.shared.velloAccel
 		rc.shared.mu.Unlock()
@@ -896,18 +878,34 @@ func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cy
 	return err
 }
 
-// flushVello flushes Vello compute if it has pending paths.
+// flushVello flushes Vello compute if it has pending paths and the effective
+// pipeline mode is Compute. In Auto mode with few shapes, SelectPipeline
+// returns RenderPass — Vello paths would be lost. Guard ensures Vello is
+// flushed only when the mode actually routes paths there.
 func (rc *GPURenderContext) flushVello(target gg.GPURenderTarget) error {
+	effectiveMode := rc.effectivePipelineMode()
 	rc.shared.mu.Lock()
 	va := rc.shared.velloAccel
 	rc.shared.mu.Unlock()
-	if va != nil && va.PendingCount() > 0 {
+	if va != nil && va.PendingCount() > 0 && effectiveMode == gg.PipelineModeCompute {
 		if err := va.Flush(target); err != nil {
 			slogger().Debug("vello compute flush failed", "err", err)
 		}
 	}
 	rc.sceneStats = gg.SceneStats{}
 	return nil
+}
+
+// effectivePipelineMode determines the actual mode for this flush.
+func (rc *GPURenderContext) effectivePipelineMode() gg.PipelineMode {
+	mode := rc.pipelineMode
+	if mode == gg.PipelineModeAuto {
+		rc.shared.mu.Lock()
+		hasCompute := rc.shared.velloAccel != nil && rc.shared.velloAccel.CanCompute()
+		rc.shared.mu.Unlock()
+		mode = gg.SelectPipeline(rc.sceneStats, hasCompute)
+	}
+	return mode
 }
 
 // CreateOffscreenTexture allocates a GPU texture for offscreen rendering.

--- a/internal/gpu/pipeline_wiring_test.go
+++ b/internal/gpu/pipeline_wiring_test.go
@@ -482,3 +482,97 @@ func TestGPURenderContext_BaseLayer_DoesNotAffectOtherCounts(t *testing.T) {
 			shapes, images, gpuTex)
 	}
 }
+
+// TestStrokeRouting_AutoModeUsesStencil verifies that in PipelineModeAuto
+// (the default), StrokePath routes through stencil-then-cover, NOT through
+// Vello compute. Vello compute writes to target.Data (CPU pixmap) which is
+// ignored in GPU-direct mode (FlushGPUWithView). Stencil path uses the
+// render session which correctly handles target.View.
+//
+// Regression test for TASK-GG-STROKE-REGRESSION-374: PR #379 changed routing
+// to != PipelineModeRenderPass, breaking GPU-direct stroke rendering in ui.
+func TestStrokeRouting_AutoModeUsesStencil(t *testing.T) {
+	s := NewGPUShared()
+	s.gpuReady = true
+	s.velloAccel = &VelloAccelerator{gpuReady: true}
+	rc := &GPURenderContext{shared: s}
+	target := makeTestTarget(200, 200)
+
+	path := gg.NewPath()
+	path.Rectangle(40, 40, 120, 80)
+
+	paint := gg.NewPaint()
+	paint.SetBrush(gg.Solid(gg.Red))
+	paint.SetStroke(gg.Stroke{Width: 2.0, Cap: gg.LineCapButt, Join: gg.LineJoinMiter, MiterLimit: 10.0})
+
+	if err := rc.StrokePath(target, path, paint); err != nil {
+		t.Fatalf("StrokePath: %v", err)
+	}
+
+	if s.velloAccel.PendingCount() != 0 {
+		t.Errorf("Auto mode: stroke routed to Vello (PendingCount=%d), want stencil path",
+			s.velloAccel.PendingCount())
+	}
+	if rc.PendingCount() == 0 {
+		t.Error("Auto mode: no pending stencil commands after StrokePath")
+	}
+}
+
+// TestStrokeRouting_ComputeModeUsesVello verifies that in PipelineModeCompute
+// (explicit), StrokePath routes through Vello compute pipeline.
+func TestStrokeRouting_ComputeModeUsesVello(t *testing.T) {
+	s := NewGPUShared()
+	s.gpuReady = true
+	s.velloAccel = &VelloAccelerator{
+		gpuReady:   true,
+		dispatcher: &VelloComputeDispatcher{initialized: true},
+	}
+	rc := &GPURenderContext{shared: s, pipelineMode: gg.PipelineModeCompute}
+	target := makeTestTarget(200, 200)
+
+	path := gg.NewPath()
+	path.Rectangle(40, 40, 120, 80)
+
+	paint := gg.NewPaint()
+	paint.SetBrush(gg.Solid(gg.Red))
+	paint.SetStroke(gg.Stroke{Width: 2.0, Cap: gg.LineCapButt, Join: gg.LineJoinMiter, MiterLimit: 10.0})
+
+	if err := rc.StrokePath(target, path, paint); err != nil {
+		t.Fatalf("StrokePath: %v", err)
+	}
+
+	if s.velloAccel.PendingCount() != 1 {
+		t.Errorf("Compute mode: Vello PendingCount=%d, want 1",
+			s.velloAccel.PendingCount())
+	}
+}
+
+// TestEvenOddFillRouting_AutoModeUsesStencil verifies that EvenOdd fills
+// in PipelineModeAuto route through stencil, not Vello. Same GPU-direct
+// issue as strokes — Vello ignores target.View.
+func TestEvenOddFillRouting_AutoModeUsesStencil(t *testing.T) {
+	s := NewGPUShared()
+	s.gpuReady = true
+	s.velloAccel = &VelloAccelerator{gpuReady: true}
+	rc := &GPURenderContext{shared: s}
+	target := makeTestTarget(200, 200)
+
+	path := gg.NewPath()
+	path.MoveTo(10, 10)
+	path.LineTo(190, 10)
+	path.LineTo(100, 190)
+	path.Close()
+
+	paint := gg.NewPaint()
+	paint.SetBrush(gg.Solid(gg.Red))
+	paint.FillRule = gg.FillRuleEvenOdd
+
+	if err := rc.FillPath(target, path, paint); err != nil {
+		t.Fatalf("FillPath: %v", err)
+	}
+
+	if s.velloAccel.PendingCount() != 0 {
+		t.Errorf("Auto mode: EvenOdd fill routed to Vello (PendingCount=%d), want stencil",
+			s.velloAccel.PendingCount())
+	}
+}


### PR DESCRIPTION
## Summary

- Revert PR #379 routing (`!= RenderPass` → `== Compute`) that broke GPU-direct stroke rendering
- Vello `compositeOver()` writes to `target.Data` (CPU), ignoring `target.View` (GPU texture)
- Stencil path handles `target.View` correctly via `resolveActiveView()`
- 3 regression tests: Auto→stencil, Compute→Vello, EvenOdd Auto→stencil
- CHANGELOG v0.48.16

Fixes TASK-GG-STROKE-REGRESSION-374. Proper GPU-direct Vello output (Option A: storage texture + blit) tracked for v0.49.0.

## Test plan

- [x] `go build ./...` — pass
- [x] `golangci-lint run` — 0 issues
- [x] 3 new routing tests pass
- [x] All existing tests pass
- [ ] CI green