### PR TITLE
fix(text): TT interpreter backward compat — movePoint architecture (#405)

### DIFF
--- a/text/glyph_outline.go
+++ b/text/glyph_outline.go
@@ -383,36 +383,6 @@ func tryTTBytecodeHinting(xiFont *ximageParsedFont, gid GlyphID, size float64) *
 		return nil
 	}
 
-	// Validate hinted outline bounds. The TT interpreter may produce corrupt
-	// coordinates for some fonts (e.g., DejaVuSans) when the bytecode moves
-	// points to degenerate positions. Two checks:
-	//
-	// 1. Coordinate range: a well-formed glyph at ppem N should have
-	//    coordinates within a few multiples of ppem. We use 4x ppem as a
-	//    generous upper bound — this catches values like 642043 px at 24 ppem
-	//    while allowing large glyphs (CJK, decorative) to pass.
-	//
-	// 2. Non-degenerate width: if the original glyph has non-zero width (it
-	//    has visible outline segments), the hinted outline should also have
-	//    non-zero width. A width of exactly 0.0 means all X coordinates
-	//    collapsed — this happens when the interpreter zeroes X coordinates
-	//    without proper IUP interpolation.
-	//
-	// When validation fails, we return nil so the caller falls back to the
-	// auto-hinter, which produces correct outlines from sfnt data.
-	maxCoord := size * 4
-	b := outline.Bounds
-	if b.MaxX-b.MinX > maxCoord || b.MaxY-b.MinY > maxCoord ||
-		b.MinX < -maxCoord || b.MinY < -maxCoord ||
-		b.MaxX > maxCoord || b.MaxY > maxCoord {
-		return nil
-	}
-	// Check for zero-width collapse: if the outline has segments (not a
-	// space/empty glyph), it must have non-zero X extent.
-	if len(outline.Segments) > 0 && b.MaxX-b.MinX < 0.01 {
-		return nil
-	}
-
 	return outline
 }
 

--- a/text/tt_engine_test.go
+++ b/text/tt_engine_test.go
@@ -335,20 +335,87 @@ func TestZone_PointAccess(t *testing.T) {
 }
 
 func TestZone_MovePoint(t *testing.T) {
-	z := ttZone{
-		points: [][2]int32{{100, 200}},
-		flags:  []ttPointFlags{0},
-	}
-	gs := defaultGraphicsState()
-	// Freedom vector = X axis
-	gs.freedomVector = [2]int32{0x4000, 0}
-	gs.updateProjectionState()
-	if err := z.movePoint(&gs, 0, 64); err != nil {
-		t.Fatalf("movePoint: %v", err)
-	}
-	if z.points[0][0] != 164 {
-		t.Errorf("x = %d, want 164", z.points[0][0])
-	}
+	t.Run("X axis no backward compat", func(t *testing.T) {
+		z := ttZone{
+			points: [][2]int32{{100, 200}},
+			flags:  []ttPointFlags{0},
+		}
+		gs := defaultGraphicsState()
+		gs.backwardCompatibility = false
+		gs.freedomVector = [2]int32{0x4000, 0}
+		gs.updateProjectionState()
+		if err := z.movePoint(&gs, 0, 64); err != nil {
+			t.Fatalf("movePoint: %v", err)
+		}
+		if z.points[0][0] != 164 {
+			t.Errorf("x = %d, want 164", z.points[0][0])
+		}
+		if !z.isTouchedX(0) {
+			t.Error("expected X-touched after movePoint")
+		}
+	})
+	t.Run("X axis backward compat suppresses move", func(t *testing.T) {
+		z := ttZone{
+			points: [][2]int32{{100, 200}},
+			flags:  []ttPointFlags{0},
+		}
+		gs := defaultGraphicsState()
+		gs.backwardCompatibility = true
+		gs.freedomVector = [2]int32{0x4000, 0}
+		gs.updateProjectionState()
+		if err := z.movePoint(&gs, 0, 64); err != nil {
+			t.Fatalf("movePoint: %v", err)
+		}
+		// In backward compat mode, X movement is suppressed but point is touched.
+		if z.points[0][0] != 100 {
+			t.Errorf("x = %d, want 100 (suppressed)", z.points[0][0])
+		}
+		if !z.isTouchedX(0) {
+			t.Error("expected X-touched even when movement suppressed")
+		}
+	})
+	t.Run("Y axis backward compat allows move", func(t *testing.T) {
+		z := ttZone{
+			points: [][2]int32{{100, 200}},
+			flags:  []ttPointFlags{0},
+		}
+		gs := defaultGraphicsState()
+		gs.backwardCompatibility = true
+		gs.freedomVector = [2]int32{0, 0x4000}
+		gs.updateProjectionState()
+		if err := z.movePoint(&gs, 0, 64); err != nil {
+			t.Fatalf("movePoint: %v", err)
+		}
+		// Y movement proceeds normally in backward compat (until IUP done).
+		if z.points[0][1] != 264 {
+			t.Errorf("y = %d, want 264", z.points[0][1])
+		}
+		if !z.isTouchedY(0) {
+			t.Error("expected Y-touched after movePoint")
+		}
+	})
+	t.Run("Y axis backward compat after IUP suppresses", func(t *testing.T) {
+		z := ttZone{
+			points: [][2]int32{{100, 200}},
+			flags:  []ttPointFlags{0},
+		}
+		gs := defaultGraphicsState()
+		gs.backwardCompatibility = true
+		gs.didIUPx = true
+		gs.didIUPy = true
+		gs.freedomVector = [2]int32{0, 0x4000}
+		gs.updateProjectionState()
+		if err := z.movePoint(&gs, 0, 64); err != nil {
+			t.Fatalf("movePoint: %v", err)
+		}
+		// After IUP done on both axes, Y movement also suppressed.
+		if z.points[0][1] != 200 {
+			t.Errorf("y = %d, want 200 (suppressed after IUP)", z.points[0][1])
+		}
+		if !z.isTouchedY(0) {
+			t.Error("expected Y-touched even when movement suppressed")
+		}
+	})
 }
 
 func TestGraphicsState_Project(t *testing.T) {

--- a/text/tt_golden_test.go
+++ b/text/tt_golden_test.go
@@ -999,6 +999,80 @@ func TestTTGolden_EdgeCasePPEM(t *testing.T) {
 	}
 }
 
+// --- Test 21: Backward compat preserves X coordinates (bug fix validation) ---
+
+// TestTTGolden_BackwardCompatXPreserved validates that in backward compatibility
+// mode (ClearType), the TT interpreter preserves X coordinates instead of zeroing
+// them. This was the root cause of the DejaVuSans X-zeroing bug.
+//
+// In backward compat mode, skrifa's move_point() (zone.rs:417-468):
+//   - Suppresses X movement (point.x stays at original, not zeroed)
+//   - Still touches the point (flag set)
+//   - Y movement proceeds normally (until both IUP axes done)
+func TestTTGolden_BackwardCompatXPreserved(t *testing.T) {
+	data := loadTTTestFont(t, "tthint_subset.ttf")
+	fp, err := loadTTFontProgram(data)
+	if err != nil || fp == nil {
+		t.Fatalf("loadTTFontProgram: fp=%v err=%v", fp, err)
+	}
+
+	for _, ppem := range []int32{12, 16, 24} {
+		t.Run("ppem_"+itoa(int(ppem)), func(t *testing.T) {
+			instance, err := newTTHintInstance(fp, ppem, ttTargetSmooth)
+			if err != nil || instance == nil {
+				t.Fatalf("newTTHintInstance: %v", err)
+			}
+			if !instance.backwardCompatibility() {
+				t.Skip("smooth target should have backward compat enabled")
+			}
+
+			loader, lerr := newTTGlyphLoader(data, fp)
+			if lerr != nil || loader == nil {
+				t.Fatalf("newTTGlyphLoader: %v", lerr)
+			}
+			outline, err := loader.loadGlyphOutline(1, instance.scale) // GID 1 = 'A'
+			if err != nil || outline == nil {
+				t.Fatalf("loadGlyphOutline: %v", err)
+			}
+
+			// Save pre-hint X coordinates.
+			numPoints := len(outline.points) - ttPhantomPointCount
+			preHintX := make([]int32, numPoints)
+			for i := range numPoints {
+				preHintX[i] = outline.points[i][0]
+			}
+
+			// Run hinting.
+			err = instance.hintGlyph(outline)
+			if err != nil {
+				t.Fatalf("hintGlyph: %v", err)
+			}
+
+			// In backward compat mode, X coordinates should be preserved
+			// (NOT zeroed). Points keep their original X values.
+			zeroedCount := 0
+			preservedCount := 0
+			for i := range numPoints {
+				postX := outline.points[i][0]
+				if preHintX[i] != 0 && postX == 0 {
+					zeroedCount++
+				}
+				if postX == preHintX[i] {
+					preservedCount++
+				}
+			}
+
+			if zeroedCount > 0 {
+				t.Errorf("REGRESSION: %d/%d X coordinates zeroed (backward compat should preserve X)",
+					zeroedCount, numPoints)
+			}
+
+			t.Logf("ppem=%d: %d/%d X coords preserved, 0 zeroed",
+				ppem, preservedCount, numPoints)
+		})
+	}
+}
+
 // --- Helpers ---
 
 // absInt64 returns the absolute value of an int64.

--- a/text/tt_ops_flow.go
+++ b/text/tt_ops_flow.go
@@ -539,56 +539,73 @@ func (e *ttEngine) opGetdata() error {
 // ============================================================
 
 // opDeltap implements DELTAP1/2/3 (0x5D, 0x71, 0x72).
-// Reference: skrifa hint/engine/delta.rs
+// Reference: skrifa hint/engine/delta.rs:30-79
 func (e *ttEngine) opDeltap(opcode byte) error {
+	gs := &e.graphics
 	count, err := e.valueStack.popCountChecked()
 	if err != nil {
 		return err
 	}
+	z := e.zone(gs.zp0)
+	pointCount := z.pointCount()
+	// Each pair needs 2 stack values; limit to prevent looping in non-pedantic mode.
+	if count > e.valueStack.len()/2 {
+		count = e.valueStack.len() / 2
+	}
+	bias := int32(gs.retained.deltaBase)
+	switch opcode {
+	case opDELTAP2:
+		bias += 16
+	case opDELTAP3:
+		bias += 32
+	}
+	backCompat := gs.backwardCompatibility
+	didIUP := gs.didIUPx && gs.didIUPy
 	for i := 0; i < count; i++ {
-		arg, err := e.valueStack.pop()
-		if err != nil {
-			return err
-		}
+		// skrifa pops point_ix first, then b (arg).
+		// Reference: skrifa hint/engine/delta.rs:47-48
 		pointIdx, err := e.valueStack.popUsize()
 		if err != nil {
 			return err
 		}
-		// Compute the ppem range for this delta opcode
-		var deltaBase int32
-		switch opcode {
-		case opDELTAP1:
-			deltaBase = int32(e.graphics.retained.deltaBase)
-		case opDELTAP2:
-			deltaBase = int32(e.graphics.retained.deltaBase) + 16
-		case opDELTAP3:
-			deltaBase = int32(e.graphics.retained.deltaBase) + 32
-		default:
+		b, err := e.valueStack.pop()
+		if err != nil {
+			return err
+		}
+		// FreeType notes that some popular fonts contain invalid DELTAP
+		// instructions so out of bounds points are ignored.
+		if pointIdx >= pointCount {
 			continue
 		}
-		ppemIdx := (arg >> 4) & 0xF
-		targetPpem := deltaBase + ppemIdx
-		if targetPpem != e.graphics.retained.ppem {
+		c := int32((uint32(b) & 0xF0) >> 4)
+		c += bias
+		if c != gs.retained.ppem {
 			continue
 		}
-		// Check backward compatibility suppression
-		if e.graphics.backwardCompatibility {
-			if e.graphics.didIUPx && e.graphics.didIUPy {
-				continue
+		// Compute distance (skrifa pattern).
+		b = (b & 0xF) - 8
+		if b >= 0 {
+			b++
+		}
+		b *= 1 << (6 - int32(gs.retained.deltaShift))
+		if backCompat {
+			// In backward compat mode, DELTAP only moves if:
+			// - IUP not done AND (composite with Y freedom OR point Y-touched)
+			// Reference: skrifa hint/engine/delta.rs:66-72
+			if !didIUP &&
+				((gs.isComposite && gs.freedomVector[1] != 0) ||
+					z.isTouchedY(pointIdx)) {
+				if err := z.movePoint(gs, pointIdx, b); err != nil {
+					if gs.isPedantic {
+						return err
+					}
+				}
 			}
-		}
-		// Compute the movement
-		mag := arg & 0xF
-		if mag >= 8 {
-			mag -= 7
 		} else {
-			mag = -(8 - mag)
-		}
-		mag <<= 6 - int32(e.graphics.retained.deltaShift)
-		z := e.zone(e.graphics.zp0)
-		if err := z.movePoint(&e.graphics, pointIdx, mag); err != nil {
-			if e.graphics.isPedantic {
-				return err
+			if err := z.movePoint(gs, pointIdx, b); err != nil {
+				if gs.isPedantic {
+					return err
+				}
 			}
 		}
 	}

--- a/text/tt_ops_outline.go
+++ b/text/tt_ops_outline.go
@@ -41,7 +41,7 @@ func (e *ttEngine) opMdap(opcode byte) error {
 			return err
 		}
 	}
-	e.touchPoint(z, pointIdx)
+	// NOTE: movePoint now handles touching (skrifa pattern).
 	e.graphics.rp0 = pointIdx
 	e.graphics.rp1 = pointIdx
 	return nil
@@ -99,7 +99,7 @@ func (e *ttEngine) opMiap(opcode byte) error {
 			return err
 		}
 	}
-	e.touchPoint(z, pointIdx)
+	// NOTE: movePoint now handles touching (skrifa pattern).
 	e.graphics.rp0 = pointIdx
 	e.graphics.rp1 = pointIdx
 	return nil
@@ -178,12 +178,8 @@ func (e *ttEngine) opMdrp(opcode byte) error {
 		}
 	}
 
-	// Backward compatibility: suppress X movement
-	if e.graphics.backwardCompatibility {
-		if e.graphics.projAxis == ttCoordX {
-			distance = 0
-		}
-	}
+	// NOTE: backward compatibility is handled inside movePoint (skrifa pattern).
+	// skrifa's op_mdrp does NOT check backward_compatibility.
 
 	// Get current position and compute movement
 	curPt, err := z.point(pointIdx)
@@ -212,7 +208,6 @@ func (e *ttEngine) opMdrp(opcode byte) error {
 	if setRP0 {
 		e.graphics.rp0 = pointIdx
 	}
-	e.touchPoint(z, pointIdx)
 	return nil
 }
 
@@ -309,12 +304,8 @@ func (e *ttEngine) opMirp(opcode byte) error {
 		}
 	}
 
-	// Backward compatibility: suppress X movement
-	if e.graphics.backwardCompatibility {
-		if e.graphics.projAxis == ttCoordX {
-			distance = 0
-		}
-	}
+	// NOTE: backward compatibility is handled inside movePoint (skrifa pattern).
+	// skrifa's op_mirp does NOT check backward_compatibility.
 
 	// Apply movement
 	z := e.zone(e.graphics.zp1)
@@ -342,7 +333,6 @@ func (e *ttEngine) opMirp(opcode byte) error {
 	if setRP0 {
 		e.graphics.rp0 = pointIdx
 	}
-	e.touchPoint(z, pointIdx)
 	return nil
 }
 
@@ -361,9 +351,8 @@ func (e *ttEngine) opMsirp(opcode byte) error {
 	if err != nil {
 		return err
 	}
-	if e.graphics.backwardCompatibility && e.graphics.projAxis == ttCoordX {
-		distance = 0
-	}
+	// NOTE: backward compatibility is handled inside movePoint (skrifa pattern).
+	// skrifa's op_msirp does NOT check backward_compatibility.
 	z := e.zone(e.graphics.zp1)
 	rp0z := e.zone(e.graphics.zp0)
 	curPt, e1 := z.point(pointIdx)
@@ -388,7 +377,6 @@ func (e *ttEngine) opMsirp(opcode byte) error {
 	if opcode&1 != 0 {
 		e.graphics.rp0 = pointIdx
 	}
-	e.touchPoint(z, pointIdx)
 	return nil
 }
 
@@ -631,7 +619,7 @@ func (e *ttEngine) opIP() error {
 		if err := z.movePoint(gs, pointIdx, newDist-curDist); err != nil {
 			return err
 		}
-		e.touchPoint(z, pointIdx)
+		// NOTE: movePoint now handles touching (skrifa pattern).
 	}
 	return nil
 }
@@ -650,9 +638,8 @@ func (e *ttEngine) opAlignrp() error {
 		if err != nil {
 			return err
 		}
-		if e.graphics.backwardCompatibility && e.graphics.projAxis == ttCoordX {
-			continue
-		}
+		// NOTE: backward compatibility handled inside movePoint (skrifa pattern).
+		// skrifa's op_alignrp does NOT check backward_compatibility.
 		z := e.zone(e.graphics.zp1)
 		rp0z := e.zone(e.graphics.zp0)
 		curPt, e1 := z.point(pointIdx)
@@ -670,7 +657,6 @@ func (e *ttEngine) opAlignrp() error {
 		if err := z.movePoint(&e.graphics, pointIdx, -dist); err != nil {
 			return err
 		}
-		e.touchPoint(z, pointIdx)
 	}
 	return nil
 }
@@ -710,8 +696,7 @@ func (e *ttEngine) opAlignpts() error {
 	if err := z1.movePoint(&e.graphics, p2Idx, dist/2); err != nil {
 		return err
 	}
-	e.touchPoint(z0, p1Idx)
-	e.touchPoint(z1, p2Idx)
+	// NOTE: movePoint now handles touching (skrifa pattern).
 	return nil
 }
 
@@ -847,13 +832,11 @@ func (e *ttEngine) opShp(opcode byte) error {
 		if err != nil {
 			return err
 		}
-		if e.graphics.backwardCompatibility && e.graphics.projAxis == ttCoordX {
-			continue
-		}
+		// NOTE: backward compatibility handled inside movePoint (skrifa pattern).
+		// skrifa's op_shp uses move_zp2_point which embeds backward compat.
 		if err := z.movePoint(&e.graphics, pointIdx, displacement); err != nil {
 			return err
 		}
-		e.touchPoint(z, pointIdx)
 	}
 	return nil
 }
@@ -866,9 +849,7 @@ func (e *ttEngine) opShc(opcode byte) error {
 	if err != nil {
 		return err
 	}
-	if e.graphics.backwardCompatibility && e.graphics.projAxis == ttCoordX {
-		return nil
-	}
+	// NOTE: backward compatibility handled inside movePoint (skrifa pattern).
 	var rpIdx int
 	var rpZone *ttZone
 	if opcode&1 != 0 {
@@ -921,9 +902,7 @@ func (e *ttEngine) opShz(opcode byte) error {
 	if err != nil {
 		return err
 	}
-	if e.graphics.backwardCompatibility && e.graphics.projAxis == ttCoordX {
-		return nil
-	}
+	// NOTE: backward compatibility handled inside movePoint (skrifa pattern).
 	zp, err := ttZonePointerFromInt32(zoneIdx)
 	if err != nil {
 		if e.graphics.isPedantic {
@@ -966,32 +945,41 @@ func (e *ttEngine) opShz(opcode byte) error {
 // ============================================================
 
 // opShpix implements SHPIX[] (0x38).
-// Reference: skrifa hint/engine/outline.rs
+// Reference: skrifa hint/engine/outline.rs:221-244
 func (e *ttEngine) opShpix() error {
+	gs := &e.graphics
+	inTwilight := gs.zp0 == ttZoneTwilight || gs.zp1 == ttZoneTwilight || gs.zp2 == ttZoneTwilight
 	distance, err := e.valueStack.pop()
 	if err != nil {
 		return err
 	}
-	loop := e.graphics.loopCounter
-	e.graphics.loopCounter = 1
-	z := e.zone(e.graphics.zp2)
+	loop := gs.loopCounter
+	gs.loopCounter = 1
+	didIUP := gs.didIUPx && gs.didIUPy
+	z := e.zone(gs.zp2)
 	for i := int32(0); i < loop; i++ {
 		pointIdx, err := e.valueStack.popUsize()
 		if err != nil {
 			return err
 		}
-		if e.graphics.backwardCompatibility {
-			if e.graphics.projAxis == ttCoordX {
-				continue
+		if gs.backwardCompatibility {
+			// In backward compat mode, SHPIX has its own gating logic:
+			// only move if in twilight zone, or if IUP hasn't been done
+			// and either (composite with Y freedom) or (point is Y-touched).
+			// Reference: skrifa hint/engine/outline.rs:232-239
+			if inTwilight ||
+				(!didIUP &&
+					((gs.isComposite && gs.freedomVector[1] != 0) ||
+						z.isTouchedY(pointIdx))) {
+				if err := z.movePoint(gs, pointIdx, distance); err != nil {
+					return err
+				}
 			}
-			if e.graphics.didIUPx && e.graphics.didIUPy {
-				continue
+		} else {
+			if err := z.movePoint(gs, pointIdx, distance); err != nil {
+				return err
 			}
 		}
-		if err := z.movePoint(&e.graphics, pointIdx, distance); err != nil {
-			return err
-		}
-		e.touchPoint(z, pointIdx)
 	}
 	return nil
 }
@@ -1072,25 +1060,8 @@ func (e *ttEngine) opFliprgoff() error {
 }
 
 // ============================================================
-// Helper: touch point based on current projection vector
+// Helper: check if point is touched along an axis
 // ============================================================
-
-// touchPoint marks a point as touched along the current projection axis.
-func (e *ttEngine) touchPoint(z *ttZone, index int) {
-	switch e.graphics.freedomAxis {
-	case ttCoordX:
-		z.touchX(index)
-	case ttCoordY:
-		z.touchY(index)
-	default:
-		if e.graphics.freedomVector[0] != 0 {
-			z.touchX(index)
-		}
-		if e.graphics.freedomVector[1] != 0 {
-			z.touchY(index)
-		}
-	}
-}
 
 // isPointTouched checks if a point has been touched along the specified axis.
 func (e *ttEngine) isPointTouched(z *ttZone, index int, isX bool) bool {

--- a/text/tt_zone.go
+++ b/text/tt_zone.go
@@ -181,7 +181,15 @@ func (z *ttZone) contourEnd(contourIndex int) (int, error) {
 // by 1/fdotp to account for the angle between projection and freedom
 // vectors.
 //
-// Reference: skrifa hint/zone.rs (Zone move methods)
+// In backward compatibility mode (ClearType):
+//   - X adjustments are suppressed (point.x NOT moved, but still touched)
+//   - Y adjustments are suppressed ONLY after IUP has been done on both axes
+//
+// This matches skrifa zone.rs:417-468 where backward compat is enforced at the
+// move level, NOT at the instruction level. Individual instructions (MDRP, MIRP,
+// etc.) must NOT check backward compat themselves.
+//
+// Reference: skrifa hint/zone.rs:417-468
 func (z *ttZone) movePoint(gs *ttGraphicsState, index int, distance int32) error {
 	if index < 0 || index >= len(z.points) {
 		if gs.isPedantic {
@@ -190,21 +198,38 @@ func (z *ttZone) movePoint(gs *ttGraphicsState, index int, distance int32) error
 		return nil
 	}
 
+	backCompat := gs.backwardCompatibility
+	backCompatAndDidIUP := backCompat && gs.didIUPx && gs.didIUPy
+
 	switch gs.freedomAxis {
 	case ttCoordX:
-		z.points[index][0] += distance
+		if !backCompat {
+			z.points[index][0] += distance
+		}
+		z.touchX(index)
 	case ttCoordY:
-		z.points[index][1] += distance
+		if !backCompatAndDidIUP {
+			z.points[index][1] += distance
+		}
+		z.touchY(index)
 	default:
 		fv := gs.freedomVector
 		fdotp := gs.fdotp
 		if fdotp != 0x4000 {
-			// Scale distance by fdotp to account for angle between
-			// projection and freedom vectors.
 			distance = ttMul14(distance, fdotp)
 		}
-		z.points[index][0] += ttMul14(distance, fv[0])
-		z.points[index][1] += ttMul14(distance, fv[1])
+		if fv[0] != 0 {
+			if !backCompat {
+				z.points[index][0] += ttMul14(distance, fv[0])
+			}
+			z.touchX(index)
+		}
+		if fv[1] != 0 {
+			if !backCompatAndDidIUP {
+				z.points[index][1] += ttMul14(distance, fv[1])
+			}
+			z.touchY(index)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes TT bytecode interpreter bug that zeroed all X coordinates for professionally hinted fonts (DejaVuSans, Arial, etc.).

### Root Cause

Backward compatibility was enforced at the **instruction level** (MDRP, MIRP, MSIRP, SHP, etc.), setting `distance=0` then computing `0-curDist` — which **actively moved** points to X=0. 

skrifa enforces backward compat in `movePoint()` (zone.rs:417-468) where points are **not moved** but **are touched** (critical for IUP anchor detection).

### Fix

- Moved backward compat logic into `movePoint()` matching skrifa architecture
- Removed incorrect checks from 9+ individual instruction handlers
- Removed bounds validation workaround (was masking this bug)
- SHPIX/DELTAP retain own gating (skrifa special cases)

### Result

- 624/624 X coordinates preserved for tthint_subset at 12/16/24ppem
- Tab test passes with original threshold (> 0), no workarounds
- All existing tests pass

## Test plan

- [x] Backward compat X preserved (624/624 points)
- [x] TestTabRenderingNoTofu — PASS (original threshold)
- [x] TestDrawStringCPU_TranslationOnly — PASS
- [x] TestTextQuality_AllStrategies — PASS
- [x] All text package tests — PASS
- [x] Lint: 0 issues