### PR TITLE
fix(gpu): preserve external content with MSAA

### DIFF
--- a/accelerator.go
+++ b/accelerator.go
@@ -59,7 +59,7 @@ const (
 // The Data slice (when used) must be in premultiplied RGBA format, 4 bytes
 // per pixel, laid out row by row with the given Stride.
 type GPURenderTarget struct {
-	// GPU-direct path: resolve directly to this view.
+	// GPU-direct path: render to this view without CPU readback.
 	// When non-nil, Data/Stride are ignored -- no CPU readback.
 	// Type-assert to *wgpu.TextureView in internal/gpu consumers.
 	View       gpucontext.TextureView
@@ -68,8 +68,9 @@ type GPURenderTarget struct {
 
 	// PreserveContent signals that the surface view already has content from an
 	// external renderer (e.g., g3d). When true, that content becomes the
-	// compositor base: the render session uses LoadOp::Load and ignores a queued
-	// DrawGPUTextureBase layer. Regular texture overlays still render normally.
+	// compositor base and a queued DrawGPUTextureBase layer is ignored. A
+	// single-sample pass loads the surface directly; an MSAA pass renders a
+	// transparent overlay and alpha-composites its resolve onto the surface.
 	// Set by gogpu after MarkExternalContent(). ADR-059.
 	PreserveContent bool
 
@@ -163,8 +164,8 @@ type GPURenderContextProvider interface {
 
 // FrameAware is an optional interface for accelerators that need per-frame
 // lifecycle management. BeginFrame resets per-frame state so that the first
-// render pass of each frame clears the surface (LoadOpClear), while
-// subsequent mid-frame flushes preserve content (LoadOpLoad).
+// render pass of each frame replaces the surface, while subsequent mid-frame
+// flushes preserve its content.
 //
 // Without calling BeginFrame, the surface is only cleared on the very first
 // frame and all subsequent frames composite on top of previous content,

--- a/context.go
+++ b/context.go
@@ -1389,9 +1389,9 @@ func (c *Context) SubmitSharedEncoder(encoder gpucontext.CommandEncoder) error {
 }
 
 // BeginGPUFrame resets per-context GPU frame state so the next render pass
-// uses LoadOpClear. Call this on persistent contexts before re-rendering
-// to the same view — without it, frameRendered=true from the previous frame
-// causes LoadOpLoad, preserving stale content.
+// replaces the surface. Call this on persistent contexts before re-rendering
+// to the same view — without it, the previous frame is treated as content that
+// must be preserved.
 //
 // Not needed for one-shot contexts (NewContext + Close per frame).
 // Not needed when the view changes between frames (auto-reset on view change).

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -416,9 +416,9 @@ func (c *Canvas) MarkDirtyRegion(r image.Rectangle) {
 // the dirty flag is set correctly for GPU upload on next Flush/RenderTo.
 //
 // BeginAcceleratorFrame is called before fn to reset per-frame GPU state.
-// This ensures the first render pass clears the surface while mid-frame
-// CPU fallback flushes (bitmap text, gradient fill) use LoadOpLoad to
-// preserve previously drawn content. See RENDER-DIRECT-003.
+// This ensures the first render pass replaces the surface while mid-frame
+// CPU fallback flushes (bitmap text, gradient fill) preserve previously drawn
+// content. See RENDER-DIRECT-003.
 //
 // Per-frame state (matrix, path, clip, mask) is automatically reset via
 // Push/Pop wrapper (Skia SkAutoCanvasRestore pattern, ADR-032). Configuration

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -145,9 +145,9 @@ type GPURenderContext struct {
 	clipRRect *ClipParams
 	clipPath  *gg.Path // arbitrary clip path for depth clipping (GPU-CLIP-003a)
 
-	// Per-context frame tracking (fixes LoadOp corruption).
-	// When frameRendered is true, subsequent render passes use LoadOpLoad.
-	// Reset by BeginFrame() at the start of each frame.
+	// Per-context frame tracking (fixes surface preservation corruption).
+	// When frameRendered is true, subsequent render passes preserve the current
+	// view. Reset by BeginFrame() at the start of each frame.
 	frameRendered bool
 	lastView      *wgpu.TextureView
 
@@ -922,7 +922,6 @@ func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cy
 
 	// Transfer per-context frame tracking to session before rendering.
 	rc.session.SetFrameState(rc.frameRendered, rc.lastView)
-	rc.session.preserveContent = target.PreserveContent // ADR-059
 
 	// The queued base layer renders before every other tier. PreserveContent
 	// makes the existing surface content the base instead, so selecting the

--- a/internal/gpu/gpu_textures.go
+++ b/internal/gpu/gpu_textures.go
@@ -9,23 +9,26 @@ import (
 	"github.com/gogpu/wgpu"
 )
 
-// textureSet holds a set of MSAA color, depth/stencil, and resolve textures
-// for offscreen rendering. This is shared by GPURenderSession and
-// StencilRenderer to avoid code duplication.
+// textureSet holds a set of MSAA color, depth/stencil, resolve, and composition
+// textures. This is shared by GPURenderSession and StencilRenderer to avoid
+// code duplication.
 //
 // The texture set supports stencil-then-cover and SDF rendering:
 //   - MSAA color: 4x samples, BGRA8Unorm, RenderAttachment
 //   - Depth/stencil: 4x samples, Depth24PlusStencil8, RenderAttachment
 //   - Resolve: 1x sample, BGRA8Unorm, RenderAttachment | CopySrc
+//   - Composition: 1x sample, BGRA8Unorm, RenderAttachment | TextureBinding
 type textureSet struct {
-	msaaTex     *wgpu.Texture
-	msaaView    *wgpu.TextureView
-	stencilTex  *wgpu.Texture
-	stencilView *wgpu.TextureView
-	resolveTex  *wgpu.Texture
-	resolveView *wgpu.TextureView
-	width       uint32
-	height      uint32
+	msaaTex       *wgpu.Texture
+	msaaView      *wgpu.TextureView
+	stencilTex    *wgpu.Texture
+	stencilView   *wgpu.TextureView
+	resolveTex    *wgpu.Texture
+	resolveView   *wgpu.TextureView
+	compositeTex  *wgpu.Texture
+	compositeView *wgpu.TextureView
+	width         uint32
+	height        uint32
 }
 
 // ensureTextures creates or recreates textures if the requested dimensions
@@ -232,8 +235,66 @@ func (ts *textureSet) ensureSurfaceTextures(device *wgpu.Device, w, h uint32, la
 	return nil
 }
 
+// ensureCompositeTexture lazily creates the single-sample texture used to
+// composite an MSAA-rendered transparent overlay onto an existing surface.
+// The surface textures must already be sized for w x h.
+func (ts *textureSet) ensureCompositeTexture(device *wgpu.Device, w, h uint32, labelPrefix string) error {
+	if ts.compositeTex != nil && ts.compositeView != nil && ts.width == w && ts.height == h {
+		return nil
+	}
+	if ts.msaaTex == nil || ts.width != w || ts.height != h {
+		return fmt.Errorf("composite texture requires matching surface textures")
+	}
+
+	if ts.compositeView != nil {
+		ts.compositeView.Release()
+		ts.compositeView = nil
+	}
+	if ts.compositeTex != nil {
+		ts.compositeTex.Release()
+		ts.compositeTex = nil
+	}
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         labelPrefix + "_composite_resolve",
+		Size:          wgpu.Extent3D{Width: w, Height: h, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     gputypes.TextureDimension2D,
+		Format:        gputypes.TextureFormatBGRA8Unorm,
+		Usage:         gputypes.TextureUsageRenderAttachment | gputypes.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		return fmt.Errorf("create composition resolve texture: %w", err)
+	}
+	ts.compositeTex = tex
+
+	view, err := device.CreateTextureView(tex, &wgpu.TextureViewDescriptor{
+		Label:         labelPrefix + "_composite_resolve_view",
+		Format:        gputypes.TextureFormatBGRA8Unorm,
+		Dimension:     gputypes.TextureViewDimension2D,
+		Aspect:        gputypes.TextureAspectAll,
+		MipLevelCount: 1,
+	})
+	if err != nil {
+		ts.compositeTex.Release()
+		ts.compositeTex = nil
+		return fmt.Errorf("create composition resolve view: %w", err)
+	}
+	ts.compositeView = view
+	return nil
+}
+
 // destroyTextures releases all texture resources and resets dimensions.
 func (ts *textureSet) destroyTextures() {
+	if ts.compositeView != nil {
+		ts.compositeView.Release()
+		ts.compositeView = nil
+	}
+	if ts.compositeTex != nil {
+		ts.compositeTex.Release()
+		ts.compositeTex = nil
+	}
 	if ts.resolveView != nil {
 		ts.resolveView.Release()
 		ts.resolveView = nil

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -213,6 +213,14 @@ type GPURenderSession struct {
 	gpuTexUniformBufs    []*wgpu.Buffer
 	gpuTexBindGroups     []*wgpu.BindGroup
 
+	// Full-surface textured quad used by the MSAA overlay composition path.
+	// These resources are separate from ordinary GPU texture draws so preparing
+	// the final composite cannot overwrite another draw's persistent buffers.
+	surfaceCompositeVertBuf    *wgpu.Buffer
+	surfaceCompositeUniformBuf *wgpu.Buffer
+	surfaceCompositeBindGroup  *wgpu.BindGroup
+	surfaceCompositeBoundView  *wgpu.TextureView
+
 	// Bind groups pending release — deferred until after command buffer submit.
 	// WebGPU requires bind groups to be alive at submit time (wgpu-core track/mod.rs:631).
 	// Skia Graphite pattern: batch-release after GPU completion.
@@ -241,9 +249,9 @@ type GPURenderSession struct {
 
 	// frameRendered tracks whether at least one render pass has been
 	// submitted to the surface in the current frame. When true, subsequent
-	// render passes use LoadOpLoad instead of LoadOpClear to preserve
-	// previously drawn content. This handles mid-frame flushes caused by
-	// CPU fallback operations (e.g., DrawImage between GPU draws).
+	// passes preserve previously drawn content. Single-sample passes use
+	// LoadOpLoad; MSAA passes resolve a transparent overlay and composite it.
+	// This handles mid-frame flushes caused by CPU fallback operations.
 	//
 	// Reset by BeginFrame() at the start of each frame, or when the
 	// active view changes (different Context targets different view).
@@ -251,8 +259,8 @@ type GPURenderSession struct {
 	// Porter-Duff "over" during readback, so LoadOpClear is always safe.
 	frameRendered bool
 
-	// preserveContent signals that the surface has external content (e.g., g3d).
-	// When true, view changes do NOT reset frameRendered → LoadOp::Load. ADR-059.
+	// preserveContent signals that the surface has external content (e.g., g3d)
+	// that must remain underneath this pass. ADR-059.
 	preserveContent bool
 
 	// antiAlias determines SDF coverage computation mode.
@@ -262,8 +270,8 @@ type GPURenderSession struct {
 
 	// lastView tracks the most recent per-pass view used for rendering.
 	// When the view changes between Flush calls (e.g., two gg.Context
-	// instances rendering to different targets), frameRendered is reset
-	// so the new view gets a LoadOpClear on its first render pass.
+	// instances rendering to different targets), prior gg content is not
+	// preserved unless the target explicitly reports external content.
 	lastView *wgpu.TextureView
 
 	// scissorRect holds the current scissor rect in device pixels.
@@ -323,14 +331,15 @@ func (s *GPURenderSession) SetSurfaceTarget(view *wgpu.TextureView, width, heigh
 			}
 			s.prevCmdBufs = s.prevCmdBufs[:0]
 		}
+		s.releaseSurfaceCompositeBinding()
 		s.textures.destroyTextures()
 	}
 
 	// Detect new frame: swapchain creates a new TextureView each frame
 	// (gogpu renderer.BeginFrame → CreateTextureView), so a different view
 	// pointer means a new frame has started. Reset per-frame state so the
-	// first render pass clears the surface while subsequent mid-frame
-	// flushes preserve content via LoadOpLoad.
+	// first render pass replaces the surface while subsequent mid-frame
+	// flushes preserve its content.
 	//
 	// When the same view is passed again (e.g., ggcanvas.RenderDirect calls
 	// SetSurfaceTarget a second time within the same frame), this is a no-op
@@ -353,8 +362,8 @@ func (s *GPURenderSession) SetSurfaceTarget(view *wgpu.TextureView, width, heigh
 
 // BeginFrame resets per-frame state. Call this at the start of each frame
 // before any drawing operations. In surface mode, this ensures the first
-// render pass clears the surface while subsequent mid-frame flushes
-// preserve previously drawn content (LoadOpLoad instead of LoadOpClear).
+// render pass replaces the surface while subsequent mid-frame flushes
+// preserve previously drawn content.
 //
 // For offscreen mode this is a no-op — offscreen readback composites via
 // Porter-Duff "over", so LoadOpClear is always safe there.
@@ -431,7 +440,7 @@ func (s *GPURenderSession) colorAttachment(targetView *wgpu.TextureView, loadOp 
 			View:          s.textures.msaaView,
 			ResolveTarget: targetView,
 			LoadOp:        loadOp,
-			StoreOp:       gputypes.StoreOpStore,
+			StoreOp:       gputypes.StoreOpDiscard,
 			ClearValue:    gputypes.Color{R: 0, G: 0, B: 0, A: 0},
 		}
 	}
@@ -471,6 +480,8 @@ func (s *GPURenderSession) effectiveDimensions(target gg.GPURenderTarget, active
 // the same frame, we must drain the GPU first — otherwise destroying MSAA
 // textures referenced by in-flight render passes is undefined behavior.
 func (s *GPURenderSession) ensureTexturesForView(activeView *wgpu.TextureView, w, h uint32) error {
+	texturesChanging := s.textures.msaaTex == nil || s.textures.width != w || s.textures.height != h
+
 	// If dimensions are changing and there are in-flight command buffers
 	// from earlier flushes in this frame, drain the GPU before destroying
 	// the old textures. Without this, the earlier flush's render pass
@@ -485,6 +496,9 @@ func (s *GPURenderSession) ensureTexturesForView(activeView *wgpu.TextureView, w
 			}
 			s.prevCmdBufs = s.prevCmdBufs[:0]
 		}
+	}
+	if texturesChanging {
+		s.releaseSurfaceCompositeBinding()
 	}
 
 	if activeView != nil {
@@ -530,6 +544,9 @@ func (s *GPURenderSession) RenderMode() RenderMode {
 // In surface mode, only MSAA and stencil textures are created -- the resolve
 // texture is skipped because the surface view serves as the resolve target.
 func (s *GPURenderSession) EnsureTextures(w, h uint32) error {
+	if s.textures.msaaTex == nil || s.textures.width != w || s.textures.height != h {
+		s.releaseSurfaceCompositeBinding()
+	}
 	if s.surfaceView != nil {
 		return s.textures.ensureSurfaceTextures(s.device, w, h, "session", s.sampleCount)
 	}
@@ -559,6 +576,7 @@ func (s *GPURenderSession) RenderFrame(
 	if len(sdfShapes) == 0 && len(convexCommands) == 0 && len(stencilPaths) == 0 && len(textBatches) == 0 && len(glyphMaskBatches) == 0 {
 		return nil
 	}
+	s.preserveContent = target.PreserveContent
 
 	// Determine render target view: per-pass target.View takes priority
 	// over session-level surfaceView (backward compat).
@@ -672,6 +690,7 @@ func (s *GPURenderSession) RenderFrameGrouped(target gg.GPURenderTarget, groups 
 	if totalItems == 0 && baseLayer == nil {
 		return nil
 	}
+	s.preserveContent = target.PreserveContent
 
 	// Determine render target view: per-pass target.View takes priority
 	// over session-level surfaceView (backward compat).
@@ -914,13 +933,12 @@ func (s *GPURenderSession) RenderFrameGrouped(target gg.GPURenderTarget, groups 
 
 	blitOnly := s.isBlitOnly(grpRes, baseLayerRes)
 
-	// ADR-021: DamageRect (LoadOpLoad + scissor) is only supported on the
-	// blit-only compositor path. MSAA render passes cannot use LoadOpLoad
-	// because multisampled content is discarded after resolve (StoreOp=DontCare).
-	// No enterprise framework (Chrome, Flutter, Skia) uses LoadOpLoad on MSAA.
-	// Warn if caller passed damageRect but MSAA path will be used.
+	// ADR-021: DamageRect scissoring is only supported on the blit-only
+	// compositor path. Vector overlays that preserve a surface use a transparent
+	// MSAA intermediate and full-surface alpha composite instead; they must not
+	// load the transient multisample attachment.
 	if !blitOnly && len(target.DamageRects) > 0 {
-		slogger().Warn("damageRects ignored: MSAA render path requires full LoadOpClear; use blit-only compositor for damage-aware rendering (ADR-021)")
+		slogger().Warn("damageRects ignored: vector render path uses full-surface MSAA composition; use blit-only compositor for damage-aware rendering (ADR-021)")
 	}
 
 	// ADR-017: shared encoder → record render pass without submit.
@@ -1107,6 +1125,7 @@ func (s *GPURenderSession) destroyPersistentBuffers() { //nolint:gocyclo,cyclop,
 		s.gpuTexBaseVertBuf = nil
 		s.gpuTexBaseVertBufCap = 0
 	}
+	s.destroySurfaceCompositeResources()
 	// Tier 4: Text per-batch pools.
 	for i, bg := range s.textBindGroups {
 		if bg != nil {
@@ -1198,6 +1217,29 @@ func (s *GPURenderSession) destroyPersistentBuffers() { //nolint:gocyclo,cyclop,
 	if s.clipBindLayout != nil {
 		s.clipBindLayout.Release()
 		s.clipBindLayout = nil
+	}
+}
+
+// releaseSurfaceCompositeBinding drops the bind group before its sampled
+// overlay resolve texture is destroyed or replaced. The vertex and uniform
+// buffers remain reusable across surface resizes.
+func (s *GPURenderSession) releaseSurfaceCompositeBinding() {
+	if s.surfaceCompositeBindGroup != nil {
+		s.surfaceCompositeBindGroup.Release()
+		s.surfaceCompositeBindGroup = nil
+	}
+	s.surfaceCompositeBoundView = nil
+}
+
+func (s *GPURenderSession) destroySurfaceCompositeResources() {
+	s.releaseSurfaceCompositeBinding()
+	if s.surfaceCompositeUniformBuf != nil {
+		s.surfaceCompositeUniformBuf.Release()
+		s.surfaceCompositeUniformBuf = nil
+	}
+	if s.surfaceCompositeVertBuf != nil {
+		s.surfaceCompositeVertBuf.Release()
+		s.surfaceCompositeVertBuf = nil
 	}
 }
 
@@ -2113,6 +2155,84 @@ func (s *GPURenderSession) buildGPUTextureResources(cmds []GPUTextureDrawCommand
 	}, nil
 }
 
+// buildSurfaceCompositeResources prepares a persistent full-surface textured
+// quad that samples the transparent single-sample overlay resolve texture.
+// Dedicated buffers keep this final pass independent from base-layer and
+// ordinary GPU-texture draw resources prepared earlier in the frame.
+func (s *GPURenderSession) buildSurfaceCompositeResources(w, h uint32) (*imageFrameResources, error) {
+	if s.textures.compositeView == nil {
+		return nil, fmt.Errorf("composition resolve view is nil")
+	}
+	if s.imagePipeline == nil {
+		s.imagePipeline = NewTexturedQuadPipeline(s.device, s.queue, s.sampleCount)
+	}
+	if err := s.imagePipeline.ensureBlitPipeline(); err != nil {
+		return nil, fmt.Errorf("ensure composition pipeline: %w", err)
+	}
+
+	const vertexBufferSize = 6 * imageVertexStride
+	if s.surfaceCompositeVertBuf == nil {
+		buf, err := s.device.CreateBuffer(&wgpu.BufferDescriptor{
+			Label: "surface_composite_vert_buf",
+			Size:  vertexBufferSize,
+			Usage: gputypes.BufferUsageVertex | gputypes.BufferUsageCopyDst,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create composition vertex buffer: %w", err)
+		}
+		s.surfaceCompositeVertBuf = buf
+	}
+	vertices := buildImageVertices(&ImageDrawCommand{
+		DstW: float32(w), DstH: float32(h),
+		U0: 0, V0: 0, U1: 1, V1: 1,
+	})
+	if err := s.queue.WriteBuffer(s.surfaceCompositeVertBuf, 0, vertices); err != nil {
+		return nil, fmt.Errorf("upload composition vertices: %w", err)
+	}
+
+	if s.surfaceCompositeUniformBuf == nil {
+		buf, err := s.device.CreateBuffer(&wgpu.BufferDescriptor{
+			Label: "surface_composite_uniform_buf",
+			Size:  imageUniformSize,
+			Usage: gputypes.BufferUsageUniform | gputypes.BufferUsageCopyDst,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create composition uniform buffer: %w", err)
+		}
+		s.surfaceCompositeUniformBuf = buf
+	}
+	if err := s.queue.WriteBuffer(s.surfaceCompositeUniformBuf, 0, makeImageUniform(w, h, 1)); err != nil {
+		return nil, fmt.Errorf("upload composition uniform: %w", err)
+	}
+
+	if s.surfaceCompositeBindGroup == nil || s.surfaceCompositeBoundView != s.textures.compositeView {
+		bg, err := s.device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+			Label:  "surface_composite_bind_group",
+			Layout: s.imagePipeline.uniformLayout,
+			Entries: []wgpu.BindGroupEntry{
+				{Binding: 0, Buffer: s.surfaceCompositeUniformBuf, Offset: 0, Size: imageUniformSize},
+				{Binding: 1, TextureView: s.textures.compositeView},
+				{Binding: 2, Sampler: s.imagePipeline.sampler},
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create composition bind group: %w", err)
+		}
+		if s.surfaceCompositeBindGroup != nil {
+			s.pendingBindGroupRelease = append(s.pendingBindGroupRelease, s.surfaceCompositeBindGroup)
+		}
+		s.surfaceCompositeBindGroup = bg
+		s.surfaceCompositeBoundView = s.textures.compositeView
+	}
+
+	return &imageFrameResources{
+		vertBuf: s.surfaceCompositeVertBuf,
+		drawCalls: []imageDrawCall{{
+			bindGroup: s.surfaceCompositeBindGroup,
+		}},
+	}, nil
+}
+
 // sliceImageResources creates an imageFrameResources referencing a sub-range of
 // the combined drawCalls. One drawCall per ImageDrawCommand.
 func (s *GPURenderSession) sliceImageResources(
@@ -2626,9 +2746,9 @@ func (s *GPURenderSession) copySubmitAndReadback(
 	return nil
 }
 
-// encodeSubmitSurface encodes the unified render pass with the given view
-// as the resolve target, then submits without readback. The MSAA color
-// attachment resolves directly to the provided texture view.
+// encodeSubmitSurface encodes the unified surface rendering and submits without
+// readback. Ordinary MSAA frames resolve directly to the provided view;
+// preserved content uses a transparent resolve followed by alpha composition.
 //
 // This is the zero-copy path for windowed rendering: no staging buffer, no
 // CopyTextureToBuffer, no ReadBuffer, no fence wait (presentation handles
@@ -2660,51 +2780,21 @@ func (s *GPURenderSession) encodeSubmitSurface(
 		}
 	}()
 
-	// Per-view frame tracking: when the view changes between flushes
-	// (e.g., two gg.Context instances rendering to different targets),
-	// reset frameRendered so the new view gets LoadOpClear on its first
-	// pass. This prevents shapes from one Context leaking into another.
-	//
-	// ADR-059: PreserveContent skips the reset — the view already has
-	// content from an external renderer (e.g., g3d). LoadOp::Load
-	// preserves it. Enterprise pattern: Qt beginExternal/endExternal,
-	// Flutter InlinePassContext pass_count, Unity Camera.DontClear.
-	if view != s.lastView {
-		if !s.preserveContent {
-			s.frameRendered = false
-		} else {
-			s.frameRendered = true
-		}
-		s.lastView = view
+	renderTarget, colorLoadOp, compositeRes, err := s.prepareSurfacePass(view, w, h)
+	if err != nil {
+		return err
 	}
-
-	// Surface render pass LoadOp: first pass clears, subsequent passes
-	// preserve existing content. This handles mid-frame flushes caused by
-	// CPU fallback operations (e.g., DrawImage between GPU draw calls).
-	// Without this, each flush would wipe previously rendered shapes.
-	colorLoadOp := gputypes.LoadOpClear
-	stencilLoadOp := gputypes.LoadOpClear
-	if s.frameRendered {
-		colorLoadOp = gputypes.LoadOpLoad
-		stencilLoadOp = gputypes.LoadOpLoad
-	}
-	// Depth is ALWAYS cleared — never loaded. DepthStoreOp=Discard means
-	// depth content is undefined after each render pass, so LoadOpLoad would
-	// read garbage on subsequent passes. The depth clip pipeline (GPU-CLIP-003a)
-	// writes Z=0.0 inside clip regions fresh each pass, so clearing to 1.0 is
-	// always the correct initial state.
-	depthLoadOp := gputypes.LoadOpClear
 
 	rpDesc := &wgpu.RenderPassDescriptor{
 		Label:            "session_surface_pass",
-		ColorAttachments: []wgpu.RenderPassColorAttachment{s.colorAttachment(view, colorLoadOp)},
+		ColorAttachments: []wgpu.RenderPassColorAttachment{s.colorAttachment(renderTarget, colorLoadOp)},
 		DepthStencilAttachment: &wgpu.RenderPassDepthStencilAttachment{
 			View:              s.textures.stencilView,
-			DepthLoadOp:       depthLoadOp,
+			DepthLoadOp:       gputypes.LoadOpClear,
 			DepthStoreOp:      gputypes.StoreOpDiscard,
 			DepthClearValue:   1.0,
-			StencilLoadOp:     stencilLoadOp,
-			StencilStoreOp:    gputypes.StoreOpStore,
+			StencilLoadOp:     gputypes.LoadOpClear,
+			StencilStoreOp:    gputypes.StoreOpDiscard,
 			StencilClearValue: 0,
 		},
 	}
@@ -2746,7 +2836,12 @@ func (s *GPURenderSession) encodeSubmitSurface(
 	}
 
 	if endErr := rp.End(); endErr != nil {
-		slogger().Warn("render pass End failed", "err", endErr)
+		return fmt.Errorf("end render pass: %w", endErr)
+	}
+	if compositeRes != nil {
+		if err := s.encodeSurfaceCompositePass(encoder, view, w, h, compositeRes); err != nil {
+			return err
+		}
 	}
 
 	// No CopyTextureToBuffer -- the surface is the resolve target.
@@ -2774,8 +2869,9 @@ func (s *GPURenderSession) encodeSubmitSurface(
 	s.prevCmdBufs = append(s.prevCmdBufs, cmdBuf)
 
 	// Mark that at least one render pass has been submitted this frame.
-	// Subsequent mid-frame flushes will use LoadOpLoad to preserve content.
+	// Subsequent mid-frame MSAA flushes use the composition path to preserve it.
 	s.frameRendered = true
+	s.lastView = view
 
 	return nil
 }
@@ -3108,7 +3204,7 @@ func (s *GPURenderSession) encodeBlitOnlyPass(
 
 	loadOp := gputypes.LoadOpClear
 	hasDamage := len(damageRects) > 0
-	if hasDamage {
+	if hasDamage || s.shouldPreserveSurface(view) {
 		loadOp = gputypes.LoadOpLoad
 	}
 
@@ -3175,9 +3271,128 @@ func (s *GPURenderSession) encodeBlitOnlyPass(
 	return nil
 }
 
-// encodeSubmitSurfaceGrouped encodes a single render pass with per-group
-// scissor state changes, resolving directly to the given view. No readback
-// occurs. This is the grouped version of encodeSubmitSurface.
+// shouldPreserveSurface reports whether this pass must retain the current
+// single-sample surface contents. PreserveContent covers external producers;
+// frameRendered covers earlier gg flushes to the same view.
+func (s *GPURenderSession) shouldPreserveSurface(view *wgpu.TextureView) bool {
+	return s.preserveContent || (s.frameRendered && view == s.lastView)
+}
+
+// prepareSurfacePass selects the correct target for a vector surface pass.
+// Single-sample rendering can preserve the surface with LoadOpLoad. An MSAA
+// pass cannot load single-sample surface content into its transient attachment,
+// so it resolves a transparent overlay for a subsequent alpha-composite pass.
+func (s *GPURenderSession) prepareSurfacePass(
+	view *wgpu.TextureView,
+	w, h uint32,
+) (*wgpu.TextureView, gputypes.LoadOp, *imageFrameResources, error) {
+	if !s.shouldPreserveSurface(view) {
+		return view, gputypes.LoadOpClear, nil, nil
+	}
+	if s.sampleCount <= 1 {
+		return view, gputypes.LoadOpLoad, nil, nil
+	}
+	if err := s.textures.ensureCompositeTexture(s.device, w, h, "session"); err != nil {
+		return nil, 0, nil, fmt.Errorf("ensure composition texture: %w", err)
+	}
+	res, err := s.buildSurfaceCompositeResources(w, h)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("build composition resources: %w", err)
+	}
+	return s.textures.compositeView, gputypes.LoadOpClear, res, nil
+}
+
+// encodeGroupedSurfacePass records the grouped vector pass. When existing
+// surface content must be preserved under MSAA, the overlay is first rendered
+// and resolved into a transparent single-sample texture, then alpha-composited
+// onto the surface. Loading the transient MSAA attachment would be incorrect:
+// it never contains content produced directly in the swapchain view.
+func (s *GPURenderSession) encodeGroupedSurfacePass(
+	encoder *wgpu.CommandEncoder,
+	label string,
+	view *wgpu.TextureView,
+	w, h uint32,
+	grpRes []groupResources,
+	baseLayerRes *imageFrameResources,
+) error {
+	renderTarget, colorLoadOp, compositeRes, err := s.prepareSurfacePass(view, w, h)
+	if err != nil {
+		return err
+	}
+
+	rp, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		Label:            label,
+		ColorAttachments: []wgpu.RenderPassColorAttachment{s.colorAttachment(renderTarget, colorLoadOp)},
+		DepthStencilAttachment: &wgpu.RenderPassDepthStencilAttachment{
+			View:              s.textures.stencilView,
+			DepthLoadOp:       gputypes.LoadOpClear,
+			DepthStoreOp:      gputypes.StoreOpDiscard,
+			DepthClearValue:   1.0,
+			StencilLoadOp:     gputypes.LoadOpClear,
+			StencilStoreOp:    gputypes.StoreOpDiscard,
+			StencilClearValue: 0,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("begin grouped surface pass: %w", err)
+	}
+	rp.SetViewport(0, 0, float32(w), float32(h), 0, 1)
+
+	if baseLayerRes != nil && len(baseLayerRes.drawCalls) > 0 {
+		rp.SetScissorRect(0, 0, w, h)
+		s.imagePipeline.RecordDraws(rp, baseLayerRes, s.noClipBindGroup)
+	}
+	for i := range grpRes {
+		s.applyGroupScissor(rp, grpRes[i].scissorRect, w, h)
+		s.recordGroupDraws(rp, &grpRes[i])
+	}
+	if endErr := rp.End(); endErr != nil {
+		return fmt.Errorf("end grouped surface pass: %w", endErr)
+	}
+
+	if compositeRes != nil {
+		if err := s.encodeSurfaceCompositePass(encoder, view, w, h, compositeRes); err != nil {
+			return err
+		}
+	}
+
+	s.frameRendered = true
+	s.lastView = view
+	return nil
+}
+
+// encodeSurfaceCompositePass alpha-blends the transparent overlay resolve onto
+// the existing single-sample surface with the image pipeline's 1x blit variant.
+func (s *GPURenderSession) encodeSurfaceCompositePass(
+	encoder *wgpu.CommandEncoder,
+	view *wgpu.TextureView,
+	w, h uint32,
+	res *imageFrameResources,
+) error {
+	rp, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		Label: "session_surface_composite_pass",
+		ColorAttachments: []wgpu.RenderPassColorAttachment{{
+			View:       view,
+			LoadOp:     gputypes.LoadOpLoad,
+			StoreOp:    gputypes.StoreOpStore,
+			ClearValue: gputypes.Color{R: 0, G: 0, B: 0, A: 0},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("begin surface composite pass: %w", err)
+	}
+	rp.SetViewport(0, 0, float32(w), float32(h), 0, 1)
+	rp.SetScissorRect(0, 0, w, h)
+	s.imagePipeline.RecordBlitDraws(rp, res)
+	if endErr := rp.End(); endErr != nil {
+		return fmt.Errorf("end surface composite pass: %w", endErr)
+	}
+	return nil
+}
+
+// encodeSubmitSurfaceGrouped encodes grouped surface rendering and submits it
+// without readback. Preserved MSAA overlays require a resolve pass followed by
+// a surface composite pass; ordinary frames retain the direct resolve path.
 func (s *GPURenderSession) encodeSubmitSurfaceGrouped(
 	view *wgpu.TextureView,
 	w, h uint32,
@@ -3200,62 +3415,8 @@ func (s *GPURenderSession) encodeSubmitSurfaceGrouped(
 		}
 	}()
 
-	// Per-view frame tracking (same as encodeSubmitSurface).
-	if view != s.lastView {
-		s.frameRendered = false
-		s.lastView = view
-	}
-
-	// Surface render pass LoadOp: first pass clears, subsequent passes
-	// preserve existing content. This handles mid-frame flushes caused by
-	// CPU fallback operations (e.g., DrawImage between GPU draw calls).
-	colorLoadOp := gputypes.LoadOpClear
-	stencilLoadOp := gputypes.LoadOpClear
-	if s.frameRendered {
-		colorLoadOp = gputypes.LoadOpLoad
-		stencilLoadOp = gputypes.LoadOpLoad
-	}
-	// Depth is ALWAYS cleared — never loaded. DepthStoreOp=Discard means
-	// depth content is undefined after each render pass, so LoadOpLoad would
-	// read garbage on subsequent passes. The depth clip pipeline (GPU-CLIP-003a)
-	// writes Z=0.0 inside clip regions fresh each pass, so clearing to 1.0 is
-	// always the correct initial state.
-	depthLoadOp := gputypes.LoadOpClear
-
-	rpDesc := &wgpu.RenderPassDescriptor{
-		Label:            "session_surface_pass",
-		ColorAttachments: []wgpu.RenderPassColorAttachment{s.colorAttachment(view, colorLoadOp)},
-		DepthStencilAttachment: &wgpu.RenderPassDepthStencilAttachment{
-			View:              s.textures.stencilView,
-			DepthLoadOp:       depthLoadOp,
-			DepthStoreOp:      gputypes.StoreOpDiscard,
-			DepthClearValue:   1.0,
-			StencilLoadOp:     stencilLoadOp,
-			StencilStoreOp:    gputypes.StoreOpStore,
-			StencilClearValue: 0,
-		},
-	}
-
-	rp, rpErr := encoder.BeginRenderPass(rpDesc)
-	if rpErr != nil {
-		return fmt.Errorf("begin render pass: %w", rpErr)
-	}
-	rp.SetViewport(0, 0, float32(w), float32(h), 0, 1)
-
-	// Base layer: pixmap textured quad drawn FIRST, before all tiers (ADR-015).
-	if baseLayerRes != nil && len(baseLayerRes.drawCalls) > 0 {
-		rp.SetScissorRect(0, 0, w, h)
-		s.imagePipeline.RecordDraws(rp, baseLayerRes, s.noClipBindGroup)
-	}
-
-	// Render each group with its scissor rect applied.
-	for i := range grpRes {
-		s.applyGroupScissor(rp, grpRes[i].scissorRect, w, h)
-		s.recordGroupDraws(rp, &grpRes[i])
-	}
-
-	if endErr := rp.End(); endErr != nil {
-		slogger().Warn("render pass End failed", "err", endErr)
+	if err := s.encodeGroupedSurfacePass(encoder, "session_surface_pass", view, w, h, grpRes, baseLayerRes); err != nil {
+		return err
 	}
 
 	// No CopyTextureToBuffer -- the surface is the resolve target.
@@ -3276,9 +3437,6 @@ func (s *GPURenderSession) encodeSubmitSurfaceGrouped(
 	// Keep reference so next frame can free it after GPU is done.
 	s.prevCmdBufs = append(s.prevCmdBufs, cmdBuf)
 
-	// Mark that at least one render pass has been submitted this frame.
-	s.frameRendered = true
-
 	return nil
 }
 
@@ -3293,54 +3451,7 @@ func (s *GPURenderSession) encodeToEncoder(
 	grpRes []groupResources,
 	baseLayerRes *imageFrameResources,
 ) error {
-	if view != s.lastView {
-		s.frameRendered = false
-		s.lastView = view
-	}
-
-	colorLoadOp := gputypes.LoadOpClear
-	stencilLoadOp := gputypes.LoadOpClear
-	if s.frameRendered {
-		colorLoadOp = gputypes.LoadOpLoad
-		stencilLoadOp = gputypes.LoadOpLoad
-	}
-	// Depth always cleared (see encodeSubmitSurfaceGrouped comment).
-	depthLoadOp := gputypes.LoadOpClear
-
-	rp, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
-		Label:            "session_shared_surface_pass",
-		ColorAttachments: []wgpu.RenderPassColorAttachment{s.colorAttachment(view, colorLoadOp)},
-		DepthStencilAttachment: &wgpu.RenderPassDepthStencilAttachment{
-			View:              s.textures.stencilView,
-			DepthLoadOp:       depthLoadOp,
-			DepthStoreOp:      gputypes.StoreOpDiscard,
-			DepthClearValue:   1.0,
-			StencilLoadOp:     stencilLoadOp,
-			StencilStoreOp:    gputypes.StoreOpStore,
-			StencilClearValue: 0,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("begin shared render pass: %w", err)
-	}
-	rp.SetViewport(0, 0, float32(w), float32(h), 0, 1)
-
-	if baseLayerRes != nil && len(baseLayerRes.drawCalls) > 0 {
-		rp.SetScissorRect(0, 0, w, h)
-		s.imagePipeline.RecordDraws(rp, baseLayerRes, s.noClipBindGroup)
-	}
-
-	for i := range grpRes {
-		s.applyGroupScissor(rp, grpRes[i].scissorRect, w, h)
-		s.recordGroupDraws(rp, &grpRes[i])
-	}
-
-	if endErr := rp.End(); endErr != nil {
-		slogger().Warn("shared render pass End failed", "err", endErr)
-	}
-
-	s.frameRendered = true
-	return nil
+	return s.encodeGroupedSurfacePass(encoder, "session_shared_surface_pass", view, w, h, grpRes, baseLayerRes)
 }
 
 // encodeBlitToEncoder records a non-MSAA blit pass into an external encoder.
@@ -3359,7 +3470,7 @@ func (s *GPURenderSession) encodeBlitToEncoder(
 
 	hasDamage := len(damageRects) > 0
 	loadOp := gputypes.LoadOpClear
-	if hasDamage {
+	if hasDamage || s.shouldPreserveSurface(view) {
 		loadOp = gputypes.LoadOpLoad
 	}
 
@@ -3406,6 +3517,7 @@ func (s *GPURenderSession) encodeBlitToEncoder(
 	}
 
 	s.frameRendered = true
+	s.lastView = view
 	return nil
 }
 

--- a/internal/gpu/render_session_test.go
+++ b/internal/gpu/render_session_test.go
@@ -130,6 +130,180 @@ func TestRenderSessionTexturesResize(t *testing.T) {
 	}
 }
 
+func TestRenderSessionMSAASurfacePreservationRoute(t *testing.T) {
+	tests := []struct {
+		name            string
+		sampleCount     uint32
+		preserveContent bool
+		previouslyDrawn bool
+		wantComposition bool
+	}{
+		{
+			name:            "external content with MSAA",
+			sampleCount:     4,
+			preserveContent: true,
+			wantComposition: true,
+		},
+		{
+			name:            "earlier gg flush with MSAA",
+			sampleCount:     4,
+			previouslyDrawn: true,
+			wantComposition: true,
+		},
+		{
+			name:        "fresh MSAA surface",
+			sampleCount: 4,
+		},
+		{
+			name:            "external content without MSAA",
+			sampleCount:     1,
+			preserveContent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			device, queue, cleanup := createNoopDevice(t)
+			defer cleanup()
+
+			const width, height = uint32(96), uint32(64)
+			tex, view := createMockSurfaceView(t, device, width, height)
+			defer tex.Release()
+			defer view.Release()
+
+			s := NewGPURenderSession(device, queue, tt.sampleCount)
+			defer s.Destroy()
+			if tt.previouslyDrawn {
+				s.SetFrameState(true, view)
+			}
+
+			encoder, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{
+				Label: "preservation_route_encoder",
+			})
+			if err != nil {
+				t.Fatalf("create encoder: %v", err)
+			}
+			groups := []ScissorGroup{{SDFShapes: []SDFRenderShape{{
+				Kind: 0, CenterX: 24, CenterY: 24, Param1: 12, Param2: 12,
+				ColorR: 1, ColorG: 1, ColorB: 1, ColorA: 1,
+			}}}}
+			target := gg.GPURenderTarget{
+				View:            gpucontext.NewTextureView(unsafe.Pointer(view)),
+				ViewWidth:       width,
+				ViewHeight:      height,
+				PreserveContent: tt.preserveContent,
+			}
+			if err := s.RenderFrameGrouped(target, groups, nil, encoder); err != nil {
+				encoder.DiscardEncoding()
+				t.Fatalf("RenderFrameGrouped: %v", err)
+			}
+
+			gotComposition := s.textures.compositeTex != nil && s.textures.compositeView != nil
+			if gotComposition != tt.wantComposition {
+				t.Fatalf("composition route = %v, want %v", gotComposition, tt.wantComposition)
+			}
+			if tt.wantComposition && (s.surfaceCompositeVertBuf == nil ||
+				s.surfaceCompositeUniformBuf == nil || s.surfaceCompositeBindGroup == nil) {
+				t.Fatal("composition route did not prepare its dedicated draw resources")
+			}
+			frameRendered, lastView := s.FrameState()
+			if !frameRendered || lastView != view {
+				t.Fatalf("frame state = (%v, %p), want (true, %p)", frameRendered, lastView, view)
+			}
+
+			cmdBuf, err := encoder.Finish()
+			if err != nil {
+				t.Fatalf("finish encoder: %v", err)
+			}
+			if _, err := queue.Submit(cmdBuf); err != nil {
+				device.FreeCommandBuffer(cmdBuf)
+				t.Fatalf("submit: %v", err)
+			}
+			if err := device.WaitIdle(); err != nil {
+				t.Fatalf("wait idle: %v", err)
+			}
+			device.FreeCommandBuffer(cmdBuf)
+		})
+	}
+}
+
+func TestRenderSessionMSAASurfacePreservationNonGrouped(t *testing.T) {
+	device, queue, cleanup := createNoopDevice(t)
+	defer cleanup()
+
+	const width, height = uint32(96), uint32(64)
+	tex, view := createMockSurfaceView(t, device, width, height)
+	defer tex.Release()
+	defer view.Release()
+
+	s := NewGPURenderSession(device, queue, 4)
+	defer s.Destroy()
+	target := gg.GPURenderTarget{
+		View:            gpucontext.NewTextureView(unsafe.Pointer(view)),
+		ViewWidth:       width,
+		ViewHeight:      height,
+		PreserveContent: true,
+	}
+	shapes := []SDFRenderShape{{
+		Kind: 0, CenterX: 24, CenterY: 24, Param1: 12, Param2: 12,
+		ColorR: 1, ColorG: 1, ColorB: 1, ColorA: 1,
+	}}
+	if err := s.RenderFrame(target, shapes, nil, nil, nil); err != nil {
+		t.Fatalf("RenderFrame: %v", err)
+	}
+	if s.textures.compositeTex == nil || s.textures.compositeView == nil {
+		t.Fatal("non-grouped preservation did not use the MSAA composition route")
+	}
+	firstCompositeView := s.textures.compositeView
+	firstBindGroup := s.surfaceCompositeBindGroup
+
+	const resizedWidth, resizedHeight = uint32(128), uint32(80)
+	resizedTex, resizedView := createMockSurfaceView(t, device, resizedWidth, resizedHeight)
+	defer resizedTex.Release()
+	defer resizedView.Release()
+	target.View = gpucontext.NewTextureView(unsafe.Pointer(resizedView))
+	target.ViewWidth = resizedWidth
+	target.ViewHeight = resizedHeight
+	if err := s.RenderFrame(target, shapes, nil, nil, nil); err != nil {
+		t.Fatalf("RenderFrame after resize: %v", err)
+	}
+	if s.textures.compositeView == firstCompositeView {
+		t.Fatal("surface resize did not recreate the composition resolve view")
+	}
+	if s.surfaceCompositeBindGroup == firstBindGroup {
+		t.Fatal("surface resize did not recreate the composition bind group")
+	}
+	if s.surfaceCompositeBoundView != s.textures.compositeView {
+		t.Fatal("composition bind group does not reference the resized resolve view")
+	}
+}
+
+func TestRenderSessionMSAAAttachmentDiscardsResolvedStorage(t *testing.T) {
+	msaaView := &wgpu.TextureView{}
+	targetView := &wgpu.TextureView{}
+	s := &GPURenderSession{
+		sampleCount: 4,
+		textures:    textureSet{msaaView: msaaView},
+	}
+
+	attachment := s.colorAttachment(targetView, gputypes.LoadOpClear)
+	if attachment.View != msaaView || attachment.ResolveTarget != targetView {
+		t.Fatal("MSAA attachment must render to the transient view and resolve to the target")
+	}
+	if attachment.StoreOp != gputypes.StoreOpDiscard {
+		t.Fatalf("MSAA StoreOp = %v, want Discard", attachment.StoreOp)
+	}
+
+	s.sampleCount = 1
+	attachment = s.colorAttachment(targetView, gputypes.LoadOpLoad)
+	if attachment.View != targetView || attachment.ResolveTarget != nil {
+		t.Fatal("single-sample attachment must render directly to the target")
+	}
+	if attachment.StoreOp != gputypes.StoreOpStore {
+		t.Fatalf("single-sample StoreOp = %v, want Store", attachment.StoreOp)
+	}
+}
+
 func TestRenderSessionDestroyAndRecreate(t *testing.T) {
 	device, queue, cleanup := createNoopDevice(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Implements Strategy C from #455: when an MSAA vector/mixed pass must preserve existing surface content, gg now renders the overlay into the existing multisample attachment with a transparent clear, resolves it into a lazy single-sample texture, and alpha-composites that resolve over the surface.

This preserves external g3d content and earlier same-view gg flushes without duplicating the seven vector/text pipeline variants or reducing stencil-cover antialiasing quality.

## What changed

- keep ordinary frames on the existing direct-to-surface resolve path
- keep preserved single-sample and blit-only frames on `LoadOpLoad`
- route only preserved MSAA vector/mixed frames through the transparent resolve + composite path
- reuse the existing premultiplied 1x textured-quad pipeline for the final composite
- support both session-owned submission and the borrowed/shared command encoder used by gogpu
- lazily allocate the extra 4 B/pixel resolve texture and recreate its binding safely on resize
- discard transient multisample color storage after resolve
- clear/discard transient depth-stencil state per pass
- add regression coverage for external content, earlier gg flushes, direct vs composed routing, the non-grouped path, resize/rebind lifecycle, and MSAA `StoreOpDiscard`
- update public comments so preservation behavior is accurate for both 1x and MSAA rendering

The GPU-direct Vello follow-up remains out of scope, but this establishes the render-to-texture -> GPU composite seam discussed in #455.

## Why Strategy C

- full MSAA and stencil-cover quality
- no public API or session configuration change
- no dual variants for seven pipelines
- one coherent path for owned and borrowed encoders
- the extra texture/pass is paid only when existing surface content actually needs preservation

## Validation

- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go build ./examples/...`
- `CGO_ENABLED=0 go build ./cmd/ggdemo`
- `CGO_ENABLED=0 go test -tags nogpu -count=1 ./...`
- `go test -race -tags nogpu -count=1 -coverprofile=coverage.txt -covermode=atomic ./...` (79.2% total)
- `CGO_ENABLED=0 go vet ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run --timeout=5m` (0 issues)
- focused GPU routing/lifecycle tests on the noop validation backend
- `CGO_ENABLED=0 go test -count=1 -skip '^TestMetalStencil(CoverMasksToShape|RoundedRectMasking|EvenOddMasking)$' ./internal/gpu`

The unfiltered local macOS GPU run still reaches the repository's existing Metal-test limitation: the requested Metal adapter resolves to the software backend, which rejects `SampleCount=4` in the three skipped stencil tests. The new MSAA route itself passes command validation; CI remains authoritative for the cross-platform builds.

Closes #455

cc @kolkov
