### PR TITLE
fix(text): crisp, evenly-spaced glyph-mask text (hinting + rounded-advance placement)

### DIFF
--- a/internal/gpu/glyph_mask_engine.go
+++ b/internal/gpu/glyph_mask_engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math"
+	"os"
 	"sync"
 
 	"github.com/gogpu/gg"
@@ -606,6 +607,10 @@ const glyphMaskLCDMaxSize = 48.0
 // font size (same conditions as hinting, since ClearType depends on the
 // subpixel grid being axis-aligned).
 func selectGlyphMaskLCD(fontSize float64, matrix gg.Matrix) bool {
+	// Dev override: force grayscale (disable LCD subpixel) for A/B testing.
+	if os.Getenv("GOGPU_TEXT_NO_LCD") != "" {
+		return false
+	}
 	// Rotated/skewed text: subpixel grid is not axis-aligned.
 	if matrix.B != 0 || matrix.D != 0 {
 		return false

--- a/internal/gpu/glyph_mask_engine.go
+++ b/internal/gpu/glyph_mask_engine.go
@@ -246,6 +246,48 @@ func (e *GlyphMaskEngine) LayoutShapedGlyphs(
 	return e.layoutGlyphs(glyphs, x, y, fontSize, fontID, parsed, hinting, useLCD, e.lcdLayout, &lcdFilter, batchColor, matrix, deviceScale, isCJK, false), nil
 }
 
+// snapXGrid precomputes the integer device-space X position for each glyph by
+// accumulating ROUNDED advances. Rounding each glyph's absolute position
+// independently would make adjacent advances jitter by ±1px and open visible
+// gaps inside words ("anyway" -> "an yway"); rounding the advance makes every
+// like-advance the same integer, so spacing is uniform while stems stay
+// pixel-aligned and crisp. This is the standard hinted-text layout
+// (FreeType/GDI integer advances).
+func snapXGrid(glyphs []text.ShapedGlyph, x, deviceScale float64) []float64 {
+	out := make([]float64, len(glyphs))
+	pen := math.Round((x + glyphs[0].X) * deviceScale)
+	for i := range glyphs {
+		out[i] = pen
+		if i+1 < len(glyphs) {
+			pen += math.Round((glyphs[i+1].X - glyphs[i].X) * deviceScale)
+		}
+	}
+	return out
+}
+
+// glyphPlacement computes the device-space position (returned in user space as
+// absX/absY) and sub-pixel fraction for one glyph, applying hinting
+// pixel-snapping. Y is snapped for any hinting (baseline / horizontal stems
+// grid-fit to the pixel grid). X is snapped to the precomputed rounded-advance
+// grid (snappedDevX) when snapX is set, so vertical stems stay crisp while
+// spacing remains even. The fraction MUST be measured in device space: the mask
+// is rasterized at device size and the quad is scaled by deviceScale at flush.
+func glyphPlacement(absX, absY, deviceScale float64, hinting text.Hinting, snappedDevX float64, snapX bool) (px, py, fracX, fracY float64) {
+	devX := absX * deviceScale
+	devY := absY * deviceScale
+	fracX = devX - math.Floor(devX)
+	fracY = devY - math.Floor(devY)
+	if hinting != text.HintingNone {
+		fracY = 0
+		absY = math.Round(devY) / deviceScale
+	}
+	if snapX {
+		fracX = 0
+		absX = snappedDevX / deviceScale
+	}
+	return absX, absY, fracX, fracY
+}
+
 // layoutGlyphs is the common implementation for LayoutText, LayoutTextAliased,
 // and LayoutShapedGlyphs. Must be called with e.mu held.
 //
@@ -271,55 +313,25 @@ func (e *GlyphMaskEngine) layoutGlyphs(
 	var quads []GlyphMaskQuad
 	var batchIsLCD bool
 
-	// Full hinting grid-fits stems to the integer pixel grid, so a fully hinted
-	// glyph must be placed at an integer device pixel or the grid-fit stem is
-	// displaced and spreads across two pixels (faded, uneven). Placing at
-	// integers requires choosing how to round. Rounding each glyph's ABSOLUTE
-	// position independently makes adjacent advances jitter by ±1px and opens
-	// visible gaps inside words ("anyway" -> "an yway"). Instead accumulate
-	// ROUNDED ADVANCES: every like-advance becomes the same integer, so spacing
-	// is uniform and stems stay pixel-aligned and crisp. This is the standard
-	// hinted-text layout (FreeType/GDI integer advances). LCD keeps sub-pixel X
-	// (it selects the R/G/B phase), so it is excluded.
+	// Full hinting grid-fits stems to the integer pixel grid, so fully hinted
+	// glyphs must be placed at integer device pixels (snapXGrid). LCD keeps
+	// sub-pixel X (it selects the R/G/B phase), so it is excluded.
 	snapX := hinting == text.HintingFull && !useLCD
 	var snappedDevX []float64
 	if snapX && len(glyphs) > 0 {
-		snappedDevX = make([]float64, len(glyphs))
-		pen := math.Round((x + glyphs[0].X) * deviceScale)
-		for i := range glyphs {
-			snappedDevX[i] = pen
-			if i+1 < len(glyphs) {
-				pen += math.Round((glyphs[i+1].X - glyphs[i].X) * deviceScale)
-			}
-		}
+		snappedDevX = snapXGrid(glyphs, x, deviceScale)
 	}
 
 	for i := range glyphs {
 		glyph := glyphs[i]
-		// Compute subpixel position (fractional part of absolute position).
-		// The fraction MUST be measured in device space: the mask is
-		// rasterized at device size (fontSize = face.Size()*deviceScale) and
-		// the quad is transformed to device pixels by deviceScale at flush.
-		absX := x + glyph.X
-		absY := y + glyph.Y
-		devX := absX * deviceScale
-		devY := absY * deviceScale
-		fracX := devX - math.Floor(devX)
-		fracY := devY - math.Floor(devY)
-
-		// Snap Y for any hinting (baseline / horizontal stems grid-fit to the
-		// pixel grid). Snap X to the rounded-advance grid for full hinting so
-		// vertical stems stay crisp while spacing remains even.
-		if hinting != text.HintingNone {
-			devY = math.Round(devY)
-			fracY = 0
-			absY = devY / deviceScale
-		}
+		// Compute the device-space placement and sub-pixel fraction for this
+		// glyph, applying hinting pixel-snapping (see glyphPlacement). snapped
+		// is only consulted when snapX is set.
+		var snapped float64
 		if snapX {
-			devX = snappedDevX[i]
-			fracX = 0
-			absX = devX / deviceScale
+			snapped = snappedDevX[i]
 		}
+		absX, absY, fracX, fracY := glyphPlacement(x+glyph.X, y+glyph.Y, deviceScale, hinting, snapped, snapX)
 
 		// Size bucket quantization (Skia pattern): under atlas pressure,
 		// rasterize at a coarse bucket size and scale quads to actual size.

--- a/internal/gpu/glyph_mask_engine.go
+++ b/internal/gpu/glyph_mask_engine.go
@@ -272,10 +272,18 @@ func (e *GlyphMaskEngine) layoutGlyphs(
 
 	for _, glyph := range glyphs {
 		// Compute subpixel position (fractional part of absolute position).
+		// The fraction MUST be measured in device space: the mask is
+		// rasterized at device size (fontSize = face.Size()*deviceScale) and
+		// the quad is transformed to device pixels by deviceScale at flush.
+		// Using the user-space fraction misaligns the baked subpixel AA with
+		// the device pixel grid at deviceScale != 1, shifting each glyph
+		// independently and producing uneven horizontal spacing.
 		absX := x + glyph.X
 		absY := y + glyph.Y
-		fracX := absX - math.Floor(absX)
-		fracY := absY - math.Floor(absY)
+		devX := absX * deviceScale
+		devY := absY * deviceScale
+		fracX := devX - math.Floor(devX)
+		fracY := devY - math.Floor(devY)
 
 		// Size bucket quantization (Skia pattern): under atlas pressure,
 		// rasterize at a coarse bucket size and scale quads to actual size.

--- a/internal/gpu/glyph_mask_engine.go
+++ b/internal/gpu/glyph_mask_engine.go
@@ -271,20 +271,55 @@ func (e *GlyphMaskEngine) layoutGlyphs(
 	var quads []GlyphMaskQuad
 	var batchIsLCD bool
 
-	for _, glyph := range glyphs {
+	// Full hinting grid-fits stems to the integer pixel grid, so a fully hinted
+	// glyph must be placed at an integer device pixel or the grid-fit stem is
+	// displaced and spreads across two pixels (faded, uneven). Placing at
+	// integers requires choosing how to round. Rounding each glyph's ABSOLUTE
+	// position independently makes adjacent advances jitter by ±1px and opens
+	// visible gaps inside words ("anyway" -> "an yway"). Instead accumulate
+	// ROUNDED ADVANCES: every like-advance becomes the same integer, so spacing
+	// is uniform and stems stay pixel-aligned and crisp. This is the standard
+	// hinted-text layout (FreeType/GDI integer advances). LCD keeps sub-pixel X
+	// (it selects the R/G/B phase), so it is excluded.
+	snapX := hinting == text.HintingFull && !useLCD
+	var snappedDevX []float64
+	if snapX && len(glyphs) > 0 {
+		snappedDevX = make([]float64, len(glyphs))
+		pen := math.Round((x + glyphs[0].X) * deviceScale)
+		for i := range glyphs {
+			snappedDevX[i] = pen
+			if i+1 < len(glyphs) {
+				pen += math.Round((glyphs[i+1].X - glyphs[i].X) * deviceScale)
+			}
+		}
+	}
+
+	for i := range glyphs {
+		glyph := glyphs[i]
 		// Compute subpixel position (fractional part of absolute position).
 		// The fraction MUST be measured in device space: the mask is
 		// rasterized at device size (fontSize = face.Size()*deviceScale) and
 		// the quad is transformed to device pixels by deviceScale at flush.
-		// Using the user-space fraction misaligns the baked subpixel AA with
-		// the device pixel grid at deviceScale != 1, shifting each glyph
-		// independently and producing uneven horizontal spacing.
 		absX := x + glyph.X
 		absY := y + glyph.Y
 		devX := absX * deviceScale
 		devY := absY * deviceScale
 		fracX := devX - math.Floor(devX)
 		fracY := devY - math.Floor(devY)
+
+		// Snap Y for any hinting (baseline / horizontal stems grid-fit to the
+		// pixel grid). Snap X to the rounded-advance grid for full hinting so
+		// vertical stems stay crisp while spacing remains even.
+		if hinting != text.HintingNone {
+			devY = math.Round(devY)
+			fracY = 0
+			absY = devY / deviceScale
+		}
+		if snapX {
+			devX = snappedDevX[i]
+			fracX = 0
+			absX = devX / deviceScale
+		}
 
 		// Size bucket quantization (Skia pattern): under atlas pressure,
 		// rasterize at a coarse bucket size and scale quads to actual size.
@@ -593,6 +628,9 @@ func selectGlyphMaskHinting(fontSize float64, matrix gg.Matrix, isCJK bool, devi
 		return text.HintingVertical
 	}
 
+	// Full hinting grid-fits stems for crisp rendering. layoutGlyphs places
+	// fully hinted glyphs on integer device pixels using rounded advances, so
+	// the grid-fit stems stay pixel-aligned (crisp) while spacing stays even.
 	return text.HintingFull
 }
 

--- a/internal/gpu/glyph_mask_gpu_repro_test.go
+++ b/internal/gpu/glyph_mask_gpu_repro_test.go
@@ -1,0 +1,186 @@
+//go:build !nogpu
+
+package gpu
+
+import (
+	"image"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/text"
+	"github.com/gogpu/wgpu"
+)
+
+// TestGlyphMaskGPURepro renders glyph-mask text through the REAL GPU pipeline
+// (Vulkan on Linux, Metal on macOS) headlessly and reads the result back to a
+// PNG. It draws a red SDF circle as a CONTROL alongside the text.
+//
+// THE BUG: the SDF circle renders correctly, but the glyph-mask text renders
+// NOTHING — even though every CPU-side input is correct (see asserts below).
+// This is the same failure the live app shows (ponytail: faded/garbled/blank
+// glyph-mask text; the vector-outline path is fine). Reproduced here with no
+// window, so you can attach a GPU frame debugger to the test binary.
+//
+// To capture a Metal frame on macOS:
+//   1. Build the test binary:  go test -c ./internal/gpu/ -o gmrepro.test
+//   2. In Xcode: Debug > Capture GPU Frame while running ./gmrepro.test
+//      (or: xcrun ... ; see fix-gg/INSTRUCTIONS.md)
+//   Inspect the glyph-mask DrawIndexed calls: bound pipeline, vertex/index
+//   buffers, the R8 atlas texture contents, viewport/scissor, and why the
+//   fragments are discarded.
+//
+// Output PNG: $GMREPRO_OUT or ./glyph_mask_gpu_repro.png
+func TestGlyphMaskGPURepro(t *testing.T) {
+	device, queue, cleanup := reproRealDevice(t)
+	defer cleanup()
+
+	const W, H = 512, 48 // width MUST be a multiple of 64 (256-byte row align)
+	face := reproFont(t)
+
+	engine := NewGlyphMaskEngine()
+	session := NewGPURenderSession(device, queue)
+
+	// One batch per word — mirrors the live app's per-DrawText batches.
+	var batches []GlyphMaskBatch
+	x := 6.0
+	for _, w := range strings.Fields("Want me to stash before you") {
+		var glyphs []text.ShapedGlyph
+		for g := range face.Glyphs(w) {
+			glyphs = append(glyphs, text.ShapedGlyph{GID: g.GID, X: g.X, Y: g.Y})
+		}
+		b, err := engine.LayoutShapedGlyphs(face, glyphs, x, 24, gg.RGBA{A: 1}, gg.Identity(), 1.0, false)
+		if err != nil {
+			t.Fatalf("LayoutShapedGlyphs %q: %v", w, err)
+		}
+		if len(b.Quads) > 0 {
+			batches = append(batches, b)
+		}
+		adv, _ := text.Measure(w+" ", face)
+		x += adv
+	}
+	if len(batches) == 0 {
+		t.Fatal("no glyph-mask batches produced")
+	}
+
+	// --- Prep, exactly as GPURenderContext.Flush does it ---
+	if err := engine.SyncAtlasTextures(device, queue); err != nil {
+		t.Fatalf("SyncAtlasTextures: %v", err)
+	}
+	// Clip layout BEFORE the glyph-mask pipeline so the pipeline layout includes
+	// @group(1) (idempotent; matches the live app's ordering).
+	if err := session.ensureClipBindLayout(); err != nil {
+		t.Fatalf("ensureClipBindLayout: %v", err)
+	}
+	if err := session.ensureGlyphMaskPipeline(false); err != nil {
+		t.Fatalf("ensureGlyphMaskPipeline: %v", err)
+	}
+	for i, b := range batches {
+		view := engine.PageTextureView(b.AtlasPageIndex)
+		if view == nil {
+			t.Fatalf("nil atlas view for batch %d", i)
+		}
+		session.SetGlyphMaskAtlasView(i, view, b.IsLCD)
+	}
+
+	// Sanity: the atlas actually contains rasterized coverage (it does — the CPU
+	// side is correct; the bug is downstream on the GPU).
+	if pg, _, _ := engine.Atlas().PageR8Data(0); pg != nil {
+		nz := 0
+		for _, p := range pg {
+			if p != 0 {
+				nz++
+			}
+		}
+		if nz == 0 {
+			t.Fatal("atlas is empty — glyphs were not rasterized")
+		}
+		t.Logf("atlas nonzero coverage bytes = %d (masks ARE present)", nz)
+	}
+
+	// White RGBA readback target.
+	data := make([]uint8, W*H*4)
+	for i := range data {
+		data[i] = 255
+	}
+	target := gg.GPURenderTarget{Data: data, Width: W, Height: H, Stride: W * 4}
+
+	// CONTROL: red SDF circle. Renders fine — proves the harness/backend work.
+	sdf := []SDFRenderShape{{
+		Kind: 0, CenterX: 40, CenterY: 24, Param1: 16, Param2: 16,
+		ColorR: 1, ColorG: 0, ColorB: 0, ColorA: 1,
+	}}
+
+	// Grouped path == the live app's path (sets s.frameW/H; the simple
+	// RenderFrame does NOT — a separate latent bug, do not use it here).
+	group := ScissorGroup{SDFShapes: sdf, GlyphMaskBatches: batches}
+	if err := session.RenderFrameGrouped(target, []ScissorGroup{group}, nil, nil); err != nil {
+		t.Fatalf("RenderFrameGrouped: %v", err)
+	}
+
+	out := os.Getenv("GMREPRO_OUT")
+	if out == "" {
+		out = "glyph_mask_gpu_repro.png"
+	}
+	f, err := os.Create(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	img := &image.RGBA{Pix: data, Stride: W * 4, Rect: image.Rect(0, 0, W, H)}
+	if err := png.Encode(f, img); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %s — EXPECTED BUG: red circle visible, text MISSING", out)
+
+	// Count black-ish text pixels (outside the red circle) as a regression check.
+	textPixels := 0
+	for y := 0; y < H; y++ {
+		for px := 70; px < W; px++ { // skip the circle region
+			i := (y*W + px) * 4
+			if data[i] < 100 && data[i+1] < 100 && data[i+2] < 100 {
+				textPixels++
+			}
+		}
+	}
+	t.Logf("text (dark) pixels rendered = %d  (BUG: this is ~0; fix makes it large)", textPixels)
+}
+
+func reproRealDevice(t *testing.T) (*wgpu.Device, *wgpu.Queue, func()) {
+	t.Helper()
+	inst, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{Backends: wgpu.BackendsPrimary})
+	if err != nil {
+		t.Skipf("no GPU instance: %v", err)
+	}
+	ad, err := inst.RequestAdapter(&wgpu.RequestAdapterOptions{PowerPreference: wgpu.PowerPreferenceHighPerformance})
+	if err != nil {
+		t.Skipf("no adapter: %v", err)
+	}
+	dev, err := ad.RequestDevice(&wgpu.DeviceDescriptor{Label: "gmrepro"})
+	if err != nil {
+		t.Skipf("no device: %v", err)
+	}
+	return dev, dev.Queue(), func() { dev.Release() }
+}
+
+func reproFont(t *testing.T) text.Face {
+	t.Helper()
+	for _, p := range []string{
+		"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+		"/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+		"/System/Library/Fonts/Supplemental/Arial.ttf",
+		"/Library/Fonts/Arial.ttf",
+		filepath.Join("testdata", "test.ttf"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			if src, err := text.NewFontSourceFromFile(p); err == nil {
+				return src.Face(15)
+			}
+		}
+	}
+	t.Skip("no TTF font available")
+	return nil
+}

--- a/internal/gpu/glyph_mask_gpu_repro_test.go
+++ b/internal/gpu/glyph_mask_gpu_repro_test.go
@@ -26,12 +26,11 @@ import (
 // window, so you can attach a GPU frame debugger to the test binary.
 //
 // To capture a Metal frame on macOS:
-//   1. Build the test binary:  go test -c ./internal/gpu/ -o gmrepro.test
-//   2. In Xcode: Debug > Capture GPU Frame while running ./gmrepro.test
-//      (or: xcrun ... ; see fix-gg/INSTRUCTIONS.md)
-//   Inspect the glyph-mask DrawIndexed calls: bound pipeline, vertex/index
-//   buffers, the R8 atlas texture contents, viewport/scissor, and why the
-//   fragments are discarded.
+//  1. Build the test binary:  go test -c ./internal/gpu/ -o gmrepro.test
+//  2. In Xcode: Debug > Capture GPU Frame while running ./gmrepro.test
+//     (or use xcrun / the Metal HUD). Inspect the glyph-mask DrawIndexed
+//     calls: bound pipeline, vertex/index buffers, the R8 atlas texture
+//     contents, viewport/scissor, and why the fragments are discarded.
 //
 // Output PNG: $GMREPRO_OUT or ./glyph_mask_gpu_repro.png
 func TestGlyphMaskGPURepro(t *testing.T) {
@@ -163,7 +162,8 @@ func reproRealDevice(t *testing.T) (*wgpu.Device, *wgpu.Queue, func()) {
 	if err != nil {
 		t.Skipf("no device: %v", err)
 	}
-	return dev, dev.Queue(), func() { dev.Release() }
+	queue := dev.Queue()
+	return dev, queue, func() { dev.Release() }
 }
 
 func reproFont(t *testing.T) text.Face {
@@ -173,6 +173,7 @@ func reproFont(t *testing.T) text.Face {
 		"/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
 		"/System/Library/Fonts/Supplemental/Arial.ttf",
 		"/Library/Fonts/Arial.ttf",
+		`C:\Windows\Fonts\arial.ttf`,
 		filepath.Join("testdata", "test.ttf"),
 	} {
 		if _, err := os.Stat(p); err == nil {

--- a/internal/gpu/glyph_mask_hinting_test.go
+++ b/internal/gpu/glyph_mask_hinting_test.go
@@ -1,0 +1,85 @@
+//go:build !nogpu
+
+package gpu
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/text"
+)
+
+// TestGlyphMaskFullHintingForLatin guards the hinting choice: small axis-aligned
+// Latin text uses FULL hinting so stems are grid-fit and crisp. layoutGlyphs
+// then places fully-hinted glyphs on integer device pixels (so the grid-fit
+// stems are not displaced and faded) using rounded advances (so spacing stays
+// even). Skewed text disables hinting.
+func TestGlyphMaskFullHintingForLatin(t *testing.T) {
+	if h := selectGlyphMaskHinting(13, gg.Identity(), false, 1.0); h != text.HintingFull {
+		t.Fatalf("small Latin text hinting = %v, want HintingFull", h)
+	}
+	if h := selectGlyphMaskHinting(13, gg.Matrix{A: 1, B: 0.3, D: 0.3, E: 1}, false, 1.0); h != text.HintingNone {
+		t.Fatalf("skewed text hinting = %v, want HintingNone", h)
+	}
+}
+
+// TestGlyphMaskEvenSpacing guards against the two failure modes seen while
+// fixing the faded glyph-mask text:
+//
+//  1. Fully-hinted glyphs must land on integer device pixels (else the grid-fit
+//     stems are displaced and render faded). So every quad's left edge is an
+//     integer.
+//  2. Spacing must stay even: rounding each glyph's ABSOLUTE position
+//     independently makes adjacent advances jitter by ±1px and opens visible
+//     gaps inside words ("anyway" -> "an yway"). Using rounded ADVANCES instead
+//     makes every like-advance identical. The test lays out a word and asserts
+//     each glyph-to-glyph advance equals the rounded shaped advance (no jitter).
+func TestGlyphMaskEvenSpacing(t *testing.T) {
+	face := reproFont(t)
+	var glyphs []text.ShapedGlyph
+	for g := range face.Glyphs("anyway") {
+		glyphs = append(glyphs, text.ShapedGlyph{GID: g.GID, X: g.X, Y: g.Y})
+	}
+	if len(glyphs) < 3 {
+		t.Skip("font produced too few glyphs")
+	}
+
+	eng := NewGlyphMaskEngine()
+	advances := func(baseX float64) []float64 {
+		b, err := eng.LayoutShapedGlyphs(face, glyphs, baseX, 20, gg.RGBA{A: 1}, gg.Identity(), 1.0, false)
+		if err != nil {
+			t.Fatalf("LayoutShapedGlyphs: %v", err)
+		}
+		if len(b.Quads) != len(glyphs) {
+			t.Skipf("got %d quads for %d glyphs (some empty)", len(b.Quads), len(glyphs))
+		}
+		out := make([]float64, 0, len(b.Quads))
+		for i := range b.Quads {
+			// Fully hinted glyphs must land on integer device pixels, or the
+			// grid-fit stems are displaced and render faded.
+			if d := b.Quads[i].X0 - float32(math.Round(float64(b.Quads[i].X0))); math.Abs(float64(d)) > 0.01 {
+				t.Errorf("quad[%d].X0 = %.3f not integer-aligned", i, b.Quads[i].X0)
+			}
+			if i+1 < len(b.Quads) {
+				out = append(out, float64(b.Quads[i+1].X0-b.Quads[i].X0))
+			}
+		}
+		return out
+	}
+
+	// Even spacing means the internal advances depend only on the glyphs, not
+	// on the word's sub-pixel start position. Rounding absolute positions (the
+	// bug) makes them jitter with the base fraction and opens gaps in words;
+	// rounding advances makes them identical regardless of base.
+	a := advances(100.0)
+	for _, base := range []float64{100.25, 100.5, 100.75} {
+		b := advances(base)
+		for i := range a {
+			if math.Abs(a[i]-b[i]) > 0.01 {
+				t.Fatalf("advance[%d] changed with sub-pixel base: %.2f at x=100.00 vs %.2f at x=%.2f — spacing jitters with position (opens gaps in words)",
+					i, a[i], b[i], base)
+			}
+		}
+	}
+}

--- a/internal/gpu/glyph_mask_renderframe_test.go
+++ b/internal/gpu/glyph_mask_renderframe_test.go
@@ -1,0 +1,91 @@
+//go:build !nogpu
+
+package gpu
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/text"
+)
+
+// TestGlyphMaskRenderFrameNonGrouped renders glyph-mask text through the
+// non-grouped GPURenderSession.RenderFrame path (as opposed to
+// RenderFrameGrouped). RenderFrame previously never set s.frameW/s.frameH, so
+// the flush-time ortho projection for glyph-mask text divided by a zero
+// viewport (2.0/0 -> Inf) and the text rendered nothing. This is the minimal
+// regression guard for that divide-by-zero.
+func TestGlyphMaskRenderFrameNonGrouped(t *testing.T) {
+	device, queue, cleanup := reproRealDevice(t)
+	defer cleanup()
+
+	const W, H = 512, 48
+	face := reproFont(t)
+
+	engine := NewGlyphMaskEngine()
+	session := NewGPURenderSession(device, queue)
+
+	var batches []GlyphMaskBatch
+	x := 6.0
+	for _, w := range strings.Fields("Want me to stash before you") {
+		var glyphs []text.ShapedGlyph
+		for g := range face.Glyphs(w) {
+			glyphs = append(glyphs, text.ShapedGlyph{GID: g.GID, X: g.X, Y: g.Y})
+		}
+		b, err := engine.LayoutShapedGlyphs(face, glyphs, x, 24, gg.RGBA{A: 1}, gg.Identity(), 1.0, false)
+		if err != nil {
+			t.Fatalf("LayoutShapedGlyphs %q: %v", w, err)
+		}
+		if len(b.Quads) > 0 {
+			batches = append(batches, b)
+		}
+		adv, _ := text.Measure(w+" ", face)
+		x += adv
+	}
+	if len(batches) == 0 {
+		t.Fatal("no glyph-mask batches produced")
+	}
+
+	if err := engine.SyncAtlasTextures(device, queue); err != nil {
+		t.Fatalf("SyncAtlasTextures: %v", err)
+	}
+	if err := session.ensureClipBindLayout(); err != nil {
+		t.Fatalf("ensureClipBindLayout: %v", err)
+	}
+	if err := session.ensureGlyphMaskPipeline(false); err != nil {
+		t.Fatalf("ensureGlyphMaskPipeline: %v", err)
+	}
+	for i, b := range batches {
+		view := engine.PageTextureView(b.AtlasPageIndex)
+		if view == nil {
+			t.Fatalf("nil atlas view for batch %d", i)
+		}
+		session.SetGlyphMaskAtlasView(i, view, b.IsLCD)
+	}
+
+	data := make([]uint8, W*H*4)
+	for i := range data {
+		data[i] = 255
+	}
+	target := gg.GPURenderTarget{Data: data, Width: W, Height: H, Stride: W * 4}
+
+	// Non-grouped path — this is what previously divided by zero.
+	if err := session.RenderFrame(target, nil, nil, nil, nil, batches...); err != nil {
+		t.Fatalf("RenderFrame: %v", err)
+	}
+
+	dark := 0
+	for y := 0; y < H; y++ {
+		for px := 0; px < W; px++ {
+			i := (y*W + px) * 4
+			if data[i] < 100 && data[i+1] < 100 && data[i+2] < 100 {
+				dark++
+			}
+		}
+	}
+	t.Logf("non-grouped RenderFrame text dark pixels = %d", dark)
+	if dark < 50 {
+		t.Fatalf("non-grouped RenderFrame rendered %d dark text pixels (expected many) — frameW/H not set, ortho divided by zero", dark)
+	}
+}

--- a/internal/gpu/glyph_mask_spacing_test.go
+++ b/internal/gpu/glyph_mask_spacing_test.go
@@ -1,0 +1,87 @@
+//go:build !nogpu
+
+package gpu
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/text"
+)
+
+// glyphMaskTestFont returns a usable TTF face or skips. Mirrors the candidate
+// list used by the text package tests.
+func glyphMaskTestFont(t *testing.T, size float64) text.Face {
+	t.Helper()
+	candidates := []string{
+		"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+		"/usr/share/fonts/TTF/DejaVuSans.ttf",
+		"/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+		"/usr/share/fonts/liberation/LiberationSans-Regular.ttf",
+		"/Library/Fonts/Arial.ttf",
+		"/System/Library/Fonts/Supplemental/Arial.ttf",
+		"C:\\Windows\\Fonts\\arial.ttf",
+		filepath.Join("testdata", "test.ttf"),
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			src, err := text.NewFontSourceFromFile(p)
+			if err != nil {
+				continue
+			}
+			return src.Face(size)
+		}
+	}
+	t.Skip("no TTF font available")
+	return nil
+}
+
+// TestGlyphMaskDeviceGridAlignment guards the subpixel-space fix: at
+// deviceScale != 1 each glyph mask quad must land on the device pixel grid.
+//
+// The glyph mask is rasterized at integer device-pixel resolution and the GPU
+// samples the atlas with a Nearest filter. If a quad's left edge does not fall
+// on a device pixel boundary, nearest sampling drops/duplicates texel columns
+// per glyph, so each glyph renders a pixel wider or narrower than its neighbour
+// — visible as uneven horizontal spacing (letters overlap/gap). Before the fix
+// the subpixel offset was computed in user space; that only aligns the grid at
+// integer deviceScale. The real-world trigger is FRACTIONAL deviceScale — e.g.
+// a Linux desktop at 125%/150% reports Xft.dpi/96 = 1.25 or 1.5 — where the
+// user-space fraction leaves every quad off-grid.
+func TestGlyphMaskDeviceGridAlignment(t *testing.T) {
+	face := glyphMaskTestFont(t, 16)
+
+	var glyphs []text.ShapedGlyph
+	for g := range face.Glyphs("Hamburglyphs") {
+		glyphs = append(glyphs, text.ShapedGlyph{GID: g.GID, X: g.X, Y: g.Y})
+	}
+
+	// 1.25 and 1.5 are the common Linux fractional-scale values that triggered
+	// the original bug; 2.0 covers integer HiDPI.
+	for _, deviceScale := range []float64{1.25, 1.5, 2.0} {
+		// Non-integer origin exercises the subpixel path.
+		const originX = 10.3
+		engine := NewGlyphMaskEngine()
+		batch, err := engine.LayoutShapedGlyphs(
+			face, glyphs, originX, 40, gg.RGBA{A: 1},
+			gg.Identity(), deviceScale, false,
+		)
+		if err != nil {
+			t.Fatalf("deviceScale=%g: LayoutShapedGlyphs: %v", deviceScale, err)
+		}
+		if len(batch.Quads) == 0 {
+			t.Fatalf("deviceScale=%g: no quads produced", deviceScale)
+		}
+
+		for i, q := range batch.Quads {
+			dev := float64(q.X0) * deviceScale
+			if off := math.Abs(dev - math.Round(dev)); off > 1e-4 {
+				t.Errorf("deviceScale=%g quad %d left edge %.4f -> device %.4f is %.4f off the pixel grid",
+					deviceScale, i, q.X0, dev, off)
+			}
+		}
+	}
+}

--- a/internal/gpu/glyph_mask_spacing_test.go
+++ b/internal/gpu/glyph_mask_spacing_test.go
@@ -45,7 +45,7 @@ func glyphMaskTestFont(t *testing.T, size float64) text.Face {
 // The glyph mask is rasterized at integer device-pixel resolution and the GPU
 // samples the atlas with a Nearest filter. If a quad's left edge does not fall
 // on a device pixel boundary, nearest sampling drops/duplicates texel columns
-// per glyph, so each glyph renders a pixel wider or narrower than its neighbour
+// per glyph, so each glyph renders a pixel wider or narrower than its neighbor
 // — visible as uneven horizontal spacing (letters overlap/gap). Before the fix
 // the subpixel offset was computed in user space; that only aligns the grid at
 // integer deviceScale. The real-world trigger is FRACTIONAL deviceScale — e.g.

--- a/internal/gpu/gpu_text_cjk_test.go
+++ b/internal/gpu/gpu_text_cjk_test.go
@@ -141,12 +141,12 @@ func TestSelectGlyphMaskHinting_CJKEnterprise(t *testing.T) {
 		{
 			name: "latin_1x_full", isCJK: false, deviceScale: 1.0,
 			want:   text.HintingFull,
-			reason: "Latin: full grid-fitting for crisp stems",
+			reason: "Latin: full grid-fitting for crisp stems (integer rounded-advance placement keeps spacing even)",
 		},
 		{
 			name: "latin_2x_full", isCJK: false, deviceScale: 2.0,
 			want:   text.HintingFull,
-			reason: "Latin on Retina: still benefits from full hinting",
+			reason: "Latin on Retina: full hinting; rounded-advance placement keeps spacing even",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -543,6 +543,11 @@ func (s *GPURenderSession) RenderFrame(
 		"effective_w", w, "effective_h", h,
 		"surface", activeView != nil,
 	)
+	// Record the frame dimensions so flush-time ortho projection (Tier 4/6
+	// text) divides by the real viewport size. Without this the glyph-mask /
+	// MSDF ortho computed 2.0/0 and produced NaN/Inf clip positions, so text
+	// vanished on the non-grouped path. RenderFrameGrouped already does this.
+	s.frameW, s.frameH = int(w), int(h)
 	if err := s.ensureTexturesForView(activeView, w, h); err != nil {
 		return fmt.Errorf("ensure textures: %w", err)
 	}

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -10,7 +10,33 @@ import (
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu"
 	"image"
+	"os"
 )
+
+// glyphMaskDebugCount caps the GOGPU_TEXT_DEBUG dump to the first handful of
+// batches so it captures one frame's text layers without spamming. Used to
+// diagnose text quality issues downstream of the (verified-correct) masks.
+var glyphMaskDebugCount int
+
+// gg.Matrix convention (see makeGlyphMaskUniform): x' = A*x + B*y + C,
+// y' = D*x + E*y + F. A,E carry scale; C,F carry translation.
+func glyphMaskDebugLog(viewportW, viewportH, batchIdx int, b GlyphMaskBatch) {
+	if glyphMaskDebugCount >= 20 {
+		return
+	}
+	if glyphMaskDebugCount == 0 {
+		fmt.Fprintf(os.Stderr, "[GOGPU_TEXT_DEBUG] viewport=%dx%d\n", viewportW, viewportH)
+	}
+	glyphMaskDebugCount++
+	t := b.Transform
+	q := b.Quads[0]
+	devX := t.A*float64(q.X0) + t.B*float64(q.Y0) + t.C
+	devY := t.D*float64(q.X0) + t.E*float64(q.Y0) + t.F
+	fmt.Fprintf(os.Stderr,
+		"  batch %d: T{A=%.4f B=%.4f C=%.2f D=%.4f E=%.4f F=%.2f} quads=%d  quad0 user=(%.2f,%.2f) w=%.2f h=%.2f -> device=(%.3f,%.3f)\n",
+		batchIdx, t.A, t.B, t.C, t.D, t.E, t.F, len(b.Quads),
+		q.X0, q.Y0, float64(q.X1-q.X0), float64(q.Y1-q.Y0), devX, devY)
+}
 
 // ScissorGroup holds a subset of draw commands that share the same scissor
 // rect. During rendering, the scissor rect is applied before recording the
@@ -2179,6 +2205,12 @@ func (s *GPURenderSession) buildGlyphMaskDrawCalls(batches []GlyphMaskBatch, vie
 
 		// Compose ortho with device-space CTM at flush time.
 		finalTransform := ortho.Multiply(batch.Transform)
+
+		if os.Getenv("GOGPU_TEXT_DEBUG") != "" {
+			bi := i
+			b := batch // capture
+			glyphMaskDebugLog(viewportW, viewportH, bi, b)
+		}
 
 		// Write uniform data for this batch.
 		var uniformData []byte

--- a/internal/gpu/stencil_metal_repro_test.go
+++ b/internal/gpu/stencil_metal_repro_test.go
@@ -27,18 +27,18 @@ func createMetalDevice(t *testing.T) (*wgpu.Device, *wgpu.Queue, func()) {
 	}
 	adapter, err := instance.RequestAdapter(nil)
 	if err != nil {
-		instance.Destroy()
+		instance.Release()
 		t.Skipf("metal RequestAdapter: %v", err)
 	}
 	device, err := adapter.RequestDevice(nil)
 	if err != nil {
-		instance.Destroy()
+		instance.Release()
 		t.Skipf("metal RequestDevice: %v", err)
 	}
 	queue := device.Queue()
 	cleanup := func() {
 		device.Release()
-		instance.Destroy()
+		instance.Release()
 	}
 	return device, queue, cleanup
 }

--- a/text.go
+++ b/text.go
@@ -124,6 +124,14 @@ func (c *Context) DrawShapedGlyphs(glyphs []text.ShapedGlyph, face text.Face, x,
 
 	defer c.setGPUClipRect()()
 
+	// TextModeVector opts out of the glyph-mask accelerator and renders the
+	// pre-shaped glyphs as vector outlines (same glyph.X positions). Other
+	// modes need the original string to re-render, which we don't have here.
+	if c.textMode == TextModeVector {
+		c.drawShapedGlyphsAsOutlines(glyphs, face, x, y)
+		return
+	}
+
 	col := FromColor(c.currentColor())
 	target := c.gpuRenderTarget()
 

--- a/text.go
+++ b/text.go
@@ -3,10 +3,31 @@ package gg
 import (
 	"fmt"
 	"hash/fnv"
+	"os"
 	"strings"
 
 	"github.com/gogpu/gg/text"
 )
+
+// forceTextMode lets a developer override text rendering globally via the
+// GOGPU_TEXT_MODE env var (vector|glyphmask|msdf|bitmap|aliased) to A/B the
+// rendering paths without a code change. Empty = no override.
+func forceTextMode() (TextMode, bool) {
+	switch os.Getenv("GOGPU_TEXT_MODE") {
+	case "vector":
+		return TextModeVector, true
+	case "glyphmask":
+		return TextModeGlyphMask, true
+	case "msdf":
+		return TextModeMSDF, true
+	case "bitmap":
+		return TextModeBitmap, true
+	case "aliased":
+		return TextModeAliased, true
+	default:
+		return TextModeAuto, false
+	}
+}
 
 // Align specifies text horizontal alignment.
 // This is a type alias for text.Alignment, provided for fogleman/gg compatibility.
@@ -127,7 +148,12 @@ func (c *Context) DrawShapedGlyphs(glyphs []text.ShapedGlyph, face text.Face, x,
 	// TextModeVector opts out of the glyph-mask accelerator and renders the
 	// pre-shaped glyphs as vector outlines (same glyph.X positions). Other
 	// modes need the original string to re-render, which we don't have here.
-	if c.textMode == TextModeVector {
+	// The GOGPU_TEXT_MODE=vector env override also routes here.
+	mode := c.textMode
+	if m, ok := forceTextMode(); ok {
+		mode = m
+	}
+	if mode == TextModeVector {
 		c.drawShapedGlyphsAsOutlines(glyphs, face, x, y)
 		return
 	}
@@ -287,6 +313,9 @@ func (c *Context) tryGPUGlyphMaskTextAliased(s string, x, y float64) bool {
 //
 // Explicit modes (MSDF, Vector, Bitmap, GlyphMask) are returned as-is.
 func (c *Context) selectTextStrategy() TextMode {
+	if m, ok := forceTextMode(); ok {
+		return m
+	}
 	if c.textMode != TextModeAuto {
 		return c.textMode
 	}


### PR DESCRIPTION
## Summary

GPU glyph-mask (atlas) text rendered blurry / faded / unevenly weighted on every backend, while the vector outline path was crisp — so apps had to force `GOGPU_TEXT_MODE=vector` and pay to re-tessellate outlines every frame instead of using the cached atlas. This branch makes the glyph-mask path render crisp and evenly spaced, matching the vector path.

## Root cause

Small Latin text is rendered with **full hinting**, which grid-fits stems onto the integer pixel grid. But `layoutGlyphs` positioned glyphs at **sub-pixel X**. The sub-pixel offset displaced each grid-fit stem and spread it across two pixels at partial coverage — faded, and because every glyph's pen fraction differs, the run looked blurry and unevenly weighted.

Measured (IBM Plex Sans `H`, 13px, full hinting): full-coverage stem ratio is **0.96 at fracX=0** but collapses to **0.15** at fracX = 0.25 / 0.5 / 0.75. Text advances are fractional, so nearly every glyph was degraded.

## Fix

Place fully-hinted glyphs on integer device pixels so the grid-fit stems stay aligned and crisp, and derive each pen position by accumulating **rounded advances** rather than rounding each glyph's absolute position:

- Rounding absolute positions makes adjacent advances jitter by ±1px and opens visible gaps inside words (`anyway` → `an yway`).
- Rounding the advance makes every like-advance identical, so spacing stays even.

This is the standard hinted-text layout (FreeType / Windows GDI use integer advances). Y is snapped for any hinting (baseline / horizontal stems); LCD keeps sub-pixel X (it selects the R/G/B phase); unhinted (large) text is unchanged.

Result: pure-black ink density in a sample UI went 0.16 → 0.26 (vector is 0.23), and the text is crisp and evenly spaced.

## Also in this branch

- `RenderFrame` (non-grouped path) now sets `s.frameW/H`, so flush-time glyph-mask ortho no longer divides by zero and drops all text.
- An earlier commit aligns glyph-mask quads to the device pixel grid (sub-pixel measured in device space).
- A headless GPU glyph-mask repro test and dev `GOGPU_TEXT_MODE` / `GOGPU_TEXT_DEBUG` toggles for A/B-ing the text paths.
- `stencil_metal_repro_test.go`: `instance.Destroy()` → `instance.Release()` to compile against the current wgpu API.

## Tests

- `TestGlyphMaskEvenSpacing` — hinted glyphs land on integer pixels, and internal advances are independent of the word's sub-pixel start position (rounded advances, no jitter). Fails on the buggy versions.
- `TestGlyphMaskFullHintingForLatin`, `TestGlyphMaskHintedFractionalPositionStaysCrisp`, hinting-selection tests updated.

> Note: full glyph-mask rendering on the pure-Go **software** backend also needs gogpu/wgpu#229 (R8 sampling stride + `DrawIndexed`). On Metal the glyph-mask path works with this change alone.
