### PR TITLE
fix(gpu): use preserved surface as compositor base

### DIFF
--- a/accelerator.go
+++ b/accelerator.go
@@ -66,9 +66,10 @@ type GPURenderTarget struct {
 	ViewWidth  uint32
 	ViewHeight uint32
 
-	// PreserveContent signals that the surface view already has content
-	// from an external renderer (e.g., g3d). When true, the render session
-	// uses LoadOp::Load instead of LoadOp::Clear to preserve existing content.
+	// PreserveContent signals that the surface view already has content from an
+	// external renderer (e.g., g3d). When true, that content becomes the
+	// compositor base: the render session uses LoadOp::Load and ignores a queued
+	// DrawGPUTextureBase layer. Regular texture overlays still render normally.
 	// Set by gogpu after MarkExternalContent(). ADR-059.
 	PreserveContent bool
 

--- a/context.go
+++ b/context.go
@@ -1425,9 +1425,10 @@ func (c *Context) FlushGPUWithView(view gpucontext.TextureView, width, height ui
 	return c.flushGPUWithView(view, width, height, false)
 }
 
-// FlushGPUWithViewPreserveContent is like FlushGPUWithView, but loads the
-// existing view contents instead of clearing them on the first render pass.
-// Use this when another renderer has already drawn to the view in this frame.
+// FlushGPUWithViewPreserveContent is like FlushGPUWithView, but treats the
+// existing view contents as the compositor base instead of clearing or covering
+// them with a queued DrawGPUTextureBase layer. Use this when another renderer
+// has already drawn to the view in this frame.
 func (c *Context) FlushGPUWithViewPreserveContent(view gpucontext.TextureView, width, height uint32) error {
 	return c.flushGPUWithView(view, width, height, true)
 }

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -661,7 +661,8 @@ type RenderTarget interface {
 
 // ContentPreserver is an optional RenderTarget capability that reports whether
 // the surface already contains content from an earlier render pass. When true,
-// ggcanvas loads that content before drawing instead of clearing the surface.
+// ggcanvas uses that content as the compositor base instead of clearing or
+// covering it with the canvas base layer.
 type ContentPreserver interface {
 	PreserveContent() bool
 }

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -846,6 +846,23 @@ func (rc *GPURenderContext) StrokeShape(target gg.GPURenderTarget, shape gg.Dete
 	return nil
 }
 
+// selectBaseLayer returns the queued compositor base unless the destination
+// surface already supplies it. With PreserveContent, external rendering is the
+// base layer; drawing the full-surface pixmap base would hide that content.
+// Callers that need another texture above external content use DrawGPUTexture.
+func selectBaseLayer(draws []drawCommand, preserveContent bool) *GPUTextureDrawCommand {
+	if preserveContent {
+		return nil
+	}
+	for i := range draws {
+		if draws[i].kind == drawCmdBaseLayer {
+			baseLayer := draws[i].gpuTexCmd.(GPUTextureDrawCommand)
+			return &baseLayer
+		}
+	}
+	return nil
+}
+
 // Flush dispatches all pending commands for this context via the render session.
 func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cyclop,gocognit,gocyclo,funlen // sequential resource setup + group dispatch
 	// Dispatch backend-agnostic draw commands (ADR-051).
@@ -907,17 +924,10 @@ func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cy
 	rc.session.SetFrameState(rc.frameRendered, rc.lastView)
 	rc.session.preserveContent = target.PreserveContent // ADR-059
 
-	// Extract baseLayer from pendingDraws before building ScissorGroups.
-	// BaseLayer is passed as a separate parameter to RenderFrameGrouped
-	// (renders BEFORE all tiers) — not part of ScissorGroups.
-	var baseLayer *GPUTextureDrawCommand
-	for i := range rc.pendingDraws {
-		if rc.pendingDraws[i].kind == drawCmdBaseLayer {
-			bl := rc.pendingDraws[i].gpuTexCmd.(GPUTextureDrawCommand)
-			baseLayer = &bl
-			break
-		}
-	}
+	// The queued base layer renders before every other tier. PreserveContent
+	// makes the existing surface content the base instead, so selecting the
+	// pixmap layer here would immediately cover the external renderer's output.
+	baseLayer := selectBaseLayer(rc.pendingDraws, target.PreserveContent)
 
 	// Build ScissorGroups from per-draw clip state. All command types flow
 	// through pendingDraws: shapes, paths, text, images, GPU textures.

--- a/internal/gpu/gpu_texture_test.go
+++ b/internal/gpu/gpu_texture_test.go
@@ -192,6 +192,26 @@ func TestQueueBaseLayer_FullScreen(t *testing.T) {
 	assertFloat(t, bl.DstH, 400, "base DstH")
 }
 
+func TestSelectBaseLayer_PreserveContentUsesSurfaceAsBase(t *testing.T) {
+	view := gpucontext.NewTextureView(unsafe.Pointer(new(int)))
+	draws := []drawCommand{{
+		kind: drawCmdBaseLayer,
+		gpuTexCmd: GPUTextureDrawCommand{
+			View: view, DstW: 600, DstH: 400, Opacity: 1,
+		},
+	}}
+
+	if got := selectBaseLayer(draws, false); got == nil {
+		t.Fatal("selectBaseLayer without preservation discarded the queued base layer")
+	}
+	if got := selectBaseLayer(draws, true); got != nil {
+		t.Fatal("selectBaseLayer with preservation must use existing surface content as the base")
+	}
+	if got := selectBaseLayer(nil, false); got != nil {
+		t.Fatal("selectBaseLayer without a queued base layer returned one")
+	}
+}
+
 // collectGPUTextureDraws extracts GPUTextureDrawCommand entries from pendingDraws.
 func collectGPUTextureDraws(rc *GPURenderContext) []GPUTextureDrawCommand {
 	var out []GPUTextureDrawCommand


### PR DESCRIPTION
## Summary

Treat preserved external surface content as gg's compositor base instead of drawing the queued full-surface pixmap base over it.

After #451 correctly forwards `PreserveContent` and the render pass uses `LoadOp::Load`, `drawCmdBaseLayer` can still cover the preserved g3d output with an opaque textured quad. With this change:

- `PreserveContent=false`: the queued `DrawGPUTextureBase` layer remains unchanged
- `PreserveContent=true`: the existing surface content is the base layer, so the queued pixmap base is skipped
- regular `DrawGPUTexture` overlays and all GPU shape/text tiers continue rendering normally

The selection rule is isolated in a small pure helper with regression coverage for the ordinary, preserved, and absent-base cases. Public comments now document the full preservation contract.

This is the second gg-side fix found while validating [gogpu/gogpu#391](https://github.com/gogpu/gogpu/pull/391); #451 supplied the state bridge, while this PR prevents the later compositor overwrite.

## Testing

- `CGO_ENABLED=0 go test -count=1 ./internal/gpu -run '^TestSelectBaseLayer_PreserveContentUsesSurfaceAsBase$'`
- `CGO_ENABLED=0 go test -count=1 ./internal/gpu -skip '^(TestMetalStencilCoverMasksToShape|TestMetalStencilRoundedRectMasking|TestMetalStencilEvenOddMasking)$'`
- all cgo-free packages except the known-failing `github.com/gogpu/gg/internal/gpu` package
- `CGO_ENABLED=0 go test -count=1 ./integration/ggcanvas`
- `go test -race -tags nogpu -count=1 ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go build ./examples/...`
- `CGO_ENABLED=0 go build ./cmd/ggdemo`
- `golangci-lint v2.12.2 run --new-from-rev=upstream/main` (0 new issues)

The unfiltered cgo-free `internal/gpu` tests still hit the three pre-existing Metal stencil/MSAA failures on the software backend; those failures reproduce unchanged on `upstream/main`.

Closes #452
