### PR TITLE
fix: FlushGPUWithView preserveContent for external renderers (#449)

### DIFF
--- a/accelerator.go
+++ b/accelerator.go
@@ -66,6 +66,12 @@ type GPURenderTarget struct {
 	ViewWidth  uint32
 	ViewHeight uint32
 
+	// PreserveContent signals that the surface view already has content
+	// from an external renderer (e.g., g3d). When true, the render session
+	// uses LoadOp::Load instead of LoadOp::Clear to preserve existing content.
+	// Set by gogpu after MarkExternalContent(). ADR-059.
+	PreserveContent bool
+
 	// Damage-aware compositing (ADR-026/028): when non-empty, compositor
 	// uses LoadOpLoad (preserve previous frame) and per-rect scissor.
 	// Single rect: one scissor for entire pass.

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -905,6 +905,7 @@ func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cy
 
 	// Transfer per-context frame tracking to session before rendering.
 	rc.session.SetFrameState(rc.frameRendered, rc.lastView)
+	rc.session.preserveContent = target.PreserveContent // ADR-059
 
 	// Extract baseLayer from pendingDraws before building ScissorGroups.
 	// BaseLayer is passed as a separate parameter to RenderFrameGrouped

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -251,6 +251,10 @@ type GPURenderSession struct {
 	// Porter-Duff "over" during readback, so LoadOpClear is always safe.
 	frameRendered bool
 
+	// preserveContent signals that the surface has external content (e.g., g3d).
+	// When true, view changes do NOT reset frameRendered → LoadOp::Load. ADR-059.
+	preserveContent bool
+
 	// antiAlias determines SDF coverage computation mode.
 	// When true (default), smoothstep produces smooth edges.
 	// When false, binary step produces aliased edges.
@@ -2660,8 +2664,17 @@ func (s *GPURenderSession) encodeSubmitSurface(
 	// (e.g., two gg.Context instances rendering to different targets),
 	// reset frameRendered so the new view gets LoadOpClear on its first
 	// pass. This prevents shapes from one Context leaking into another.
+	//
+	// ADR-059: PreserveContent skips the reset — the view already has
+	// content from an external renderer (e.g., g3d). LoadOp::Load
+	// preserves it. Enterprise pattern: Qt beginExternal/endExternal,
+	// Flutter InlinePassContext pass_count, Unity Camera.DontClear.
 	if view != s.lastView {
-		s.frameRendered = false
+		if !s.preserveContent {
+			s.frameRendered = false
+		} else {
+			s.frameRendered = true
+		}
 		s.lastView = view
 	}
 

--- a/preserve_content_test.go
+++ b/preserve_content_test.go
@@ -1,0 +1,39 @@
+package gg
+
+import (
+	"testing"
+)
+
+// TestPreserveContent_DefaultFalse verifies zero value is false (backward compat).
+func TestPreserveContent_DefaultFalse(t *testing.T) {
+	var target GPURenderTarget
+	if target.PreserveContent {
+		t.Error("PreserveContent should default to false")
+	}
+}
+
+// TestPreserveContent_SetTrue verifies the flag can be set.
+func TestPreserveContent_SetTrue(t *testing.T) {
+	target := GPURenderTarget{PreserveContent: true}
+	if !target.PreserveContent {
+		t.Error("PreserveContent should be true when set")
+	}
+}
+
+// TestPreserveContent_DoesNotAffectExistingFields verifies no struct layout breakage.
+func TestPreserveContent_DoesNotAffectExistingFields(t *testing.T) {
+	target := GPURenderTarget{
+		ViewWidth:       800,
+		ViewHeight:      600,
+		PreserveContent: true,
+		Width:           800,
+		Height:          600,
+		Stride:          3200,
+	}
+	if target.ViewWidth != 800 || target.ViewHeight != 600 {
+		t.Error("PreserveContent field broke existing fields")
+	}
+	if target.Width != 800 || target.Height != 600 || target.Stride != 3200 {
+		t.Error("PreserveContent field broke readback fields")
+	}
+}


### PR DESCRIPTION
Fixes #449. Added `PreserveContent bool` to GPURenderTarget. When true, render session uses LoadOp::Load instead of Clear. Zero overhead for existing gg-only usage (default false). ADR-059.