### PR TITLE
fix(ggcanvas): forward external content preservation

### DIFF
--- a/context.go
+++ b/context.go
@@ -1422,12 +1422,24 @@ func (c *Context) FlushGPU() error {
 // This is the per-pass render target path for ggcanvas.RenderDirect.
 // When view is nil/zero, behaves identically to FlushGPU (CPU readback).
 func (c *Context) FlushGPUWithView(view gpucontext.TextureView, width, height uint32) error {
+	return c.flushGPUWithView(view, width, height, false)
+}
+
+// FlushGPUWithViewPreserveContent is like FlushGPUWithView, but loads the
+// existing view contents instead of clearing them on the first render pass.
+// Use this when another renderer has already drawn to the view in this frame.
+func (c *Context) FlushGPUWithViewPreserveContent(view gpucontext.TextureView, width, height uint32) error {
+	return c.flushGPUWithView(view, width, height, true)
+}
+
+func (c *Context) flushGPUWithView(view gpucontext.TextureView, width, height uint32, preserveContent bool) error {
 	t := c.gpuRenderTarget()
 	if !view.IsNil() {
 		t.View = view
 		t.ViewWidth = width
 		t.ViewHeight = height
 	}
+	t.PreserveContent = preserveContent
 	rc := c.gpuCtxOps()
 	if rc != nil {
 		return rc.Flush(t)

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -564,6 +564,10 @@ func (c *Canvas) FlushPixmap() (any, error) {
 //	    canvas.RenderDirect(dc.RenderTarget().SurfaceView(), w, h)
 //	})
 func (c *Canvas) RenderDirect(surfaceView gpucontext.TextureView, width, height uint32) error {
+	return c.renderDirect(surfaceView, width, height, false)
+}
+
+func (c *Canvas) renderDirect(surfaceView gpucontext.TextureView, width, height uint32, preserveContent bool) error {
 	if c.closed {
 		return ErrCanvasClosed
 	}
@@ -590,7 +594,12 @@ func (c *Canvas) RenderDirect(surfaceView gpucontext.TextureView, width, height 
 	// GPU commands with LoadOpClear. Calling BeginFrame here would reset
 	// frameRendered=false, causing the final FlushGPU to wipe that content
 	// with a second LoadOpClear. See RENDER-DIRECT-003.
-	err := c.ctx.FlushGPUWithView(surfaceView, width, height)
+	var err error
+	if preserveContent {
+		err = c.ctx.FlushGPUWithViewPreserveContent(surfaceView, width, height)
+	} else {
+		err = c.ctx.FlushGPUWithView(surfaceView, width, height)
+	}
 
 	c.dirty = false
 	c.dirtyRect = image.Rectangle{}
@@ -648,6 +657,13 @@ type RenderTarget interface {
 	SurfaceView() gpucontext.TextureView
 	SurfaceSize() (uint32, uint32)
 	PresentTexture(tex any) error
+}
+
+// ContentPreserver is an optional RenderTarget capability that reports whether
+// the surface already contains content from an earlier render pass. When true,
+// ggcanvas loads that content before drawing instead of clearing the surface.
+type ContentPreserver interface {
+	PreserveContent() bool
 }
 
 // DamageRectSetter is an optional interface for RenderTargets that support
@@ -710,7 +726,11 @@ func (c *Canvas) Render(dc RenderTarget) error {
 	sv := dc.SurfaceView()
 	if !sv.IsNil() && gg.AcceleratorCanRenderDirect() {
 		sw, sh := dc.SurfaceSize()
-		if err := c.RenderDirect(sv, sw, sh); err == nil {
+		preserveContent := false
+		if preserver, ok := dc.(ContentPreserver); ok {
+			preserveContent = preserver.PreserveContent()
+		}
+		if err := c.renderDirect(sv, sw, sh, preserveContent); err == nil {
 			c.forwardDamageRects(dc, damageRects)
 			return nil
 		}

--- a/integration/ggcanvas/canvas_render_test.go
+++ b/integration/ggcanvas/canvas_render_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"image"
 	"testing"
+	"unsafe"
 
+	"github.com/gogpu/gg"
 	"github.com/gogpu/gpucontext"
 )
 
@@ -63,6 +65,43 @@ func (m *renderMockWithCreator) TextureCreator() gpucontext.TextureCreator {
 	return m.renderer
 }
 
+type renderMockContentPreserver struct {
+	mockRenderTarget
+	preserveContent bool
+}
+
+func (m *renderMockContentPreserver) PreserveContent() bool { return m.preserveContent }
+
+type renderTargetCaptureAccelerator struct {
+	lastTarget gg.GPURenderTarget
+	flushes    int
+}
+
+func (a *renderTargetCaptureAccelerator) Name() string { return "render-target-capture" }
+func (a *renderTargetCaptureAccelerator) Init() error  { return nil }
+func (a *renderTargetCaptureAccelerator) Close()       {}
+func (a *renderTargetCaptureAccelerator) CanAccelerate(gg.AcceleratedOp) bool {
+	return false
+}
+func (a *renderTargetCaptureAccelerator) FillPath(gg.GPURenderTarget, *gg.Path, *gg.Paint) error {
+	return gg.ErrFallbackToCPU
+}
+func (a *renderTargetCaptureAccelerator) StrokePath(gg.GPURenderTarget, *gg.Path, *gg.Paint) error {
+	return gg.ErrFallbackToCPU
+}
+func (a *renderTargetCaptureAccelerator) FillShape(gg.GPURenderTarget, gg.DetectedShape, *gg.Paint) error {
+	return gg.ErrFallbackToCPU
+}
+func (a *renderTargetCaptureAccelerator) StrokeShape(gg.GPURenderTarget, gg.DetectedShape, *gg.Paint) error {
+	return gg.ErrFallbackToCPU
+}
+func (a *renderTargetCaptureAccelerator) Flush(target gg.GPURenderTarget) error {
+	a.lastTarget = target
+	a.flushes++
+	return nil
+}
+func (a *renderTargetCaptureAccelerator) CanRenderDirect() bool { return true }
+
 // TestRender_NotDirty_Noop verifies that Render returns nil without presenting
 // when the canvas is not dirty.
 func TestRender_NotDirty_Noop(t *testing.T) {
@@ -99,6 +138,65 @@ func TestRender_Closed_ReturnsError(t *testing.T) {
 	err = c.Render(dc)
 	if !errors.Is(err, ErrCanvasClosed) {
 		t.Errorf("Render on closed canvas: err = %v, want ErrCanvasClosed", err)
+	}
+}
+
+func TestRender_PreserveContentForwardedToGPU(t *testing.T) {
+	gg.CloseAccelerator()
+	accelerator := &renderTargetCaptureAccelerator{}
+	if err := gg.RegisterAccelerator(accelerator); err != nil {
+		t.Fatalf("RegisterAccelerator: %v", err)
+	}
+	t.Cleanup(gg.CloseAccelerator)
+
+	view := gpucontext.NewTextureView(unsafe.Pointer(new(int))) //nolint:gosec // non-nil opaque handle for routing test
+	defaultTarget := &mockRenderTarget{surfaceView: view, surfaceW: 10, surfaceH: 10}
+	preservingTarget := &renderMockContentPreserver{
+		mockRenderTarget: *defaultTarget,
+		preserveContent:  true,
+	}
+
+	tests := []struct {
+		name             string
+		render           func(*Canvas) error
+		wantPreservation bool
+	}{
+		{
+			name:   "RenderDirect defaults to clear",
+			render: func(c *Canvas) error { return c.RenderDirect(view, 10, 10) },
+		},
+		{
+			name:   "RenderTarget without capability defaults to clear",
+			render: func(c *Canvas) error { return c.Render(defaultTarget) },
+		},
+		{
+			name:             "RenderTarget forwards preservation",
+			render:           func(c *Canvas) error { return c.Render(preservingTarget) },
+			wantPreservation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accelerator.lastTarget = gg.GPURenderTarget{}
+			accelerator.flushes = 0
+
+			canvas, err := New(newMockProvider(), 10, 10)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			defer canvas.Close()
+
+			if err := tt.render(canvas); err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			if accelerator.flushes != 1 {
+				t.Fatalf("accelerator Flush calls = %d, want 1", accelerator.flushes)
+			}
+			if got := accelerator.lastTarget.PreserveContent; got != tt.wantPreservation {
+				t.Errorf("GPURenderTarget.PreserveContent = %v, want %v", got, tt.wantPreservation)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Complete gg's side of the external-content preservation bridge added in #450.

- add `Context.FlushGPUWithViewPreserveContent` while preserving the existing `FlushGPUWithView` contract
- let `ggcanvas.Canvas.Render` detect the optional `ContentPreserver` capability
- forward that state to `GPURenderTarget.PreserveContent`
- keep existing `RenderTarget` implementations source-compatible

This is the gg-side fix required by [gogpu/gogpu#390](https://github.com/gogpu/gogpu/issues/390). [gogpu/gogpu#391](https://github.com/gogpu/gogpu/pull/391) exposes `ContextRenderTarget.PreserveContent()` from the active surface's `frameCleared` state.

## Testing

- `CGO_ENABLED=0 go test -count=1 ./integration/ggcanvas -run '^TestRender_PreserveContentForwardedToGPU$'`
- `go test -race -tags nogpu -count=1 ./integration/ggcanvas -run '^TestRender_PreserveContentForwardedToGPU$'`
- `CGO_ENABLED=0 go test -count=1 . -run '^(TestPreserveContent|TestContext)'`
- all packages except `github.com/gogpu/gg/internal/gpu`
- `golangci-lint v2.12.2 run --new-from-rev=upstream/main` (0 new issues)
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go build ./examples/...`

The full test suite still hits the three pre-existing Metal stencil/MSAA failures in `internal/gpu` on the software backend; the same failures reproduce unchanged on the then-current `upstream/main`. Full lint likewise reports three existing `importShadow` findings in `internal/gpu/stencil_metal_repro_test.go`; linting only this PR's diff reports zero issues.
