### PR TITLE
fix(text): aliased text rendering with variable fonts (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.4] - 2026-06-29
+
+### Fixed
+
+- **Aliased text with variable fonts** (#385) — `TextModeAliased` / `DrawAliased` ignored
+  variable font variations, rendering with 256-level AA instead of binary (0/255) coverage.
+  Root cause: `drawGlyphsVariable` hardcoded AA rasterization, discarding the aliased callback.
+  Fix: outline extraction and rasterization mode are now orthogonal (Skia `SkFont::Edging` pattern).
+  New `RasterizeOutlineAliased` public method, `glyphRasterMode` enum, mode propagated through
+  variable font rendering path. 2 tests: binary-only coverage validation, AA vs aliased ink comparison.
+
 ## [0.49.3] - 2026-06-29
 
 ### Changed

--- a/text/draw.go
+++ b/text/draw.go
@@ -32,6 +32,16 @@ func Draw(dst draw.Image, text string, face Face, x, y float64, col color.Color)
 	}
 }
 
+// glyphRasterMode selects the rasterization coverage mode.
+// Outline extraction (sfnt or go-text) and rasterization mode are orthogonal
+// concerns (Skia pattern: SkFont::Edging is independent of font variations).
+type glyphRasterMode int
+
+const (
+	rasterModeAA      glyphRasterMode = iota // 256-level analytic AA coverage
+	rasterModeAliased                        // binary 0/255 coverage (Skia kAlias)
+)
+
 // glyphRasterizeFunc is the per-glyph rasterization callback used by drawGlyphs.
 // It abstracts the difference between RasterizeHinted (256-level AA) and
 // RasterizeAliased (binary coverage), allowing drawSourceFace and DrawAliased
@@ -61,7 +71,7 @@ func drawGlyphs(
 	rasterize glyphRasterizeFunc,
 ) {
 	if vars := sf.Variations(); len(vars) > 0 {
-		drawGlyphsVariable(dst, sf, text, x, y, col, vars)
+		drawGlyphsVariable(dst, sf, text, x, y, col, vars, rasterModeAA)
 		return
 	}
 
@@ -108,6 +118,9 @@ func drawGlyphs(
 // drawGlyphsVariable renders text using go-text/typesetting for outline extraction,
 // which supports variable font tables (gvar/HVAR). This path is used when
 // the face has font variations configured via WithVariations.
+//
+// The mode parameter selects coverage computation (Skia pattern: outline source
+// and rasterization mode are orthogonal — variable fonts don't affect AA choice).
 func drawGlyphsVariable(
 	dst draw.Image,
 	sf *sourceFace,
@@ -115,6 +128,7 @@ func drawGlyphsVariable(
 	x, y float64,
 	col color.Color,
 	variations []FontVariation,
+	mode glyphRasterMode,
 ) {
 	source := sf.source
 	gtFont, err := GetGoTextFont(source)
@@ -155,8 +169,15 @@ func drawGlyphsVariable(
 			continue
 		}
 
-		result, err := rast.RasterizeOutline(outline, subpixelX, subpixelY)
-		if err != nil || result == nil {
+		var result *GlyphMaskResult
+		var rErr error
+		switch mode {
+		case rasterModeAliased:
+			result, rErr = rast.RasterizeOutlineAliased(outline, subpixelX, subpixelY)
+		default:
+			result, rErr = rast.RasterizeOutline(outline, subpixelX, subpixelY)
+		}
+		if rErr != nil || result == nil {
 			advanceX += float64(outline.Advance)
 			continue
 		}

--- a/text/draw_aliased.go
+++ b/text/draw_aliased.go
@@ -27,5 +27,10 @@ func DrawAliased(dst draw.Image, text string, face Face, x, y float64, col color
 
 	text = expandTabs(text)
 
+	if vars := sf.Variations(); len(vars) > 0 {
+		drawGlyphsVariable(dst, sf, text, x, y, col, vars, rasterModeAliased)
+		return
+	}
+
 	drawGlyphs(dst, sf, text, x, y, col, rasterizeAliasedGlyph)
 }

--- a/text/glyph_mask_rasterizer.go
+++ b/text/glyph_mask_rasterizer.go
@@ -171,6 +171,20 @@ func (r *GlyphMaskRasterizer) RasterizeAliased(
 	return r.rasterizeOutlineAliased(outline, subpixelX, subpixelY)
 }
 
+// RasterizeOutlineAliased renders a pre-extracted glyph outline into an R8 alpha
+// mask with binary (0 or 255) coverage. Same as RasterizeOutline but with no
+// anti-aliasing — matches Skia's SkFont::Edging::kAlias applied to any outline
+// source (sfnt or go-text variable font).
+func (r *GlyphMaskRasterizer) RasterizeOutlineAliased(
+	outline *GlyphOutline,
+	subpixelX, subpixelY float64,
+) (*GlyphMaskResult, error) {
+	if outline == nil || outline.IsEmpty() {
+		return nil, nil //nolint:nilnil // nil result = empty glyph, not an error
+	}
+	return r.rasterizeOutlineAliased(outline, subpixelX, subpixelY)
+}
+
 // rasterizeOutlineAliased is the aliased (binary coverage) rasterization path.
 func (r *GlyphMaskRasterizer) rasterizeOutlineAliased(
 	outline *GlyphOutline,

--- a/text/varfont_test.go
+++ b/text/varfont_test.go
@@ -744,6 +744,85 @@ func TestVariations_OutlineExtraction(t *testing.T) {
 	}
 }
 
+// TestVariations_AliasedRendering verifies that DrawAliased produces binary
+// (0 or 255) coverage with variable fonts — no intermediate alpha values.
+// This is the regression test for @tsl0922's report that TextModeAliased
+// didn't work with variable fonts.
+func TestVariations_AliasedRendering(t *testing.T) {
+	source := requireVariableFont(t)
+	defer func() { _ = source.Close() }()
+
+	boldFace := source.Face(28, WithVariations(NewFontVariation("wght", 700)))
+
+	w, h := 300, 50
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	white := color.RGBA{255, 255, 255, 255}
+	draw.Draw(img, img.Bounds(), image.NewUniform(white), image.Point{}, draw.Src)
+
+	DrawAliased(img, "Hello World", boldFace, 10, 35, color.Black)
+
+	ink := countInkPixels(img)
+	if ink == 0 {
+		t.Fatal("aliased variable font rendered zero ink pixels")
+	}
+	t.Logf("aliased variable font: %d ink pixels", ink)
+
+	// Verify binary coverage: every pixel must be either fully white or fully black.
+	hasIntermediate := false
+	b := img.Bounds()
+	for y := b.Min.Y; y < b.Max.Y; y++ {
+		for x := b.Min.X; x < b.Max.X; x++ {
+			r, g, bb, _ := img.At(x, y).RGBA()
+			isWhite := r >= 0xF000 && g >= 0xF000 && bb >= 0xF000
+			isBlack := r < 0x1000 && g < 0x1000 && bb < 0x1000
+			if !isWhite && !isBlack {
+				hasIntermediate = true
+				break
+			}
+		}
+		if hasIntermediate {
+			break
+		}
+	}
+
+	if hasIntermediate {
+		t.Error("aliased variable font has intermediate alpha — expected binary (0 or 255) coverage only")
+	}
+}
+
+// TestVariations_AliasedVsAA verifies that aliased and AA rendering of variable
+// fonts produce different output — aliased should have fewer ink pixels (no fringe).
+func TestVariations_AliasedVsAA(t *testing.T) {
+	source := requireVariableFont(t)
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(28, WithVariations(NewFontVariation("wght", 500)))
+
+	w, h := 300, 50
+	aaImg := image.NewRGBA(image.Rect(0, 0, w, h))
+	aliasedImg := image.NewRGBA(image.Rect(0, 0, w, h))
+	white := color.RGBA{255, 255, 255, 255}
+	draw.Draw(aaImg, aaImg.Bounds(), image.NewUniform(white), image.Point{}, draw.Src)
+	draw.Draw(aliasedImg, aliasedImg.Bounds(), image.NewUniform(white), image.Point{}, draw.Src)
+
+	Draw(aaImg, "Test", face, 10, 35, color.Black)
+	DrawAliased(aliasedImg, "Test", face, 10, 35, color.Black)
+
+	aaInk := countInkPixels(aaImg)
+	aliasedInk := countInkPixels(aliasedImg)
+
+	t.Logf("variable font AA: %d ink, aliased: %d ink", aaInk, aliasedInk)
+
+	if aaInk == 0 || aliasedInk == 0 {
+		t.Fatalf("rendering failed: AA=%d, aliased=%d ink pixels", aaInk, aliasedInk)
+	}
+
+	// AA produces more ink pixels due to anti-aliased fringe.
+	if aaInk <= aliasedInk {
+		t.Errorf("AA (%d) should have more ink than aliased (%d) — AA fringe adds partial coverage pixels", aaInk, aliasedInk)
+	}
+}
+
 func countInkPixels(img *image.RGBA) int {
 	count := 0
 	b := img.Bounds()


### PR DESCRIPTION
TextModeAliased now works with variable fonts. Outline extraction and rasterization mode are orthogonal (Skia pattern). Reported by @tsl0922.