### PR TITLE
chore: update examples to gogpu v0.45.0

### DIFF
--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 	github.com/gogpu/gpucontext v0.21.1
 )
 

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 )
 
 require (

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/compositing/go.mod
+++ b/examples/compositing/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 	github.com/gogpu/gpucontext v0.21.1
 )
 

--- a/examples/compositing/go.sum
+++ b/examples/compositing/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 	github.com/gogpu/gpucontext v0.21.1
 )
 

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 	github.com/gogpu/gpucontext v0.21.1
 )
 

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 )
 
 require (

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/multi_damage_demo/go.mod
+++ b/examples/multi_damage_demo/go.mod
@@ -6,7 +6,7 @@ replace github.com/gogpu/gg => ../..
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 	github.com/gogpu/gpucontext v0.21.1
 )
 

--- a/examples/multi_damage_demo/go.sum
+++ b/examples/multi_damage_demo/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.2 h1:xuMaUbqsNQ/xiyy5UwAKZb5vQZUDg9QRCrJIpHJaXSE
 github.com/go-webgpu/goffi v0.6.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V4=
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 )
 
 require (

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/software_overlay/go.mod
+++ b/examples/software_overlay/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 	github.com/gogpu/gpucontext v0.21.1
 )
 

--- a/examples/software_overlay/go.sum
+++ b/examples/software_overlay/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 )
 
 require (

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 )
 
 require (

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=


### PR DESCRIPTION
Update all example modules to gogpu v0.45.0.