### PR TITLE
chore(examples): update gogpu v0.42.11 → v0.43.0

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/multi_damage_demo/go.mod
+++ b/examples/multi_damage_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/gogpu/gg => ../..
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/multi_damage_demo/go.sum
+++ b/examples/multi_damage_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=


### PR DESCRIPTION
Dependency update: gogpu v0.43.0 (event-driven rendering by default).