### PR TITLE
chore(examples): update gogpu v0.42.11 → v0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.3] - 2026-06-29
+
+### Changed
+
+- **Examples:** gogpu v0.42.11 → v0.43.0 (event-driven rendering by default).
+  Removed explicit `WithContinuousRender(false)` from all examples — now the default.
+
 ## [0.49.2] - 2026-06-28
 
 ### Fixed

--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/blit_only/main.go
+++ b/examples/blit_only/main.go
@@ -32,8 +32,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("Blit-Only Path (ADR-016, non-MSAA)").
-		WithSize(width, height).
-		WithContinuousRender(false))
+		WithSize(width, height))
 
 	var (
 		canvas       *ggcanvas.Canvas

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/clip_demo/main.go
+++ b/examples/clip_demo/main.go
@@ -14,8 +14,8 @@
 //	Labels:     "No Clip" and "Clipped Region" above each section
 //
 // Rendering mode: event-driven with animation token.
-// Uses ContinuousRender=false + StartAnimation() to render at VSync
-// only while animation is active. Press Space to pause/resume.
+// Uses StartAnimation() to render at VSync while animation is active.
+// Press Space to pause/resume.
 //
 // Requirements:
 //   - gogpu v0.26.4+
@@ -42,8 +42,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("GoGPU + gg: Clip Demo").
-		WithSize(width, height).
-		WithContinuousRender(false)) // Event-driven: 0% CPU when paused
+		WithSize(width, height))
 
 	// Load system font for text labels.
 	fontSource := loadFontSource()

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/clip_path/main.go
+++ b/examples/clip_path/main.go
@@ -27,8 +27,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("GPU-CLIP-003a: Arbitrary Path Clip Test").
-		WithSize(width, height).
-		WithContinuousRender(false))
+		WithSize(width, height))
 
 	log.Println("=== REBUILD MARKER 2026-05-01 22:30 ===")
 	fontSource := loadFontSource()

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/damage_demo/main.go
+++ b/examples/damage_demo/main.go
@@ -31,8 +31,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("Damage Pipeline Demo (ADR-021)").
-		WithSize(width, height).
-		WithContinuousRender(false))
+		WithSize(width, height))
 
 	var (
 		canvas       *ggcanvas.Canvas

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/gogpu_integration/main.go
+++ b/examples/gogpu_integration/main.go
@@ -15,8 +15,8 @@
 //	Tier 4 (MSDF text):     title text, FPS counter
 //
 // Rendering mode: event-driven with animation token.
-// Uses ContinuousRender=false + StartAnimation() to render at VSync
-// only while animation is active. Press Space to pause/resume.
+// Uses StartAnimation() to render at VSync while animation is active.
+// Press Space to pause/resume.
 //
 // Requirements:
 //   - gogpu v0.26.0+
@@ -43,8 +43,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("GoGPU + gg: Six-Tier GPU Rendering").
-		WithSize(width, height).
-		WithContinuousRender(false)) // Event-driven: 0% CPU when paused
+		WithSize(width, height))
 
 	// Load system fonts for Tier 4 (MSDF text rendering).
 	fontSource := loadFontSource()

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/lcd_text/main.go
+++ b/examples/lcd_text/main.go
@@ -26,8 +26,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("LCD ClearType Text — ADR-024").
-		WithSize(700, 400).
-		WithContinuousRender(false))
+		WithSize(700, 400))
 
 	var canvas *ggcanvas.Canvas
 

--- a/examples/multi_damage_demo/go.mod
+++ b/examples/multi_damage_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/gogpu/gg => ../..
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 	github.com/gogpu/gpucontext v0.21.0
 )
 

--- a/examples/multi_damage_demo/go.sum
+++ b/examples/multi_damage_demo/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/multi_damage_demo/main.go
+++ b/examples/multi_damage_demo/main.go
@@ -30,8 +30,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("Multi-Rect Damage Demo (ADR-028)").
-		WithSize(width, height).
-		WithContinuousRender(false))
+		WithSize(width, height))
 
 	var (
 		canvas       *ggcanvas.Canvas

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/scene_gpu_visual/main.go
+++ b/examples/scene_gpu_visual/main.go
@@ -30,8 +30,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("Scene GPU Rendering — ARCH-GG-001").
-		WithSize(width, height).
-		WithContinuousRender(false))
+		WithSize(width, height))
 
 	var (
 		canvas       *ggcanvas.Canvas

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/zero_readback/main.go
+++ b/examples/zero_readback/main.go
@@ -32,8 +32,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("Zero-Readback Compositor (ADR-015/016)").
-		WithSize(width, height).
-		WithContinuousRender(false))
+		WithSize(width, height))
 
 	var fontFace text.Face
 	if src, err := text.NewFontSourceFromFile("C:/Windows/Fonts/arial.ttf"); err == nil {

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.49.2
-	github.com/gogpu/gogpu v0.42.11
+	github.com/gogpu/gogpu v0.43.0
 )
 
 require (

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gg v0.49.2 h1:mWFY7/aUWlMP0gkSvcX1UGBm04aFiSQUtKYHcm0EXqw=
 github.com/gogpu/gg v0.49.2/go.mod h1:HokAu1+epUdlCy5ILJr1vZnurhRpfUQ+N7yCT8wJkJM=
-github.com/gogpu/gogpu v0.42.11 h1:MRdVjUEzDlVifC7eYYijfaYAVXkFGeamVZD8piU9cQw=
-github.com/gogpu/gogpu v0.42.11/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
+github.com/gogpu/gogpu v0.43.0 h1:ZOXQugm7UMFtsN57o4v+tb5BvUlBTBchHLHIVT84pLo=
+github.com/gogpu/gogpu v0.43.0/go.mod h1:AdLj9Tsemz5r7mFYnwfl8Mmaqrgt6US0zZVPBI6gN0Y=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/zero_readback_manual/main.go
+++ b/examples/zero_readback_manual/main.go
@@ -33,8 +33,7 @@ func main() {
 
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("Manual Zero-Readback Pipeline").
-		WithSize(width, height).
-		WithContinuousRender(false))
+		WithSize(width, height))
 
 	var fontFace text.Face
 	if src, err := text.NewFontSourceFromFile("C:/Windows/Fonts/arial.ttf"); err == nil {


### PR DESCRIPTION
Remove WithContinuousRender(false) — event-driven rendering is now the default in gogpu v0.43.0.