### PR TITLE
refactor(gpu): remove HAL imports — gg must not know backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.17] - 2026-06-25
+
+### Fixed
+
+- **macOS Metal stencil rendering** (#390, @samyfodil) — adopt wgpu v0.30.4 which
+  fixes Metal HAL not translating stencil state into `MTLDepthStencilState`. Stencil
+  test was silently inert (`compare=Always`), causing stencil-then-cover fills to
+  flood the entire cover quad: rounded panels rendered as squares, clipped content
+  vanished. 3 Metal regression tests added (circle, rounded rect, even-odd ring).
+
+### Changed
+
+- **Architecture: remove HAL imports from production code** — gg no longer imports
+  `wgpu/hal/vulkan` directly. Backend registration belongs in the application
+  (gogpu registers all backends per-platform via `gpu/backend/native/`). gg is a
+  pure consumer of the wgpu WebGPU standard API. Metal test rewritten to use
+  `wgpu.CreateInstance(BackendsMetal)` public API instead of `hal/metal` import.
+
+- **Dependencies:** wgpu v0.30.3 → v0.30.4.
+
 ## [0.48.16] - 2026-06-25
 
 ### Fixed

--- a/internal/gpu/sdf_gpu.go
+++ b/internal/gpu/sdf_gpu.go
@@ -9,9 +9,6 @@ import (
 	"github.com/gogpu/gg"
 	"github.com/gogpu/gg/text"
 	"github.com/gogpu/gpucontext"
-
-	// Import Vulkan backend so it registers via init().
-	_ "github.com/gogpu/wgpu/hal/vulkan"
 )
 
 // SDFAccelerator provides GPU-accelerated rendering using wgpu/hal render

--- a/internal/gpu/stencil_metal_repro_test.go
+++ b/internal/gpu/stencil_metal_repro_test.go
@@ -11,42 +11,29 @@ import (
 	"testing"
 
 	"github.com/gogpu/gg"
-	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu"
-	"github.com/gogpu/wgpu/hal/metal"
 )
 
 // createMetalDevice creates a REAL Metal-backed *wgpu.Device + *wgpu.Queue for
-// pixel-exact integration testing on Apple Silicon. Unlike the noop backend,
-// this drives the actual Metal HAL: MTLRenderPipelineState, MTLDepthStencilState,
-// stencil attachments, MSAA resolve, and CPU readback are all exercised.
+// pixel-exact integration testing on Apple Silicon. Uses public wgpu API with
+// BackendsMetal filter — no HAL imports needed.
 func createMetalDevice(t *testing.T) (*wgpu.Device, *wgpu.Queue, func()) {
 	t.Helper()
-	instance, err := metal.Backend{}.CreateInstance(nil)
+	instance, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{
+		Backends: wgpu.BackendsMetal,
+	})
 	if err != nil {
 		t.Skipf("metal CreateInstance: %v", err)
 	}
-	adapters := instance.EnumerateAdapters(nil)
-	if len(adapters) == 0 {
-		instance.Destroy()
-		t.Skip("metal backend: no adapters")
-	}
-	openDev, err := adapters[0].Adapter.Open(0, gputypes.DefaultLimits())
+	adapter, err := instance.RequestAdapter(nil)
 	if err != nil {
 		instance.Destroy()
-		t.Fatalf("metal Open: %v", err)
+		t.Skipf("metal RequestAdapter: %v", err)
 	}
-	device, err := wgpu.NewDeviceFromHAL(
-		openDev.Device,
-		openDev.Queue,
-		gputypes.Features(0),
-		gputypes.DefaultLimits(),
-		"metal-stencil-test",
-	)
+	device, err := adapter.RequestDevice(nil)
 	if err != nil {
-		openDev.Device.Destroy()
 		instance.Destroy()
-		t.Fatalf("NewDeviceFromHAL: %v", err)
+		t.Skipf("metal RequestDevice: %v", err)
 	}
 	queue := device.Queue()
 	cleanup := func() {

--- a/internal/gpu/vello_accelerator.go
+++ b/internal/gpu/vello_accelerator.go
@@ -21,9 +21,6 @@ import (
 	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu"
-
-	// Import Vulkan backend so it registers via init().
-	_ "github.com/gogpu/wgpu/hal/vulkan"
 )
 
 // VelloAccelerator provides GPU-accelerated scene rendering using the Vello-style


### PR DESCRIPTION
## Summary

- Remove `hal/vulkan` blank imports from production code (sdf_gpu.go, vello_accelerator.go)
- Replace `hal/metal` in stencil_metal_repro_test.go with `wgpu.CreateInstance(BackendsMetal)` public API
- Adopt wgpu v0.30.4 Metal stencil fix (#390, @samyfodil)
- CHANGELOG v0.48.17

Backend registration belongs in the application (gogpu `gpu/backend/native/`), not the library.

## Test plan

- [x] Vulkan — gogpu_integration, clip_demo, clip_path
- [x] DX12 — gogpu_integration
- [x] GLES — gogpu_integration
- [x] Software — gogpu_integration
- [x] `go build ./...`, `golangci-lint`, all tests pass
- [ ] CI green