### PR TITLE
fix: software adapter routing — prevent SDF pipeline hang (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Software adapter hang** (#421) — SDF GPU pipeline hung on software/CPU adapters
+  (llvmpipe, SwiftShader, WARP). `SDFAccelerator` now implements `AdapterAware` —
+  shapes route to CPU rasterizer on software, GPU device stays alive for textures.
+  Follows Skia Graphite `kRasterAtlas` pattern. Regression from ADR-046 refactoring.
+
 ## [0.50.3] - 2026-07-03
 
 ### Changed

--- a/internal/gpu/gpu_shared.go
+++ b/internal/gpu/gpu_shared.go
@@ -200,10 +200,13 @@ func (s *GPUShared) SetDeviceProvider(provider gpucontext.DeviceProvider) error 
 }
 
 // CanRenderDirect reports whether the GPU is initialized and can render
-// directly to a surface. Returns false on CPU-only adapters.
+// directly to a surface. Returns false on CPU-only adapters (BUG-SW-002).
 func (s *GPUShared) CanRenderDirect() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.softwareMode {
+		return false
+	}
 	return s.gpuReady
 }
 
@@ -356,6 +359,14 @@ func (s *GPUShared) initGPU() error {
 		return fmt.Errorf("request adapter: %w", err)
 	}
 
+	// Check for software/CPU adapter before creating device.
+	adapterInfo := adapter.Info()
+	if adapterInfo.DeviceType == gputypes.DeviceTypeCPU {
+		slogger().Info("gpu-shared: software adapter detected, SDF pipeline disabled",
+			"adapter", adapterInfo.Name)
+		s.softwareMode = true
+	}
+
 	device, err := adapter.RequestDevice(&wgpu.DeviceDescriptor{Label: "gg-shared"})
 	if err != nil {
 		return fmt.Errorf("request device: %w", err)
@@ -366,7 +377,7 @@ func (s *GPUShared) initGPU() error {
 	// Probe MSAA support (Skia Graphite pattern: try 4x, fallback to 1x).
 	s.sampleCount = resolveSampleCount(s.device)
 
-	// Create pipelines.
+	// Create pipelines (device stays alive for texture ops even in softwareMode).
 	s.sdfRenderPipeline = NewSDFRenderPipeline(s.device, s.queue, s.sampleCount)
 	s.convexRenderer = NewConvexRenderer(s.device, s.queue, s.sampleCount)
 	s.stencilRenderer = NewStencilRenderer(s.device, s.queue, s.sampleCount)
@@ -377,8 +388,9 @@ func (s *GPUShared) initGPU() error {
 	s.initVelloAccelerator(s.device, s.queue)
 
 	slogger().Info("gpu-shared: GPU initialized",
-		"adapter", adapter.Info().Name,
+		"adapter", adapterInfo.Name,
 		"msaa_samples", s.sampleCount,
+		"softwareMode", s.softwareMode,
 	)
 	return nil
 }

--- a/internal/gpu/sdf_gpu.go
+++ b/internal/gpu/sdf_gpu.go
@@ -37,6 +37,7 @@ type SDFAccelerator struct {
 var _ gg.GPUAccelerator = (*SDFAccelerator)(nil)
 var _ gg.GPURenderContextProvider = (*SDFAccelerator)(nil)
 var _ gg.DirectRenderCapable = (*SDFAccelerator)(nil)
+var _ gg.AdapterAware = (*SDFAccelerator)(nil)
 var _ gg.GPUTextAccelerator = (*SDFAccelerator)(nil)
 var _ gg.GPUGlyphMaskAccelerator = (*SDFAccelerator)(nil)
 var _ gg.PipelineModeAware = (*SDFAccelerator)(nil)
@@ -55,6 +56,18 @@ func (a *SDFAccelerator) Shared() *GPUShared {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.shared
+}
+
+// IsSoftwareAdapter reports whether the accelerator is running on a software
+// (CPU) adapter such as llvmpipe, SwiftShader, or WARP. Used by
+// AcceleratorCanRenderDirect in auto mode (ADR-020) to route shapes to CPU.
+func (a *SDFAccelerator) IsSoftwareAdapter() bool {
+	if a.shared == nil {
+		return false
+	}
+	a.shared.mu.Lock()
+	defer a.shared.mu.Unlock()
+	return a.shared.softwareMode
 }
 
 // NewGPURenderContext creates a new per-context GPU render context.
@@ -122,7 +135,12 @@ func (a *SDFAccelerator) ClearClipPath() {
 }
 
 // CanAccelerate reports whether this accelerator supports the given operation.
+// Returns false on software adapters to prevent SDF pipeline hang — shapes
+// route to CPU rasterizer instead (Skia kRasterAtlas pattern, BUG-SW-002).
 func (a *SDFAccelerator) CanAccelerate(op gg.AcceleratedOp) bool {
+	if a.IsSoftwareAdapter() {
+		return false
+	}
 	return op&(gg.AccelCircleSDF|gg.AccelRRectSDF|gg.AccelFill|gg.AccelStroke|gg.AccelText) != 0
 }
 
@@ -190,7 +208,9 @@ func (a *SDFAccelerator) SetDeviceProvider(provider gpucontext.DeviceProvider) e
 }
 
 // CanRenderDirect reports whether the GPU accelerator can render to a surface.
+// Returns false on software adapters — SDF pipelines hang on CPU (BUG-SW-002).
 func (a *SDFAccelerator) CanRenderDirect() bool {
+	// GPUShared.CanRenderDirect() already checks softwareMode under lock.
 	return a.shared.CanRenderDirect()
 }
 


### PR DESCRIPTION
## Summary

Fixes #421 — SDF GPU pipeline hangs on software/CPU adapters (llvmpipe, SwiftShader, WARP).

### Root Cause

`softwareMode` flag correctly set but never read for routing decisions (regression from ADR-046 refactoring, commit cb055c9).

### Fix (Skia Graphite kRasterAtlas pattern)

- `SDFAccelerator` implements `AdapterAware` → `IsSoftwareAdapter()` returns true on CPU adapters
- `CanAccelerate()` returns false → shapes route to CPU rasterizer
- `CanRenderDirect()` returns false → no GPU-direct path
- `initGPU()` detects `DeviceTypeCPU` → sets `softwareMode`
- GPU device stays alive for texture operations (ADR-046 preserved)

### Enterprise Research

Decision based on verified analysis of Skia Graphite (`RendererProvider.cpp:86-97`), wgpu (`instance.rs:462`), and Vello (`compare.rs:101`). Adaptive runtime probing rejected — hang is infinite, `queue.Submit` has no cancellation.

## Test plan

- [x] Build: PASS
- [x] All production tests: PASS
- [x] Lint: 0 issues
- [x] Visual test: hardware GPU rendering unchanged
- [x] Thread safety: softwareMode reads under lock