### PR TITLE
fix(text): aliased variable font hinting + grid-fit (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.5] - 2026-06-29
+
+### Fixed
+
+- **Aliased variable font hinting** (#385, #405) — apply `gridFitOutline` to go-text
+  extracted outlines for aliased mode only. AA uses unhinted outlines (Skia pattern:
+  `FT_LOAD_TARGET_MONO` for kAlias, lighter hinting for kAntiAlias). Enterprise
+  auto-hinter upgrade (FreeType parity) tracked in #405.
+
 ## [0.49.4] - 2026-06-29
 
 ### Fixed

--- a/text/draw.go
+++ b/text/draw.go
@@ -141,6 +141,14 @@ func drawGlyphsVariable(
 	rast := NewGlyphMaskRasterizer()
 	src := image.NewUniform(col)
 
+	// Hinting only for aliased mode (Skia pattern: FT_LOAD_TARGET_MONO for kAlias,
+	// FT_LOAD_TARGET_NORMAL for kAntiAlias). AA rendering benefits from smooth
+	// unhinted outlines; aliased needs grid-fitting for crisp stems.
+	var hintingOpts []Hinting
+	if mode == rasterModeAliased {
+		hintingOpts = []Hinting{sf.config.hinting}
+	}
+
 	advanceX := 0.0
 	for _, r := range text {
 		if r < 0x20 && r != '\t' {
@@ -161,7 +169,7 @@ func drawGlyphsVariable(
 		subpixelX := glyphX - intX
 		subpixelY := glyphY - intY
 
-		outline := ExtractOutlineGoText(gtFont, gid, ppem, variations)
+		outline := ExtractOutlineGoText(gtFont, gid, ppem, variations, hintingOpts...)
 		if outline == nil || outline.IsEmpty() {
 			if outline != nil {
 				advanceX += float64(outline.Advance)

--- a/text/varfont_render.go
+++ b/text/varfont_render.go
@@ -44,11 +44,16 @@ func GetGoTextFont(source *FontSource) (*font.Font, error) {
 
 // ExtractOutlineGoText extracts a glyph outline using go-text with variations applied.
 // Coordinates are returned in pixel units (scaled by ppem/upem), matching sfnt output.
+//
+// When hinting is not HintingNone, gridFitOutline is applied after scaling
+// (Skia/FreeType pattern: hinting AFTER variation interpolation). This snaps
+// horizontal stems to pixel boundaries for crisp rendering at small sizes.
 func ExtractOutlineGoText(
 	goTextFont *font.Font,
 	gid GlyphID,
 	ppem float64,
 	variations []FontVariation,
+	hinting ...Hinting,
 ) *GlyphOutline {
 	face := font.NewFace(goTextFont)
 	if len(variations) > 0 {
@@ -120,6 +125,13 @@ func ExtractOutlineGoText(
 
 	advance := float64(face.HorizontalAdvance(font.GID(gid)))
 	outline.Advance = float32(advance * scale)
+
+	// Apply grid-fitting after scaling (Skia/FreeType pattern: hint AFTER variation
+	// interpolation). go-text returns unhinted outlines; our auto-hinter snaps
+	// horizontal stems to pixel boundaries for crisp rendering at small sizes.
+	if len(hinting) > 0 && hinting[0] != HintingNone {
+		gridFitOutline(outline, hinting[0])
+	}
 
 	return outline
 }


### PR DESCRIPTION
Aliased variable font outlines now grid-fitted via gridFitOutline (Skia FT_LOAD_TARGET_MONO pattern). AA outlines remain unhinted. Enterprise auto-hinter upgrade tracked separately.