### PR TITLE
fix: composite glyph fan-out DoS + cycle detection + gvar guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Composite glyph DoS hardening** (#418) — added shared work budget
+  (`maxCompositeComponents=4096`) and cycle-detection map to both composite
+  recursion sites. The depth-only guard (32 levels) did not bound multiplicative
+  fan-out (F siblings × N levels = F^N resolutions). Cycle hits now degrade
+  gracefully; gvar delta application skipped for composites (wrong point-number
+  space corrupted variable font geometry). Patch contributed by issue author.
 - **Software adapter hang** (#421) — SDF GPU pipeline hung on software/CPU adapters
   (llvmpipe, SwiftShader, WARP). `SDFAccelerator` now implements `AdapterAware` —
   shapes route to CPU rasterizer on software, GPU device stays alive for textures.

--- a/text/composite_hardening_test.go
+++ b/text/composite_hardening_test.go
@@ -1,0 +1,292 @@
+package text
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+	"time"
+)
+
+func appendU16(b []byte, v uint16) []byte {
+	return binary.BigEndian.AppendUint16(b, v)
+}
+
+func buildSimpleSquare() []byte {
+	var b []byte
+	b = appendU16(b, 1)       // numberOfContours
+	b = appendU16(b, 0)       // xMin
+	b = appendU16(b, 0)       // yMin
+	b = appendU16(b, 100)     // xMax
+	b = appendU16(b, 100)     // yMax
+	b = appendU16(b, 3)       // endPtsOfContours[0]
+	b = appendU16(b, 0)       // instructionLength
+	b = append(b, 1, 1, 1, 1) // flags: on-curve, word deltas
+	for _, dx := range []int16{0, 100, 0, -100} {
+		b = appendU16(b, uint16(dx))
+	}
+	for _, dy := range []int16{0, 0, 100, 0} {
+		b = appendU16(b, uint16(dy))
+	}
+	return b
+}
+
+func compositeHeader() []byte {
+	var b []byte
+	b = appendU16(b, 0xFFFF) // numberOfContours = -1
+	b = appendU16(b, 0)      // xMin
+	b = appendU16(b, 0)      // yMin
+	b = appendU16(b, 200)    // xMax
+	b = appendU16(b, 200)    // yMax
+	return b
+}
+
+func buildFixtureFont(records ...[]byte) (glyfData, locaData []byte) {
+	loca := make([]uint16, 1, 1+len(records))
+	loca[0] = 0
+	for _, rec := range records {
+		glyfData = append(glyfData, rec...)
+		if len(glyfData)%2 != 0 {
+			glyfData = append(glyfData, 0)
+		}
+		loca = append(loca, uint16(len(glyfData)/2)) //nolint:gosec // fixture size is tiny
+	}
+	for _, off := range loca {
+		locaData = appendU16(locaData, off)
+	}
+	return glyfData, locaData
+}
+
+func TestSimpleGlyph_Unchanged(t *testing.T) {
+	glyf, loca := buildFixtureFont(buildSimpleSquare())
+	got, err := extractGlyfContourOwn(glyf, loca, 0, false)
+	if err != nil {
+		t.Fatalf("extractGlyfContourOwn: %v", err)
+	}
+	if got == nil || got.IsComposite || len(got.Points) != 4 {
+		t.Fatalf("simple glyph parsing changed: %+v", got)
+	}
+}
+
+func TestCompositeContours_TwoComponents(t *testing.T) {
+	// Sibling reuse of the same component gid must not trip cycle detection.
+	comp := compositeHeader()
+	comp = appendU16(comp, compositeArgsAreXY|compositeMoreComponents)
+	comp = appendU16(comp, 0)
+	comp = append(comp, 0, 0) // dx=0, dy=0
+	comp = appendU16(comp, compositeArgsAreXY)
+	comp = appendU16(comp, 0)
+	comp = append(comp, 10, 120) // dx=10, dy=120
+
+	glyf, loca := buildFixtureFont(buildSimpleSquare(), comp)
+	got, err := extractGlyfContourOwn(glyf, loca, 1, false)
+	if err != nil {
+		t.Fatalf("extractGlyfContourOwn: %v", err)
+	}
+	if got == nil || !got.IsComposite {
+		t.Fatalf("expected composite contours, got %+v", got)
+	}
+	if len(got.Points) != 8 {
+		t.Fatalf("merged points = %d, want 8", len(got.Points))
+	}
+	if got.EndPts[0] != 3 || got.EndPts[1] != 7 {
+		t.Fatalf("EndPts = %v, want [3 7]", got.EndPts)
+	}
+	if p := got.Points[4]; p.X != 10 || p.Y != 120 {
+		t.Fatalf("second component origin = (%d,%d), want (10,120)", p.X, p.Y)
+	}
+	if !got.Points[0].OnCurve {
+		t.Fatalf("on-curve flag lost in merge")
+	}
+}
+
+func TestCompositeContours_Scale(t *testing.T) {
+	comp := compositeHeader()
+	comp = appendU16(comp, compositeArgsAreXY|compositeHaveScale)
+	comp = appendU16(comp, 0)
+	comp = append(comp, 0, 0)
+	comp = appendU16(comp, 0x2000) // F2Dot14 0.5
+
+	glyf, loca := buildFixtureFont(buildSimpleSquare(), comp)
+	got, err := extractGlyfContourOwn(glyf, loca, 1, false)
+	if err != nil {
+		t.Fatalf("extractGlyfContourOwn: %v", err)
+	}
+	if got == nil || len(got.Points) != 4 {
+		t.Fatalf("expected 4 points, got %+v", got)
+	}
+	if p := got.Points[2]; p.X != 50 || p.Y != 50 {
+		t.Fatalf("scaled corner = (%d,%d), want (50,50)", p.X, p.Y)
+	}
+}
+
+func TestCompositeContours_TwoByTwo(t *testing.T) {
+	comp := compositeHeader()
+	comp = appendU16(comp, compositeArgsAreXY|compositeHave2x2)
+	comp = appendU16(comp, 0)
+	comp = append(comp, 0, 0)
+	comp = appendU16(comp, 0x0000) // xx = 0
+	comp = appendU16(comp, 0xC000) // xy = -1
+	comp = appendU16(comp, 0x4000) // yx = 1
+	comp = appendU16(comp, 0x0000) // yy = 0
+
+	glyf, loca := buildFixtureFont(buildSimpleSquare(), comp)
+	got, err := extractGlyfContourOwn(glyf, loca, 1, false)
+	if err != nil {
+		t.Fatalf("extractGlyfContourOwn: %v", err)
+	}
+	if got == nil || len(got.Points) != 4 {
+		t.Fatalf("expected 4 points, got %+v", got)
+	}
+	// (100, 100) → (-100, 100)
+	if p := got.Points[2]; p.X != -100 || p.Y != 100 {
+		t.Fatalf("rotated corner = (%d,%d), want (-100,100)", p.X, p.Y)
+	}
+}
+
+func TestCompositeContours_Nested(t *testing.T) {
+	inner := compositeHeader()
+	inner = appendU16(inner, compositeArgsAreXY|compositeMoreComponents)
+	inner = appendU16(inner, 0)
+	inner = append(inner, 0, 0)
+	inner = appendU16(inner, compositeArgsAreXY)
+	inner = appendU16(inner, 0)
+	inner = append(inner, 10, 120)
+
+	outer := compositeHeader()
+	outer = appendU16(outer, compositeArgsAreXY)
+	outer = appendU16(outer, 1)
+	outer = append(outer, 5, 7)
+
+	glyf, loca := buildFixtureFont(buildSimpleSquare(), inner, outer)
+	got, err := extractGlyfContourOwn(glyf, loca, 2, false)
+	if err != nil {
+		t.Fatalf("extractGlyfContourOwn: %v", err)
+	}
+	if got == nil || len(got.Points) != 8 {
+		t.Fatalf("expected 8 merged points, got %+v", got)
+	}
+	if p := got.Points[4]; p.X != 15 || p.Y != 127 {
+		t.Fatalf("nested offset composition = (%d,%d), want (15,127)", p.X, p.Y)
+	}
+}
+
+func TestCompositeContours_SelfCycle_DegradesGracefully(t *testing.T) {
+	comp := compositeHeader()
+	comp = appendU16(comp, compositeArgsAreXY)
+	comp = appendU16(comp, 1)
+	comp = append(comp, 0, 0)
+
+	glyf, loca := buildFixtureFont(buildSimpleSquare(), comp)
+	got, err := extractGlyfContourOwn(glyf, loca, 1, false)
+	if err != nil {
+		t.Fatalf("cycle should degrade, not error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("self-referencing composite should resolve to nil, got %+v", got)
+	}
+}
+
+func buildFanOutComposite(childGID uint16, count int) []byte {
+	comp := compositeHeader()
+	for i := range count {
+		flags := uint16(compositeArgsAreXY)
+		if i < count-1 {
+			flags |= compositeMoreComponents
+		}
+		comp = appendU16(comp, flags)
+		comp = appendU16(comp, childGID)
+		comp = append(comp, 0, 0) // dx=0, dy=0
+	}
+	return comp
+}
+
+func TestCompositeContours_FanOutBudgetBounded(t *testing.T) {
+	const levels = compositeRecursionLimit
+	const branch = 6
+
+	records := make([][]byte, levels+1)
+	for i := range levels {
+		records[i] = buildFanOutComposite(uint16(i+1), branch) //nolint:gosec // fixture size is tiny
+	}
+	records[levels] = nil // empty leaf glyph
+
+	glyf, loca := buildFixtureFont(records...)
+
+	start := time.Now()
+	got, err := extractGlyfContourOwn(glyf, loca, 0, false)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("fan-out resolution took %s — work budget did not bound it", elapsed)
+	}
+	if err == nil {
+		t.Fatalf("expected a budget-exceeded error, got nil error and %+v", got)
+	}
+	if !strings.Contains(err.Error(), "budget") {
+		t.Fatalf("expected a budget-exceeded error, got: %v", err)
+	}
+}
+
+func newFixtureTTGlyphLoader(records ...[]byte) *ttGlyphLoader {
+	var glyfData []byte
+	offsets := make([]glyfOffset, len(records))
+	for i, rec := range records {
+		start := len(glyfData)
+		glyfData = append(glyfData, rec...)
+		offsets[i] = glyfOffset{offset: uint32(start), length: uint32(len(rec))} //nolint:gosec // fixture size is tiny
+	}
+	return &ttGlyphLoader{
+		font:    &ttFontProgram{},
+		tables:  map[string][]byte{"glyf": glyfData},
+		glyfOff: offsets,
+		hmtxAdv: []uint16{100},
+		hmtxLSB: []int16{0},
+		numHMtx: 1,
+	}
+}
+
+func TestTTLoadCompositeGlyphOutline_SelfCycle_DegradesGracefully(t *testing.T) {
+	comp := compositeHeader()
+	comp = appendU16(comp, compositeArgsAreXY)
+	comp = appendU16(comp, 1)
+	comp = append(comp, 0, 0)
+
+	l := newFixtureTTGlyphLoader(buildSimpleSquare(), comp)
+	got, err := l.loadGlyphOutline(1, 1<<16) // scale 1.0 in 16.16
+	if err != nil {
+		t.Fatalf("cycle should degrade, not error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected an empty-glyph outline, got nil")
+	}
+	if len(got.contours) != 0 {
+		t.Fatalf("expected no contours from a fully-cyclic composite, got %v", got.contours)
+	}
+}
+
+func TestTTLoadCompositeGlyphOutline_FanOutBudgetBounded(t *testing.T) {
+	const levels = compositeRecursionLimit
+	const branch = 6
+
+	records := make([][]byte, levels+1)
+	for i := range levels {
+		records[i] = buildFanOutComposite(uint16(i+1), branch) //nolint:gosec // fixture size is tiny
+	}
+	records[levels] = nil // empty leaf glyph
+
+	l := newFixtureTTGlyphLoader(records...)
+
+	start := time.Now()
+	got, err := l.loadGlyphOutline(0, 1<<16)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("fan-out resolution took %s — work budget did not bound it", elapsed)
+	}
+	if err == nil {
+		t.Fatalf("expected a budget-exceeded error, got nil error and %+v", got)
+	}
+	if !strings.Contains(err.Error(), "budget") {
+		t.Fatalf("expected a budget-exceeded error, got: %v", err)
+	}
+}

--- a/text/glyf_parser.go
+++ b/text/glyf_parser.go
@@ -42,6 +42,9 @@ type GlyfContours struct {
 	YMin   int16
 	XMax   int16
 	YMax   int16
+
+	// gvar point-number space for composites != merged simple-glyph space.
+	IsComposite bool
 }
 
 // NumContours returns the number of contours in the glyph.
@@ -301,6 +304,15 @@ const (
 // Matches skrifa GLYF_COMPOSITE_RECURSION_LIMIT = 32.
 const compositeRecursionLimit = 32
 
+// maxCompositeComponents bounds the total number of composite-glyph
+// resolutions across an entire top-level glyph's recursion. The depth cap
+// alone does not bound multiplicative fan-out: F siblings × N levels =
+// F^N resolutions (e.g. 6 siblings × 32 levels ≈ 8×10^24). 4096
+// comfortably covers any legitimate composite (real fonts rarely exceed
+// single digits of components). Neither skrifa nor FreeType enforce a
+// component budget — this is additional hardening for untrusted fonts.
+const maxCompositeComponents = 4096
+
 // compositeComponent holds the parsed data for a single component of a
 // composite TrueType glyph.
 type compositeComponent struct {
@@ -401,22 +413,49 @@ func parseCompositeComponents(data []byte, startPos int) ([]compositeComponent, 
 }
 
 // extractCompositeContours recursively loads and merges component glyphs
-// for a composite glyph (numContours < 0) in the glyf table.
-//
-// For each component, the function:
-//  1. Reads flags, component GID, and offsets from the composite glyph data
-//  2. Recursively loads the component's contour points
-//  3. Applies the component's affine transform (offset, scale, 2x2 matrix)
-//  4. Merges all component points and contour endpoints into a single GlyfContours
+// for a composite glyph (numContours < 0). Entry point: seeds fresh
+// cycle-detection map and work budget for extractCompositeContoursGuarded.
 //
 // Reference: skrifa glyf/mod.rs:784-960 (load_composite)
-// Reference: https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#composite-glyph-description
-//
-//nolint:nilnil // Intentional nil-nil for empty/missing glyphs.
 func extractCompositeContours(glyfData, locaData []byte, glyphIndex int, isLong bool, depth int) (*GlyfContours, error) {
+	return extractCompositeContoursGuarded(glyfData, locaData, glyphIndex, isLong, depth, nil, nil)
+}
+
+// extractCompositeContoursGuarded resolves composite components with shared
+// cycle map and work budget. Cycle hits degrade gracefully (nil, nil);
+// budget exhaustion is a hard error (adversarial font).
+//
+//nolint:nilnil // Intentional nil-nil for empty/missing/cyclic glyphs.
+func extractCompositeContoursGuarded(
+	glyfData, locaData []byte,
+	glyphIndex int,
+	isLong bool,
+	depth int,
+	visiting map[uint16]bool,
+	budget *int,
+) (*GlyfContours, error) {
 	if depth > compositeRecursionLimit {
 		return nil, fmt.Errorf("text: glyf parser: composite recursion limit exceeded for glyph %d", glyphIndex)
 	}
+
+	gid := uint16(glyphIndex) //nolint:gosec // glyph indices are inherently uint16 (glyf/loca/GlyphID)
+	if visiting == nil {
+		visiting = make(map[uint16]bool, 4)
+	}
+	if visiting[gid] {
+		return nil, nil // cycle in component graph — degrade gracefully
+	}
+
+	if budget == nil {
+		budget = new(int)
+	}
+	*budget++
+	if *budget > maxCompositeComponents {
+		return nil, fmt.Errorf("text: glyf parser: glyph %d: composite exceeds max component budget (>%d)", glyphIndex, maxCompositeComponents)
+	}
+
+	visiting[gid] = true
+	defer delete(visiting, gid)
 
 	off, length := locateGlyph(locaData, glyphIndex, isLong)
 	if length == 0 {
@@ -454,8 +493,9 @@ func extractCompositeContours(glyfData, locaData []byte, glyphIndex int, isLong 
 	var allEndPts []uint16
 
 	for _, comp := range components {
-		// Recursively load the component glyph.
-		componentContours, compErr := extractCompositeContours(glyfData, locaData, int(comp.glyphID), isLong, depth+1)
+		// Recursively load the component glyph, sharing the cycle map and
+		// work budget across all components at all depths.
+		componentContours, compErr := extractCompositeContoursGuarded(glyfData, locaData, int(comp.glyphID), isLong, depth+1, visiting, budget)
 		if compErr != nil {
 			return nil, fmt.Errorf("text: glyf parser: composite glyph %d component %d: %w", glyphIndex, comp.glyphID, compErr)
 		}
@@ -500,12 +540,13 @@ func extractCompositeContours(glyfData, locaData []byte, glyphIndex int, isLong 
 	}
 
 	return &GlyfContours{
-		Points: allPoints,
-		EndPts: allEndPts,
-		XMin:   xMin,
-		YMin:   yMin,
-		XMax:   xMax,
-		YMax:   yMax,
+		Points:      allPoints,
+		EndPts:      allEndPts,
+		XMin:        xMin,
+		YMin:        yMin,
+		XMax:        xMax,
+		YMax:        yMax,
+		IsComposite: true,
 	}, nil
 }
 

--- a/text/glyph_outline.go
+++ b/text/glyph_outline.go
@@ -773,33 +773,38 @@ func (e *OutlineExtractor) extractFromOwnVariableImpl(
 		}, nil, nil
 	}
 
-	// Build points array for applyVariations: [x, y] pairs + 4 phantom points.
-	nPts := len(contours.Points)
-	points := make([][2]int32, nPts+4)
-	for i, pt := range contours.Points {
-		points[i] = [2]int32{int32(pt.X), int32(pt.Y)}
-	}
+	// Skip gvar for composites: merged point-number space doesn't match
+	// gvar's per-component space (would silently corrupt geometry).
+	// Matches loadGlyphOutlineVar's existing skip for composites.
+	if !contours.IsComposite {
+		// Build points array for applyVariations: [x, y] pairs + 4 phantom points.
+		nPts := len(contours.Points)
+		points := make([][2]int32, nPts+4)
+		for i, pt := range contours.Points {
+			points[i] = [2]int32{int32(pt.X), int32(pt.Y)}
+		}
 
-	// Compute hmtx advance for phantom points.
-	var hmtxAdv int32
-	f.ensureHmtx()
-	if f.hmtxParsed && f.hmtxAdv != nil {
-		hmtxAdv = int32(hmtxAdvance(f.hmtxAdv, f.numHMetrics, uint16(gid)))
-	}
+		// Compute hmtx advance for phantom points.
+		var hmtxAdv int32
+		f.ensureHmtx()
+		if f.hmtxParsed && f.hmtxAdv != nil {
+			hmtxAdv = int32(hmtxAdvance(f.hmtxAdv, f.numHMetrics, uint16(gid)))
+		}
 
-	// Phantom points: [nPts+0]=origin, [nPts+1]=advance, [nPts+2/3]=vertical.
-	points[nPts] = [2]int32{0, 0}
-	points[nPts+1] = [2]int32{hmtxAdv, 0}
-	points[nPts+2] = [2]int32{0, 0}
-	points[nPts+3] = [2]int32{0, 0}
+		// Phantom points: [nPts+0]=origin, [nPts+1]=advance, [nPts+2/3]=vertical.
+		points[nPts] = [2]int32{0, 0}
+		points[nPts+1] = [2]int32{hmtxAdv, 0}
+		points[nPts+2] = [2]int32{0, 0}
+		points[nPts+3] = [2]int32{0, 0}
 
-	// Apply gvar deltas.
-	f.applyVariations(uint16(gid), points, contours.EndPts, variations)
+		// Apply gvar deltas.
+		f.applyVariations(uint16(gid), points, contours.EndPts, variations)
 
-	// Write modified points back to contours.
-	for i := range contours.Points {
-		contours.Points[i].X = int16(points[i][0])
-		contours.Points[i].Y = int16(points[i][1])
+		// Write modified points back to contours.
+		for i := range contours.Points {
+			contours.Points[i].X = int16(points[i][0])
+			contours.Points[i].Y = int16(points[i][1])
+		}
 	}
 
 	// Scale and convert to segments.

--- a/text/tt_glyph.go
+++ b/text/tt_glyph.go
@@ -346,16 +346,21 @@ func (l *ttGlyphLoader) loadGlyphOutline(glyphID uint16, scale int32) (*ttGlyphO
 }
 
 // loadCompositeGlyphOutline loads a composite glyph by recursively loading
-// each component glyph, applying transforms/offsets, and merging the result
-// into a single ttGlyphOutline with phantom points.
+// each component, applying transforms/offsets, and merging into a single
+// ttGlyphOutline. Entry point: seeds cycle-detection map (pre-marked with
+// own ID) and work budget for loadCompositeGlyphOutlineGuarded.
 //
-// This follows the skrifa load_composite pattern (glyf/mod.rs:784-960):
-// for each component, load its glyph (recursively), apply the 2x2 transform
-// and XY offset, then merge points and contour endpoints.
-//
-// Reference: skrifa glyf/mod.rs:784-960 (FreeTypeScaler::load_composite)
-// Reference: FreeType ttgload.c:1259-1330 (composite glyph loading)
+// Reference: skrifa glyf/mod.rs:784-960 (load_composite)
 func (l *ttGlyphLoader) loadCompositeGlyphOutline(glyphID uint16, scale int32, data []byte, depth int) (*ttGlyphOutline, error) {
+	visiting := map[uint16]bool{glyphID: true}
+	budget := new(int)
+	*budget = 1
+	return l.loadCompositeGlyphOutlineGuarded(glyphID, scale, data, depth, visiting, budget)
+}
+
+// loadCompositeGlyphOutlineGuarded is the merge logic with shared cycle
+// map and work budget. Caller has already marked glyphID in visiting.
+func (l *ttGlyphLoader) loadCompositeGlyphOutlineGuarded(glyphID uint16, scale int32, data []byte, depth int, visiting map[uint16]bool, budget *int) (*ttGlyphOutline, error) {
 	if depth > compositeRecursionLimit {
 		return nil, fmt.Errorf("tt: composite recursion limit exceeded for glyph %d", glyphID)
 	}
@@ -376,8 +381,9 @@ func (l *ttGlyphLoader) loadCompositeGlyphOutline(glyphID uint16, scale int32, d
 	var compositeInstructions []byte
 
 	for ci, comp := range components {
-		// Recursively load the component glyph.
-		componentOutline, compErr := l.loadGlyphOutlineRecursive(comp.glyphID, scale, depth+1)
+		// Recursively load the component glyph, sharing the cycle map and
+		// work budget across all components at all depths.
+		componentOutline, compErr := l.loadGlyphOutlineRecursive(comp.glyphID, scale, depth+1, visiting, budget)
 		if compErr != nil {
 			return nil, fmt.Errorf("tt: composite glyph %d component %d: %w", glyphID, comp.glyphID, compErr)
 		}
@@ -501,14 +507,25 @@ func (l *ttGlyphLoader) loadCompositeGlyphOutline(glyphID uint16, scale int32, d
 	return outline, nil
 }
 
-// loadGlyphOutlineRecursive loads a glyph outline, supporting recursion for
-// composite glyph components. This is the internal recursive entry point.
+// loadGlyphOutlineRecursive loads a glyph outline for a composite component.
+// Checks cycle detection and charges work budget before resolving.
+// Cycle hits degrade gracefully (nil, nil); budget exhaustion errors.
 //
 //nolint:nilnil // nil result = "no outline", not an error
-func (l *ttGlyphLoader) loadGlyphOutlineRecursive(glyphID uint16, scale int32, depth int) (*ttGlyphOutline, error) {
+func (l *ttGlyphLoader) loadGlyphOutlineRecursive(glyphID uint16, scale int32, depth int, visiting map[uint16]bool, budget *int) (*ttGlyphOutline, error) {
 	if depth > compositeRecursionLimit {
 		return nil, fmt.Errorf("tt: composite recursion limit exceeded for glyph %d", glyphID)
 	}
+	if visiting[glyphID] {
+		return nil, nil // cycle in component graph — degrade gracefully
+	}
+	*budget++
+	if *budget > maxCompositeComponents {
+		return nil, fmt.Errorf("tt: glyph %d: composite exceeds max component budget (>%d)", glyphID, maxCompositeComponents)
+	}
+	visiting[glyphID] = true
+	defer delete(visiting, glyphID)
+
 	if int(glyphID) >= len(l.glyfOff) {
 		return nil, fmt.Errorf("tt: glyph %d out of range (%d glyphs)", glyphID, len(l.glyfOff))
 	}
@@ -535,7 +552,7 @@ func (l *ttGlyphLoader) loadGlyphOutlineRecursive(glyphID uint16, scale int32, d
 
 	numContours := int16(binary.BigEndian.Uint16(data[0:2]))
 	if numContours < 0 {
-		return l.loadCompositeGlyphOutline(glyphID, scale, data, depth)
+		return l.loadCompositeGlyphOutlineGuarded(glyphID, scale, data, depth, visiting, budget)
 	}
 
 	// Simple glyph — delegate to the main loader (which won't recurse since numContours >= 0).


### PR DESCRIPTION
## Summary

Fixes #418 — composite glyph resolution hardening (patch contributed by issue author, enterprise-reviewed).

- **Fan-out DoS**: depth guard (32 levels) did not bound multiplicative fan-out (F siblings × N levels = F^N resolutions). Added shared work budget `maxCompositeComponents=4096` across entire recursion — neither skrifa nor FreeType enforce this, additional hardening for untrusted fonts
- **Cycle detection**: self/mutual glyph references had no cycle map — bounded only by 32 stack frames with hard error. Added `visiting map[uint16]bool` with graceful degradation (cyclic component contributes nothing)
- **gvar corruption**: `extractFromOwnVariableImpl` applied gvar deltas to composite-merged points unconditionally — wrong point-number space silently corrupted variable font composites. Gated on `GlyfContours.IsComposite`, matching `loadGlyphOutlineVar`'s existing skip

Both recursion sites hardened consistently: `extractCompositeContours` (glyf_parser.go) and `loadCompositeGlyphOutline` (tt_glyph.go).

## Test plan

- [x] 9 new tests in `composite_hardening_test.go` — both recursion paths
- [x] Simple glyph unchanged, two-component merge, scale, 2×2 rotation, nested transforms
- [x] Self-cycle degrades gracefully (no error, no hang)
- [x] Fan-out budget bounded (<2s for 6^32 adversarial DAG)
- [x] `go test ./text/...` all pass
- [x] `golangci-lint run ./text/...` — 0 issues
- [x] Enterprise review: verified against skrifa + FreeType patterns
