### PR TITLE
chore(examples): update gogpu v0.42.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Dependencies:** wgpu v0.30.4 → v0.30.5 (software backend text rendering fix, @samyfodil).
+- **Examples:** gogpu v0.42.7 → v0.42.9 (Wayland frame callback gating).
 
 ## [0.48.17] - 2026-06-25
 

--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 )
 
 require (

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.0 h1:UuXLqcQeRDExbEjBbXWKO5iLjXM2UfX2Q6GVxrZdNMc=
 github.com/gogpu/gg v0.49.0/go.mod h1:bjqJBkhA1hqWYDCCr/ERte7YDvqno1jIuz88v79qcZ0=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.0 h1:UuXLqcQeRDExbEjBbXWKO5iLjXM2UfX2Q6GVxrZdNMc=
 github.com/gogpu/gg v0.49.0/go.mod h1:bjqJBkhA1hqWYDCCr/ERte7YDvqno1jIuz88v79qcZ0=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 )
 
 require (

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.0 h1:UuXLqcQeRDExbEjBbXWKO5iLjXM2UfX2Q6GVxrZdNMc=
 github.com/gogpu/gg v0.49.0/go.mod h1:bjqJBkhA1hqWYDCCr/ERte7YDvqno1jIuz88v79qcZ0=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.0 h1:UuXLqcQeRDExbEjBbXWKO5iLjXM2UfX2Q6GVxrZdNMc=
 github.com/gogpu/gg v0.49.0/go.mod h1:bjqJBkhA1hqWYDCCr/ERte7YDvqno1jIuz88v79qcZ0=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.0 h1:UuXLqcQeRDExbEjBbXWKO5iLjXM2UfX2Q6GVxrZdNMc=
 github.com/gogpu/gg v0.49.0/go.mod h1:bjqJBkhA1hqWYDCCr/ERte7YDvqno1jIuz88v79qcZ0=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 )
 
 require (

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.0 h1:UuXLqcQeRDExbEjBbXWKO5iLjXM2UfX2Q6GVxrZdNMc=
 github.com/gogpu/gg v0.49.0/go.mod h1:bjqJBkhA1hqWYDCCr/ERte7YDvqno1jIuz88v79qcZ0=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/multi_damage_demo/go.mod
+++ b/examples/multi_damage_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/gogpu/gg => ../..
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/multi_damage_demo/go.sum
+++ b/examples/multi_damage_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 )
 
 require (

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.0 h1:UuXLqcQeRDExbEjBbXWKO5iLjXM2UfX2Q6GVxrZdNMc=
 github.com/gogpu/gg v0.49.0/go.mod h1:bjqJBkhA1hqWYDCCr/ERte7YDvqno1jIuz88v79qcZ0=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 )
 
 require (

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.0 h1:UuXLqcQeRDExbEjBbXWKO5iLjXM2UfX2Q6GVxrZdNMc=
 github.com/gogpu/gg v0.49.0/go.mod h1:bjqJBkhA1hqWYDCCr/ERte7YDvqno1jIuz88v79qcZ0=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.49.0
-	github.com/gogpu/gogpu v0.42.8
+	github.com/gogpu/gogpu v0.42.9
 )
 
 require (

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.0 h1:UuXLqcQeRDExbEjBbXWKO5iLjXM2UfX2Q6GVxrZdNMc=
 github.com/gogpu/gg v0.49.0/go.mod h1:bjqJBkhA1hqWYDCCr/ERte7YDvqno1jIuz88v79qcZ0=
-github.com/gogpu/gogpu v0.42.8 h1:iehXpnvJpwM5xZctTnnxrqAckzAJ1t+aU3/X0qa0X34=
-github.com/gogpu/gogpu v0.42.8/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
+github.com/gogpu/gogpu v0.42.9 h1:XlVedUQaJjU0ffqjypZTRCQRjnyi2yEbnpdN2+Rr+lc=
+github.com/gogpu/gogpu v0.42.9/go.mod h1:2UjG2OUZ/PDemaET6X+cS7Qrlb1tk+sb4wVQaz8lW+E=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=


### PR DESCRIPTION
gogpu v0.42.8 → v0.42.9 (Wayland frame callback gating).