### PR TITLE
fix(ggcanvas): borrow render target command encoder

### DIFF
--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -612,13 +612,18 @@ func (c *Canvas) renderDirectToTarget(
 	dc RenderTarget,
 	surfaceView gpucontext.TextureView,
 	width, height uint32,
-	preserveContent bool,
 ) error {
-	provider, ok := dc.(CommandEncoderProvider)
-	if !ok {
-		return c.renderDirect(surfaceView, width, height, preserveContent)
+	var encoder gpucontext.CommandEncoder
+	if provider, ok := dc.(CommandEncoderProvider); ok {
+		// Acquiring the encoder may record deferred target work (for example,
+		// gogpu flushes a pending clear), so sample content state afterwards.
+		encoder = provider.CommandEncoder()
 	}
-	encoder := provider.CommandEncoder()
+
+	preserveContent := false
+	if preserver, ok := dc.(ContentPreserver); ok {
+		preserveContent = preserver.PreserveContent()
+	}
 	if encoder.IsNil() {
 		return c.renderDirect(surfaceView, width, height, preserveContent)
 	}
@@ -686,14 +691,17 @@ type RenderTarget interface {
 // ContentPreserver is an optional RenderTarget capability that reports whether
 // the surface already contains content from an earlier render pass. When true,
 // ggcanvas uses that content as the compositor base instead of clearing or
-// covering it with the canvas base layer.
+// covering it with the canvas base layer. Canvas queries this after borrowing
+// any shared command encoder so the result reflects current frame state.
 type ContentPreserver interface {
 	PreserveContent() bool
 }
 
 // CommandEncoderProvider is an optional RenderTarget capability for
-// single-command-buffer compositing. The returned encoder is owned and
-// submitted by the target; Canvas only records its render passes into it.
+// single-command-buffer compositing. The returned encoder is borrowed for the
+// current Render call and remains owned by the target. Canvas only records its
+// render passes; it never finishes, submits, or discards the encoder. A zero
+// value requests the normal independently submitted fallback path.
 type CommandEncoderProvider interface {
 	CommandEncoder() gpucontext.CommandEncoder
 }
@@ -758,11 +766,7 @@ func (c *Canvas) Render(dc RenderTarget) error {
 	sv := dc.SurfaceView()
 	if !sv.IsNil() && gg.AcceleratorCanRenderDirect() {
 		sw, sh := dc.SurfaceSize()
-		preserveContent := false
-		if preserver, ok := dc.(ContentPreserver); ok {
-			preserveContent = preserver.PreserveContent()
-		}
-		if err := c.renderDirectToTarget(dc, sv, sw, sh, preserveContent); err == nil {
+		if err := c.renderDirectToTarget(dc, sv, sw, sh); err == nil {
 			c.forwardDamageRects(dc, damageRects)
 			return nil
 		}

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -667,6 +667,13 @@ type ContentPreserver interface {
 	PreserveContent() bool
 }
 
+// CommandEncoderProvider is an optional RenderTarget capability for
+// single-command-buffer compositing. The returned encoder is owned and
+// submitted by the target; Canvas only records its render passes into it.
+type CommandEncoderProvider interface {
+	CommandEncoder() gpucontext.CommandEncoder
+}
+
 // DamageRectSetter is an optional interface for RenderTargets that support
 // damage-aware presentation (ADR-021 Level 3-4). gogpu.ContextRenderTarget
 // implements this via Context.SetDamageRects().
@@ -731,7 +738,23 @@ func (c *Canvas) Render(dc RenderTarget) error {
 		if preserver, ok := dc.(ContentPreserver); ok {
 			preserveContent = preserver.PreserveContent()
 		}
-		if err := c.renderDirect(sv, sw, sh, preserveContent); err == nil {
+		encoder := gpucontext.CommandEncoder{}
+		if provider, ok := dc.(CommandEncoderProvider); ok {
+			encoder = provider.CommandEncoder()
+			if !encoder.IsNil() {
+				c.ctx.SetSharedEncoder(encoder)
+			}
+		}
+		err := func() error {
+			if encoder.IsNil() {
+				return c.renderDirect(sv, sw, sh, preserveContent)
+			}
+			// The target owns submission. Always clear the borrowed encoder before
+			// a fallback path can flush to a different destination.
+			defer c.ctx.SetSharedEncoder(gpucontext.CommandEncoder{})
+			return c.renderDirect(sv, sw, sh, preserveContent)
+		}()
+		if err == nil {
 			c.forwardDamageRects(dc, damageRects)
 			return nil
 		}

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -606,6 +606,30 @@ func (c *Canvas) renderDirect(surfaceView gpucontext.TextureView, width, height 
 	return err
 }
 
+// renderDirectToTarget borrows the target's encoder when available. The target
+// keeps ownership of finishing and submission; gg only records its pass.
+func (c *Canvas) renderDirectToTarget(
+	dc RenderTarget,
+	surfaceView gpucontext.TextureView,
+	width, height uint32,
+	preserveContent bool,
+) error {
+	provider, ok := dc.(CommandEncoderProvider)
+	if !ok {
+		return c.renderDirect(surfaceView, width, height, preserveContent)
+	}
+	encoder := provider.CommandEncoder()
+	if encoder.IsNil() {
+		return c.renderDirect(surfaceView, width, height, preserveContent)
+	}
+
+	c.ctx.SetSharedEncoder(encoder)
+	// The target owns submission. Always clear the borrowed encoder before a
+	// fallback path can flush to a different destination.
+	defer c.ctx.SetSharedEncoder(gpucontext.CommandEncoder{})
+	return c.renderDirect(surfaceView, width, height, preserveContent)
+}
+
 // RenderDirectWithDamage renders canvas content to a surface view with a damage
 // rect hint. Only the damaged region is re-rendered; the rest preserves the
 // previous frame (LoadOpLoad + scissor). This enables per-boundary incremental
@@ -738,23 +762,7 @@ func (c *Canvas) Render(dc RenderTarget) error {
 		if preserver, ok := dc.(ContentPreserver); ok {
 			preserveContent = preserver.PreserveContent()
 		}
-		encoder := gpucontext.CommandEncoder{}
-		if provider, ok := dc.(CommandEncoderProvider); ok {
-			encoder = provider.CommandEncoder()
-			if !encoder.IsNil() {
-				c.ctx.SetSharedEncoder(encoder)
-			}
-		}
-		err := func() error {
-			if encoder.IsNil() {
-				return c.renderDirect(sv, sw, sh, preserveContent)
-			}
-			// The target owns submission. Always clear the borrowed encoder before
-			// a fallback path can flush to a different destination.
-			defer c.ctx.SetSharedEncoder(gpucontext.CommandEncoder{})
-			return c.renderDirect(sv, sw, sh, preserveContent)
-		}()
-		if err == nil {
+		if err := c.renderDirectToTarget(dc, sv, sw, sh, preserveContent); err == nil {
 			c.forwardDamageRects(dc, damageRects)
 			return nil
 		}

--- a/integration/ggcanvas/canvas_render_test.go
+++ b/integration/ggcanvas/canvas_render_test.go
@@ -83,6 +83,28 @@ func (m *renderMockCommandEncoderProvider) CommandEncoder() gpucontext.CommandEn
 	return m.encoder
 }
 
+// renderMockFrameTarget models a target where borrowing the frame encoder
+// records deferred work and changes whether the next pass must preserve the
+// surface. gogpu.ContextRenderTarget has this behavior when CommandEncoder
+// flushes a deferred clear.
+type renderMockFrameTarget struct {
+	mockRenderTarget
+	encoder         gpucontext.CommandEncoder
+	preserveContent bool
+	calls           []string
+}
+
+func (m *renderMockFrameTarget) CommandEncoder() gpucontext.CommandEncoder {
+	m.calls = append(m.calls, "encoder")
+	m.preserveContent = true
+	return m.encoder
+}
+
+func (m *renderMockFrameTarget) PreserveContent() bool {
+	m.calls = append(m.calls, "preserve")
+	return m.preserveContent
+}
+
 type renderTargetCaptureAccelerator struct {
 	lastTarget gg.GPURenderTarget
 	flushes    int
@@ -239,6 +261,37 @@ func TestRender_BorrowsCommandEncoderFromTarget(t *testing.T) {
 	}
 	if accelerator.flushes != 1 {
 		t.Fatalf("accelerator Flush calls = %d, want 1", accelerator.flushes)
+	}
+}
+
+func TestRender_SamplesContentAfterBorrowingEncoder(t *testing.T) {
+	gg.CloseAccelerator()
+	accelerator := &renderTargetCaptureAccelerator{}
+	if err := gg.RegisterAccelerator(accelerator); err != nil {
+		t.Fatalf("RegisterAccelerator: %v", err)
+	}
+	t.Cleanup(gg.CloseAccelerator)
+
+	view := gpucontext.NewTextureView(unsafe.Pointer(new(int)))       //nolint:gosec // non-nil opaque handle for routing test
+	encoder := gpucontext.NewCommandEncoder(unsafe.Pointer(new(int))) //nolint:gosec // non-nil opaque handle for routing test
+	target := &renderMockFrameTarget{
+		mockRenderTarget: mockRenderTarget{surfaceView: view, surfaceW: 10, surfaceH: 10},
+		encoder:          encoder,
+	}
+	canvas, err := New(newMockProvider(), 10, 10)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer canvas.Close()
+
+	if err := canvas.Render(target); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(target.calls) != 2 || target.calls[0] != "encoder" || target.calls[1] != "preserve" {
+		t.Fatalf("capability call order = %v, want [encoder preserve]", target.calls)
+	}
+	if !accelerator.lastTarget.PreserveContent {
+		t.Error("GPURenderTarget.PreserveContent = false after encoder acquisition, want true")
 	}
 }
 

--- a/integration/ggcanvas/canvas_render_test.go
+++ b/integration/ggcanvas/canvas_render_test.go
@@ -72,6 +72,17 @@ type renderMockContentPreserver struct {
 
 func (m *renderMockContentPreserver) PreserveContent() bool { return m.preserveContent }
 
+type renderMockCommandEncoderProvider struct {
+	mockRenderTarget
+	encoder      gpucontext.CommandEncoder
+	encoderCalls int
+}
+
+func (m *renderMockCommandEncoderProvider) CommandEncoder() gpucontext.CommandEncoder {
+	m.encoderCalls++
+	return m.encoder
+}
+
 type renderTargetCaptureAccelerator struct {
 	lastTarget gg.GPURenderTarget
 	flushes    int
@@ -197,6 +208,37 @@ func TestRender_PreserveContentForwardedToGPU(t *testing.T) {
 				t.Errorf("GPURenderTarget.PreserveContent = %v, want %v", got, tt.wantPreservation)
 			}
 		})
+	}
+}
+
+func TestRender_BorrowsCommandEncoderFromTarget(t *testing.T) {
+	gg.CloseAccelerator()
+	accelerator := &renderTargetCaptureAccelerator{}
+	if err := gg.RegisterAccelerator(accelerator); err != nil {
+		t.Fatalf("RegisterAccelerator: %v", err)
+	}
+	t.Cleanup(gg.CloseAccelerator)
+
+	view := gpucontext.NewTextureView(unsafe.Pointer(new(int)))       //nolint:gosec // non-nil opaque handle for routing test
+	encoder := gpucontext.NewCommandEncoder(unsafe.Pointer(new(int))) //nolint:gosec // non-nil opaque handle for routing test
+	target := &renderMockCommandEncoderProvider{
+		mockRenderTarget: mockRenderTarget{surfaceView: view, surfaceW: 10, surfaceH: 10},
+		encoder:          encoder,
+	}
+	canvas, err := New(newMockProvider(), 10, 10)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer canvas.Close()
+
+	if err := canvas.Render(target); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if target.encoderCalls != 1 {
+		t.Fatalf("CommandEncoder calls = %d, want 1", target.encoderCalls)
+	}
+	if accelerator.flushes != 1 {
+		t.Fatalf("accelerator Flush calls = %d, want 1", accelerator.flushes)
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes the gg side of [gogpu/gogpu#393](https://github.com/gogpu/gogpu/issues/393): `ggcanvas.Canvas.Render` now detects an optional frame-owned command encoder on its render target and records the overlay into that borrowed encoder.

This uses gg's existing `Context.SetSharedEncoder` support; it adds no gogpu dependency and keeps the render-target boundary opaque through `gpucontext.CommandEncoder`.

## Changes

- adds the optional `CommandEncoderProvider` render-target capability
- borrows the target encoder only for the GPU-direct flush
- always clears the borrowed encoder from the gg context before any fallback path
- preserves the existing path for targets without the capability
- adds routing coverage for encoder-capable targets

Paired gogpu owner PR: [gogpu/gogpu#394](https://github.com/gogpu/gogpu/pull/394). The API is optional, so this PR is independently mergeable; gogpu#394 activates it automatically through `ContextRenderTarget`.

## Testing

- `CGO_ENABLED=0 go test -count=1 ./integration/ggcanvas`
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go test -race -count=1 ./integration/ggcanvas`
- local compile-only integration module with gogpu#394 and g3d `RenderTo`

Refs [gogpu/gogpu#393](https://github.com/gogpu/gogpu/issues/393)
