### PR TITLE
feat(svg): lower documents into retained scene vectors

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -423,10 +423,11 @@ gg/
 ├── raster/                 # PUBLIC opt-in: tile rasterizer only (no GPU)
 │   └── raster.go           # init() registers AdaptiveFiller (CPU-only)
 │
-├── svg/                    # SVG renderer (Parse + Render SVG XML → image.RGBA)
+├── svg/                    # SVG renderer (immediate Context or retained Scene vectors)
 │   ├── svg.go              # Public API: Parse, Render, RenderWithColor
 │   ├── parser.go           # SVG XML parser → Document tree
-│   ├── renderer.go         # Element rendering via gg.Context
+│   ├── renderer.go         # Shared geometry/transform/style resolution
+│   ├── scene_renderer.go   # Document.RenderToScene retained Fill/Stroke lowering
 │   ├── colors.go           # SVG color parsing (#hex, rgb(), named)
 │   ├── transform.go        # SVG transform parsing (translate, rotate, scale)
 │   └── document.go         # Document, Element types

--- a/svg/doc.go
+++ b/svg/doc.go
@@ -35,4 +35,11 @@
 //	img1 := doc.Render(16, 16)
 //	img2 := doc.Render(32, 32)
 //	img3 := doc.RenderWithColor(24, 24, themeColor)
+//
+//	// Retain ordinary vector fill/stroke commands in a Scene:
+//	s := scene.NewScene()
+//	doc.RenderToScene(s, 0, 0, 24, 24)
+//
+// RenderToScene keeps geometry vector-based so the Scene renderer resolves it
+// at the final display resolution.
 package svg

--- a/svg/renderer.go
+++ b/svg/renderer.go
@@ -8,252 +8,131 @@ import (
 	"github.com/gogpu/gg"
 )
 
-// strokeHintMaxCanvasSize is the maximum canvas dimension (in pixels) at which
-// stroke hinting is applied. Above this size, strokes are thick enough that
-// sub-pixel positioning produces acceptable results without hinting.
-const strokeHintMaxCanvasSize = 48
+const (
+	// strokeHintMaxCanvasSize limits automatic hinting to icon-sized targets.
+	strokeHintMaxCanvasSize = 48
+	// strokeHintMaxWidth limits hinting to thin strokes in device pixels.
+	strokeHintMaxWidth = 1.5
+)
 
-// strokeHintMaxWidth is the maximum stroke width (in device pixels, after
-// viewBox scaling) that qualifies for hinting. Thin strokes suffer most from
-// sub-pixel positioning; thicker strokes already span multiple pixels.
-const strokeHintMaxWidth = 1.5
-
-// renderState holds the rendering state during SVG traversal.
+// renderState is shared by immediate and retained traversal. Matrix is the
+// complete logical transform at the current nesting level.
 type renderState struct {
-	overrideColor color.Color // non-nil → replace all non-colorNone colors
-	parentFill    string      // inherited fill from parent <g>
-	parentStroke  string      // inherited stroke from parent <g>
-	strokeHinting bool        // true → snap thin stroke coords to pixel centers
-	scaleX        float64     // viewBox → device X scale (for device-px stroke width)
-	scaleY        float64     // viewBox → device Y scale
+	overrideColor color.Color
+	parentFill    string
+	parentStroke  string
+	opacity       float64
+	matrix        gg.Matrix
+	strokeHinting bool
+	scaleX        float64
+	scaleY        float64
 }
 
-// renderElements renders a list of elements into the given gg.Context.
+type resolvedFill struct {
+	present bool
+	rule    gg.FillRule
+	color   gg.RGBA
+}
+
+type resolvedStroke struct {
+	present bool
+	width   float64
+	cap     gg.LineCap
+	join    gg.LineJoin
+	color   gg.RGBA
+}
+
+type resolvedStyle struct {
+	fill   resolvedFill
+	stroke resolvedStroke
+}
+
 func renderElements(dc *gg.Context, elements []Element, state *renderState) {
 	for _, elem := range elements {
 		renderElement(dc, elem, state)
 	}
 }
 
-// renderElement dispatches rendering to the appropriate element-specific function.
 func renderElement(dc *gg.Context, elem Element, state *renderState) {
 	switch e := elem.(type) {
 	case *PathElement:
-		renderPath(dc, e, state)
+		if e.D == "" {
+			return
+		}
+		path, err := gg.ParseSVGPath(e.D)
+		if err != nil {
+			return
+		}
+		renderGeometry(dc, path, &e.Attrs, state, true)
 	case *CircleElement:
-		renderCircle(dc, e, state)
+		path := gg.NewPath()
+		path.Circle(e.CX, e.CY, e.R)
+		renderGeometry(dc, path, &e.Attrs, state, true)
 	case *RectElement:
-		renderRect(dc, e, state)
+		path := gg.NewPath()
+		if e.RX > 0 || e.RY > 0 {
+			r := e.RX
+			if e.RY > r {
+				r = e.RY
+			}
+			path.RoundedRectangle(e.X, e.Y, e.W, e.H, r)
+		} else {
+			path.Rectangle(e.X, e.Y, e.W, e.H)
+		}
+		renderGeometry(dc, path, &e.Attrs, state, true)
 	case *EllipseElement:
-		renderEllipse(dc, e, state)
+		path := gg.NewPath()
+		path.Ellipse(e.CX, e.CY, e.RX, e.RY)
+		renderGeometry(dc, path, &e.Attrs, state, true)
 	case *LineElement:
-		renderLine(dc, e, state)
+		path := gg.NewPath()
+		path.MoveTo(e.X1, e.Y1)
+		path.LineTo(e.X2, e.Y2)
+		renderGeometry(dc, path, &e.Attrs, state, false)
 	case *PolygonElement:
-		renderPolygon(dc, e, state)
+		if path := pointsPath(e.Points, true); path != nil {
+			renderGeometry(dc, path, &e.Attrs, state, true)
+		}
 	case *PolylineElement:
-		renderPolyline(dc, e, state)
+		if path := pointsPath(e.Points, false); path != nil {
+			renderGeometry(dc, path, &e.Attrs, state, true)
+		}
 	case *GroupElement:
 		renderGroup(dc, e, state)
 	}
 }
 
-// renderPath renders an SVG <path> element.
-func renderPath(dc *gg.Context, e *PathElement, state *renderState) {
-	if e.D == "" {
-		return
+func renderGeometry(dc *gg.Context, path *gg.Path, attrs *Attrs, state *renderState, allowFill bool) {
+	local := elementTransformMatrix(attrs)
+	style := resolveStyle(attrs, state)
+	if !allowFill {
+		style.fill.present = false
 	}
-	path, err := gg.ParseSVGPath(e.D)
-	if err != nil {
-		return // skip invalid paths silently
+	if !style.fill.present && !style.stroke.present {
+		return
 	}
 
 	dc.Push()
-	applyElementTransform(dc, &e.Attrs)
-
-	// Apply stroke hinting: snap path line endpoints to pixel centers.
-	// The original path is used for fill (hinting would displace filled shapes).
-	// A separate hinted path is used for stroke when conditions are met.
-	strokePath := path
-	if shouldStroke(&e.Attrs, state) && shouldHintStroke(&e.Attrs, state) {
-		strokePath = hintSVGPath(path, state.scaleX, state.scaleY)
-	}
-
-	fillAndStroke(dc, &e.Attrs, state, func() {
+	dc.Transform(local)
+	if style.fill.present {
+		dc.SetFillRule(style.fill.rule)
+		setResolvedColor(dc, style.fill.color)
 		dc.DrawPath(path)
-	}, func() {
-		dc.DrawPath(strokePath)
-	})
-
-	dc.Pop()
-}
-
-// renderCircle renders an SVG <circle> element.
-func renderCircle(dc *gg.Context, e *CircleElement, state *renderState) {
-	dc.Push()
-	applyElementTransform(dc, &e.Attrs)
-
-	draw := func() { dc.DrawCircle(e.CX, e.CY, e.R) }
-	fillAndStroke(dc, &e.Attrs, state, draw, draw)
-
-	dc.Pop()
-}
-
-// renderRect renders an SVG <rect> element.
-func renderRect(dc *gg.Context, e *RectElement, state *renderState) {
-	dc.Push()
-	applyElementTransform(dc, &e.Attrs)
-
-	draw := func() {
-		if e.RX > 0 || e.RY > 0 {
-			// Use the larger of rx/ry for the rounded rectangle radius.
-			r := e.RX
-			if e.RY > r {
-				r = e.RY
-			}
-			dc.DrawRoundedRectangle(e.X, e.Y, e.W, e.H, r)
-		} else {
-			dc.DrawRectangle(e.X, e.Y, e.W, e.H)
-		}
-	}
-	fillAndStroke(dc, &e.Attrs, state, draw, draw)
-
-	dc.Pop()
-}
-
-// renderEllipse renders an SVG <ellipse> element.
-func renderEllipse(dc *gg.Context, e *EllipseElement, state *renderState) {
-	dc.Push()
-	applyElementTransform(dc, &e.Attrs)
-
-	draw := func() { dc.DrawEllipse(e.CX, e.CY, e.RX, e.RY) }
-	fillAndStroke(dc, &e.Attrs, state, draw, draw)
-
-	dc.Pop()
-}
-
-// renderLine renders an SVG <line> element.
-func renderLine(dc *gg.Context, e *LineElement, state *renderState) {
-	dc.Push()
-	applyElementTransform(dc, &e.Attrs)
-
-	// Lines are stroke-only by default.
-	applyStrokeAttrs(dc, &e.Attrs, state)
-	x1, y1, x2, y2 := e.X1, e.Y1, e.X2, e.Y2
-	if shouldHintStroke(&e.Attrs, state) {
-		x1, y1 = hintLineCoords(x1, y1, state.scaleX, state.scaleY)
-		x2, y2 = hintLineCoords(x2, y2, state.scaleX, state.scaleY)
-	}
-	dc.DrawLine(x1, y1, x2, y2)
-	_ = dc.Stroke()
-
-	dc.Pop()
-}
-
-// renderPolygon renders an SVG <polygon> element.
-func renderPolygon(dc *gg.Context, e *PolygonElement, state *renderState) {
-	if len(e.Points) < 4 {
-		return // need at least 2 points
-	}
-
-	dc.Push()
-	applyElementTransform(dc, &e.Attrs)
-
-	drawFill := func() {
-		dc.ClearPath()
-		drawPointsPath(dc, e.Points, true)
-	}
-	drawStroke := drawFill
-	if shouldStroke(&e.Attrs, state) && shouldHintStroke(&e.Attrs, state) {
-		hintedPts := hintPoints(e.Points, state.scaleX, state.scaleY)
-		drawStroke = func() {
-			dc.ClearPath()
-			drawPointsPath(dc, hintedPts, true)
-		}
-	}
-	fillAndStroke(dc, &e.Attrs, state, drawFill, drawStroke)
-
-	dc.Pop()
-}
-
-// renderPolyline renders an SVG <polyline> element.
-func renderPolyline(dc *gg.Context, e *PolylineElement, state *renderState) {
-	if len(e.Points) < 4 {
-		return
-	}
-
-	dc.Push()
-	applyElementTransform(dc, &e.Attrs)
-
-	drawFill := func() {
-		dc.ClearPath()
-		drawPointsPath(dc, e.Points, false)
-	}
-	drawStroke := drawFill
-	if shouldStroke(&e.Attrs, state) && shouldHintStroke(&e.Attrs, state) {
-		hintedPts := hintPoints(e.Points, state.scaleX, state.scaleY)
-		drawStroke = func() {
-			dc.ClearPath()
-			drawPointsPath(dc, hintedPts, false)
-		}
-	}
-	fillAndStroke(dc, &e.Attrs, state, drawFill, drawStroke)
-
-	dc.Pop()
-}
-
-// renderGroup renders an SVG <g> element and its children.
-func renderGroup(dc *gg.Context, e *GroupElement, state *renderState) {
-	dc.Push()
-	applyElementTransform(dc, &e.Attrs)
-
-	// Create child state with inherited attrs.
-	childState := &renderState{
-		overrideColor: state.overrideColor,
-		parentFill:    state.parentFill,
-		parentStroke:  state.parentStroke,
-		strokeHinting: state.strokeHinting,
-		scaleX:        state.scaleX,
-		scaleY:        state.scaleY,
-	}
-	if e.Attrs.Fill != "" {
-		childState.parentFill = e.Attrs.Fill
-	}
-	if e.Attrs.Stroke != "" {
-		childState.parentStroke = e.Attrs.Stroke
-	}
-
-	renderElements(dc, e.Children, childState)
-
-	dc.Pop()
-}
-
-// fillAndStroke applies fill and/or stroke to the current path.
-//
-// drawFill sets up the path for filling (original coordinates).
-// drawStroke sets up the path for stroking (may have hinted coordinates
-// when stroke hinting is active for crisp thin lines in small icons).
-func fillAndStroke(dc *gg.Context, a *Attrs, state *renderState, drawFill, drawStroke func()) {
-	hasFill := shouldFill(a, state)
-	hasStroke := shouldStroke(a, state)
-
-	if !hasFill && !hasStroke {
-		// Default SVG behavior: fill with black if no fill/stroke specified.
-		if a.Fill == "" && a.Stroke == "" {
-			hasFill = true
-		}
-	}
-
-	if hasFill {
-		applyFillAttrs(dc, a, state)
-		drawFill()
 		_ = dc.Fill()
 	}
-
-	if hasStroke {
-		applyStrokeAttrs(dc, a, state)
-		drawStroke()
+	if style.stroke.present {
+		strokePath := path
+		if shouldHintStroke(attrs, state) {
+			strokePath = hintSVGPath(path, state.scaleX, state.scaleY)
+		}
+		dc.SetLineWidth(style.stroke.width)
+		dc.SetLineCap(style.stroke.cap)
+		dc.SetLineJoin(style.stroke.join)
+		setResolvedColor(dc, style.stroke.color)
+		dc.DrawPath(strokePath)
 		_ = dc.Stroke()
 	}
+	dc.Pop()
 }
 
 // shouldHintStroke reports whether stroke hinting should be applied to this
@@ -322,12 +201,6 @@ func hintSVGPath(src *gg.Path, sx, sy float64) *gg.Path {
 	return result
 }
 
-// hintLineCoords snaps line endpoint coordinates (in viewBox space) to pixel
-// centers in device space, returning the snapped viewBox coordinates.
-func hintLineCoords(x, y, sx, sy float64) (float64, float64) {
-	return snapViewBoxCoord(x, sx), snapViewBoxCoord(y, sy)
-}
-
 // snapViewBoxCoord converts a viewBox coordinate to device space, snaps it
 // to the nearest pixel center, and converts back to viewBox space.
 //
@@ -365,148 +238,152 @@ func strokeHintingDisabled() bool {
 	return os.Getenv("GOGPU_SVG_NO_HINT") != ""
 }
 
-// shouldFill returns true if the element should be filled.
-func shouldFill(a *Attrs, state *renderState) bool {
-	fill := resolveFill(a, state)
-	return fill != colorNone
+func renderGroup(dc *gg.Context, group *GroupElement, state *renderState) {
+	local := elementTransformMatrix(&group.Attrs)
+	child := *state
+	child.matrix = state.matrix.Multiply(local)
+	child.opacity *= group.Attrs.Opacity
+	if group.Attrs.Fill != "" {
+		child.parentFill = group.Attrs.Fill
+	}
+	if group.Attrs.Stroke != "" {
+		child.parentStroke = group.Attrs.Stroke
+	}
+
+	dc.Push()
+	dc.Transform(local)
+	renderElements(dc, group.Children, &child)
+	dc.Pop()
 }
 
-// shouldStroke returns true if the element should be stroked.
-func shouldStroke(a *Attrs, state *renderState) bool {
-	stroke := resolveStroke(a, state)
-	return stroke != "" && stroke != colorNone
+func resolveStyle(attrs *Attrs, state *renderState) resolvedStyle {
+	fillString := resolveFill(attrs, state)
+	strokeString := resolveStroke(attrs, state)
+
+	fillRule := gg.FillRuleNonZero
+	rule := attrs.FillRule
+	if rule == "" {
+		rule = attrs.ClipRule
+	}
+	if rule == "evenodd" {
+		fillRule = gg.FillRuleEvenOdd
+	}
+
+	style := resolvedStyle{
+		fill: resolvedFill{
+			present: fillString != colorNone,
+			rule:    fillRule,
+		},
+		stroke: resolvedStroke{
+			present: strokeString != "" && strokeString != colorNone,
+			width:   attrs.StrokeWidth,
+			cap:     resolveLineCap(attrs.StrokeCap),
+			join:    resolveLineJoin(attrs.StrokeJoin),
+		},
+	}
+
+	fillColor, fillOK := resolvePaintColor(fillString, color.Black, state.overrideColor,
+		attrs.FillOpacity*attrs.Opacity*state.opacity)
+	style.fill.color = fillColor
+	style.fill.present = style.fill.present && fillOK
+
+	strokeColor, strokeOK := resolvePaintColor(strokeString, nil, state.overrideColor,
+		attrs.StrokeOpacity*attrs.Opacity*state.opacity)
+	style.stroke.color = strokeColor
+	style.stroke.present = style.stroke.present && strokeOK
+	return style
 }
 
-// resolveFill returns the effective fill color string, considering inheritance.
-func resolveFill(a *Attrs, state *renderState) string {
-	if a.Fill != "" {
-		return a.Fill
+func resolveFill(attrs *Attrs, state *renderState) string {
+	if attrs.Fill != "" {
+		return attrs.Fill
 	}
 	if state.parentFill != "" {
 		return state.parentFill
 	}
-	return "" // will be treated as "black" by SVG spec default
+	return "" // SVG's default fill is black.
 }
 
-// resolveStroke returns the effective stroke color string, considering inheritance.
-func resolveStroke(a *Attrs, state *renderState) string {
-	if a.Stroke != "" {
-		return a.Stroke
+func resolveStroke(attrs *Attrs, state *renderState) string {
+	if attrs.Stroke != "" {
+		return attrs.Stroke
 	}
 	return state.parentStroke
 }
 
-// applyFillAttrs sets the fill color and fill rule on the context.
-func applyFillAttrs(dc *gg.Context, a *Attrs, state *renderState) {
-	fillStr := resolveFill(a, state)
-
-	// Set fill rule.
-	fillRule := a.FillRule
-	if fillRule == "" {
-		fillRule = a.ClipRule
+func resolvePaintColor(value string, fallback color.Color, override color.Color, opacity float64) (gg.RGBA, bool) {
+	var c color.Color
+	if override != nil && value != colorNone {
+		c = override
+	} else {
+		parsed, err := parseColor(value)
+		if err != nil || parsed == nil {
+			c = fallback
+		} else {
+			c = parsed
+		}
 	}
-	switch fillRule {
-	case "evenodd":
-		dc.SetFillRule(gg.FillRuleEvenOdd)
-	default:
-		dc.SetFillRule(gg.FillRuleNonZero)
+	if c == nil {
+		return gg.RGBA{}, false
 	}
-
-	// Set fill color.
-	if state.overrideColor != nil && fillStr != colorNone {
-		setColorWithOpacity(dc, state.overrideColor, a.FillOpacity*a.Opacity)
-		return
+	if opacity < 0 {
+		opacity = 0
+	} else if opacity > 1 {
+		opacity = 1
 	}
-
-	c, err := parseColor(fillStr)
-	if err != nil || c == nil {
-		// Default fill is black per SVG spec.
-		setColorWithOpacity(dc, color.Black, a.FillOpacity*a.Opacity)
-		return
-	}
-	setColorWithOpacity(dc, c, a.FillOpacity*a.Opacity)
+	result := gg.FromColor(c)
+	result.A *= opacity
+	return result, true
 }
 
-// applyStrokeAttrs sets stroke color, width, cap, and join on the context.
-func applyStrokeAttrs(dc *gg.Context, a *Attrs, state *renderState) {
-	strokeStr := resolveStroke(a, state)
-
-	dc.SetLineWidth(a.StrokeWidth)
-
-	// Stroke cap
-	switch a.StrokeCap {
+func resolveLineCap(value string) gg.LineCap {
+	switch value {
 	case "round":
-		dc.SetLineCap(gg.LineCapRound)
+		return gg.LineCapRound
 	case "square":
-		dc.SetLineCap(gg.LineCapSquare)
+		return gg.LineCapSquare
 	default:
-		dc.SetLineCap(gg.LineCapButt)
+		return gg.LineCapButt
 	}
+}
 
-	// Stroke join
-	switch a.StrokeJoin {
+func resolveLineJoin(value string) gg.LineJoin {
+	switch value {
 	case "round":
-		dc.SetLineJoin(gg.LineJoinRound)
+		return gg.LineJoinRound
 	case "bevel":
-		dc.SetLineJoin(gg.LineJoinBevel)
+		return gg.LineJoinBevel
 	default:
-		dc.SetLineJoin(gg.LineJoinMiter)
-	}
-
-	// Stroke color
-	if state.overrideColor != nil && strokeStr != colorNone {
-		setColorWithOpacity(dc, state.overrideColor, a.StrokeOpacity*a.Opacity)
-		return
-	}
-
-	c, err := parseColor(strokeStr)
-	if err != nil || c == nil {
-		return
-	}
-	setColorWithOpacity(dc, c, a.StrokeOpacity*a.Opacity)
-}
-
-// setColorWithOpacity sets the drawing color on the context, applying
-// an additional opacity multiplier.
-func setColorWithOpacity(dc *gg.Context, c color.Color, opacity float64) {
-	if opacity >= 1.0 {
-		dc.SetColor(c)
-		return
-	}
-	r, g, b, a := c.RGBA()
-	// Un-premultiply, apply opacity, set as straight alpha RGBA.
-	if a == 0 {
-		dc.SetRGBA(0, 0, 0, 0)
-		return
-	}
-	fa := float64(a) / 65535.0
-	dc.SetRGBA(
-		float64(r)/65535.0/fa,
-		float64(g)/65535.0/fa,
-		float64(b)/65535.0/fa,
-		fa*opacity,
-	)
-}
-
-// applyElementTransform applies the element's transform attribute to the context.
-func applyElementTransform(dc *gg.Context, a *Attrs) {
-	if a.Transform != "" {
-		// Errors in transforms are silently ignored (best effort).
-		_ = applyTransform(dc, a.Transform)
+		return gg.LineJoinMiter
 	}
 }
 
-// drawPointsPath draws a path from alternating x,y point values.
-// If closed is true, the path is closed (polygon). Otherwise it's open (polyline).
-func drawPointsPath(dc *gg.Context, points []float64, closed bool) {
+func setResolvedColor(dc *gg.Context, c gg.RGBA) {
+	dc.SetRGBA(c.R, c.G, c.B, c.A)
+}
+
+func elementTransformMatrix(attrs *Attrs) gg.Matrix {
+	if attrs == nil || attrs.Transform == "" {
+		return gg.Identity()
+	}
+	matrix, _ := transformMatrix(attrs.Transform)
+	return matrix
+}
+
+func pointsPath(points []float64, closed bool) *gg.Path {
+	if len(points) < 4 {
+		return nil
+	}
+	path := gg.NewPath()
 	for i := 0; i+1 < len(points); i += 2 {
 		if i == 0 {
-			dc.MoveTo(points[i], points[i+1])
+			path.MoveTo(points[i], points[i+1])
 		} else {
-			dc.LineTo(points[i], points[i+1])
+			path.LineTo(points[i], points[i+1])
 		}
 	}
 	if closed {
-		dc.ClosePath()
+		path.Close()
 	}
+	return path
 }

--- a/svg/renderer_boundary_test.go
+++ b/svg/renderer_boundary_test.go
@@ -1,0 +1,179 @@
+package svg
+
+import (
+	"image/color"
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/scene"
+)
+
+func TestImmediateRendererSkipsInvalidAndInvisibleGeometry(t *testing.T) {
+	dc := gg.NewContext(16, 16)
+	state := &renderState{opacity: 1, matrix: gg.Identity()}
+	attrs := testPresentationAttrs()
+
+	renderElements(dc, []Element{
+		&PathElement{Attrs: attrs},
+		&PathElement{Attrs: attrs, D: "M definitely-not-a-number"},
+	}, state)
+
+	path := gg.NewPath()
+	path.Circle(8, 8, 4)
+	invisible := attrs
+	invisible.Fill = colorNone
+	invisible.Stroke = colorNone
+	renderGeometry(dc, path, &invisible, state, true)
+
+	renderElement(dc, &PolygonElement{Attrs: attrs, Points: []float64{1, 2}}, state)
+	renderElement(dc, &PolylineElement{Attrs: attrs, Points: []float64{1, 2}}, state)
+	if got := pointsPath([]float64{1, 2}, true); got != nil {
+		t.Fatalf("pointsPath accepted one point: %+v", got)
+	}
+
+	if imageHasAlpha(dc) {
+		t.Fatal("invalid or explicitly invisible geometry produced pixels")
+	}
+}
+
+func TestImmediateRendererBoundaryStylesAndGeometry(t *testing.T) {
+	doc, err := Parse([]byte(`<svg viewBox="0 0 20 20">
+  <rect x="1" y="1" width="7" height="6" rx="1" ry="3" fill="red"/>
+  <g transform="translate(0 1)" stroke="blue" opacity=".5">
+    <path d="M2 12 L18 12 L18 17" fill="none" stroke-width="2" stroke-linecap="square" stroke-linejoin="round"/>
+  </g>
+</svg>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	img := doc.Render(20, 20)
+	assertNonEmpty(t, img, "rounded rectangle and inherited stroke")
+	if alphaOf(img.At(2, 2)) == 0 {
+		t.Error("rounded rectangle with ry greater than rx was not filled")
+	}
+	if alphaOf(img.At(10, 13)) == 0 {
+		t.Error("group-inherited stroke was not rendered")
+	}
+}
+
+func TestResolvedPaintAndStrokeBoundaries(t *testing.T) {
+	tests := []struct {
+		name    string
+		opacity float64
+		wantA   float64
+	}{
+		{name: "negative clamps transparent", opacity: -0.1, wantA: 0},
+		{name: "fractional preserved", opacity: 0.4, wantA: 0.4},
+		{name: "above one clamps opaque", opacity: 1.1, wantA: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := resolvePaintColor("red", nil, nil, test.opacity)
+			if !ok || got.R != 1 || got.G != 0 || got.B != 0 || got.A != test.wantA {
+				t.Fatalf("resolvePaintColor(red, %g)=(%+v,%v), want red alpha %g", test.opacity, got, ok, test.wantA)
+			}
+		})
+	}
+
+	if got, ok := resolvePaintColor("not-a-color", nil, nil, 1); ok || got != (gg.RGBA{}) {
+		t.Fatalf("invalid stroke color=(%+v,%v), want unavailable", got, ok)
+	}
+	got, ok := resolvePaintColor("not-a-color", color.Black, color.NRGBA{R: 12, G: 34, B: 56, A: 128}, 1)
+	if !ok || got.A == 0 || got.R == 0 {
+		t.Fatalf("override color was not used for non-none paint: (%+v,%v)", got, ok)
+	}
+
+	capTests := map[string]gg.LineCap{
+		"": gg.LineCapButt, "round": gg.LineCapRound, "square": gg.LineCapSquare,
+	}
+	for input, want := range capTests {
+		if got := resolveLineCap(input); got != want {
+			t.Errorf("resolveLineCap(%q)=%v, want %v", input, got, want)
+		}
+		if got := sceneLineCap(want); got != scene.LineCap(want) {
+			t.Errorf("sceneLineCap(%v)=%v, want %v", want, got, scene.LineCap(want))
+		}
+	}
+	joinTests := map[string]gg.LineJoin{
+		"": gg.LineJoinMiter, "round": gg.LineJoinRound, "bevel": gg.LineJoinBevel,
+	}
+	for input, want := range joinTests {
+		if got := resolveLineJoin(input); got != want {
+			t.Errorf("resolveLineJoin(%q)=%v, want %v", input, got, want)
+		}
+		if got := sceneLineJoin(want); got != scene.LineJoin(want) {
+			t.Errorf("sceneLineJoin(%v)=%v, want %v", want, got, scene.LineJoin(want))
+		}
+	}
+}
+
+func TestSceneRendererBoundaryElements(t *testing.T) {
+	attrs := testPresentationAttrs()
+	red := attrs
+	red.Fill = "red"
+	stroke := attrs
+	stroke.Fill = colorNone
+	stroke.Stroke = "blue"
+	stroke.StrokeCap = "square"
+	stroke.StrokeJoin = "round"
+	stroke.StrokeWidth = 2
+
+	doc := &Document{
+		ViewBox: ViewBox{Width: 20, Height: 20},
+		Elements: []Element{
+			&PathElement{Attrs: attrs},
+			&PathElement{Attrs: attrs, D: "M invalid"},
+			&RectElement{Attrs: red, X: 1, Y: 1, W: 4, H: 4},
+			&RectElement{Attrs: red, X: 7, Y: 1, W: 5, H: 6, RX: 1, RY: 2},
+			&PathElement{Attrs: stroke, D: "M2 12 L18 12 L18 17"},
+			&PolygonElement{Attrs: red, Points: []float64{1, 2}},
+			&PolylineElement{Attrs: red, Points: []float64{1, 2}},
+			&GroupElement{Attrs: attrs, Children: []Element{
+				&CircleElement{Attrs: red, CX: 15, CY: 5, R: 2},
+			}},
+		},
+	}
+	s := scene.NewScene()
+	doc.RenderToScene(s, 0, 0, 20, 20)
+
+	var fills int
+	var gotStroke *scene.StrokeStyle
+	dec := scene.NewDecoder(s.Encoding())
+	for dec.Next() {
+		switch dec.Tag() {
+		case scene.TagFill:
+			fills++
+			_, _ = dec.Fill()
+		case scene.TagFillRoundRect:
+			fills++
+			_, _, _, _, _ = dec.FillRoundRect()
+		case scene.TagStroke:
+			_, gotStroke = dec.Stroke()
+		case scene.TagTransform:
+			_ = dec.Transform()
+		}
+	}
+	if fills != 3 {
+		t.Errorf("fill command count=%d, want 3 valid filled shapes", fills)
+	}
+	if gotStroke == nil || gotStroke.Width != 2 || gotStroke.Cap != scene.LineCapSquare || gotStroke.Join != scene.LineJoinRound {
+		t.Fatalf("stroke style=%+v, want width=2 square cap round join", gotStroke)
+	}
+}
+
+func testPresentationAttrs() Attrs {
+	return Attrs{FillOpacity: 1, StrokeOpacity: 1, StrokeWidth: 1, Opacity: 1}
+}
+
+func imageHasAlpha(dc *gg.Context) bool {
+	bounds := dc.Image().Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			_, _, _, alpha := dc.Image().At(x, y).RGBA()
+			if alpha != 0 {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/svg/scene_renderer.go
+++ b/svg/scene_renderer.go
@@ -1,593 +1,203 @@
 package svg
 
 import (
-	"fmt"
 	"image/color"
 	"math"
-	"strconv"
-	"strings"
 
 	"github.com/gogpu/gg"
 	"github.com/gogpu/gg/scene"
 )
 
-// sceneRenderState holds the rendering state during SVG-to-scene traversal.
-type sceneRenderState struct {
-	overrideColor *gg.RGBA // non-nil → replace all non-"none" colors
-	parentFill    string   // inherited fill from parent <g>
-	parentStroke  string   // inherited stroke from parent <g>
-	strokeHinting bool     // true → snap thin stroke coords to pixel centers
-	scaleX        float64  // viewBox → canvas X scale (for hinting)
-	scaleY        float64  // viewBox → canvas Y scale (for hinting)
-}
-
-// renderToSceneInternal is the shared implementation for scene rendering.
+// renderToSceneInternal is the shared implementation for retained rendering.
+// It preserves the public positional RenderToScene API while lowering through
+// the same geometry and style model as the immediate renderer.
 func (d *Document) renderToSceneInternal(
-	s *scene.Scene,
-	x, y, w, h float32,
+	target *scene.Scene,
+	x, y, width, height float32,
 	overrideColor *gg.RGBA,
 ) {
-	if d.ViewBox.Width <= 0 || d.ViewBox.Height <= 0 {
+	if d == nil || target == nil || d.ViewBox.Width <= 0 || d.ViewBox.Height <= 0 ||
+		width <= 0 || height <= 0 {
 		return
 	}
 
-	// Compute viewBox → target scaling.
-	sx := w / float32(d.ViewBox.Width)
-	sy := h / float32(d.ViewBox.Height)
-
-	// Build the viewBox-to-target transform.
-	viewBoxTransform := scene.IdentityAffine()
-
-	// Position at (x, y).
-	if x != 0 || y != 0 {
-		viewBoxTransform = viewBoxTransform.Multiply(scene.TranslateAffine(x, y))
-	}
-
-	// Scale from viewBox to target size.
-	viewBoxTransform = viewBoxTransform.Multiply(scene.ScaleAffine(sx, sy))
-
-	// Apply viewBox minX/minY offset.
-	if d.ViewBox.MinX != 0 || d.ViewBox.MinY != 0 {
-		viewBoxTransform = viewBoxTransform.Multiply(
-			scene.TranslateAffine(-float32(d.ViewBox.MinX), -float32(d.ViewBox.MinY)),
-		)
-	}
-
-	s.PushTransform(viewBoxTransform)
-
-	// Enable stroke hinting for small icons (same criteria as bitmap renderer).
-	maxDim := math.Max(float64(w), float64(h))
-	hinting := maxDim <= strokeHintMaxCanvasSize && !strokeHintingDisabled()
-
-	state := &sceneRenderState{
-		overrideColor: overrideColor,
-		parentFill:    d.RootFill,
-		strokeHinting: hinting,
-		scaleX:        float64(sx),
-		scaleY:        float64(sy),
-	}
-
-	sceneRenderElements(s, d.Elements, state)
-
-	s.PopTransform()
-}
-
-// sceneRenderElements renders a list of SVG elements into the scene.
-func sceneRenderElements(s *scene.Scene, elements []Element, state *sceneRenderState) {
-	for _, elem := range elements {
-		sceneRenderElement(s, elem, state)
-	}
-}
-
-// sceneRenderElement dispatches rendering to the appropriate element handler.
-func sceneRenderElement(s *scene.Scene, elem Element, state *sceneRenderState) {
-	switch e := elem.(type) {
-	case *PathElement:
-		sceneRenderPath(s, e, state)
-	case *CircleElement:
-		sceneRenderCircle(s, e, state)
-	case *RectElement:
-		sceneRenderRect(s, e, state)
-	case *EllipseElement:
-		sceneRenderEllipse(s, e, state)
-	case *LineElement:
-		sceneRenderLine(s, e, state)
-	case *PolygonElement:
-		sceneRenderPolygon(s, e, state)
-	case *PolylineElement:
-		sceneRenderPolyline(s, e, state)
-	case *GroupElement:
-		sceneRenderGroup(s, e, state)
-	}
-}
-
-// sceneRenderPath renders an SVG <path> element to the scene.
-func sceneRenderPath(s *scene.Scene, e *PathElement, state *sceneRenderState) {
-	if e.D == "" {
-		return
-	}
-	ggPath, err := gg.ParseSVGPath(e.D)
-	if err != nil {
-		return // skip invalid paths silently
-	}
-
-	fillShape := scene.NewGGPathShape(ggPath)
-	strokeShape := fillShape
-
-	// Apply stroke hinting: snap thin stroke endpoints to pixel centers.
-	// Reuses hintSVGPath from renderer.go. Same criteria as bitmap path.
-	if state.strokeHinting && e.Attrs.Stroke != "" && e.Attrs.Stroke != colorNone {
-		avgScale := (state.scaleX + state.scaleY) / 2.0
-		deviceWidth := e.Attrs.StrokeWidth * avgScale
-		if deviceWidth <= strokeHintMaxWidth {
-			hintedPath := hintSVGPath(ggPath, state.scaleX, state.scaleY)
-			strokeShape = scene.NewGGPathShape(hintedPath)
-		}
-	}
-
-	pushSceneTransform(s, &e.Attrs)
-	sceneApplyFillAndStroke(s, &e.Attrs, state, fillShape, strokeShape)
-	popSceneTransform(s, &e.Attrs)
-}
-
-// sceneRenderCircle renders an SVG <circle> element to the scene.
-// Uses native CircleShape for SDF-friendly rendering.
-func sceneRenderCircle(s *scene.Scene, e *CircleElement, state *sceneRenderState) {
-	shape := scene.NewCircleShape(float32(e.CX), float32(e.CY), float32(e.R))
-
-	pushSceneTransform(s, &e.Attrs)
-	sceneApplyFillAndStroke(s, &e.Attrs, state, shape, shape)
-	popSceneTransform(s, &e.Attrs)
-}
-
-// sceneRenderRect renders an SVG <rect> element to the scene.
-// Uses RoundRectShape for rounded rects (SDF-based) or RectShape for plain rects.
-func sceneRenderRect(s *scene.Scene, e *RectElement, state *sceneRenderState) {
-	var fillShape, strokeShape scene.Shape
-
-	if e.RX > 0 || e.RY > 0 {
-		// Use the larger of rx/ry for the rounded rectangle radius (SVG spec).
-		rx := float32(e.RX)
-		ry := float32(e.RY)
-		if ry > rx {
-			rx = ry
-		}
-		rect := scene.Rect{
-			MinX: float32(e.X),
-			MinY: float32(e.Y),
-			MaxX: float32(e.X + e.W),
-			MaxY: float32(e.Y + e.H),
-		}
-		rr := scene.NewRoundRectShapeUniform(rect, rx)
-		fillShape = rr
-		strokeShape = rr
-	} else {
-		rs := scene.NewRectShape(float32(e.X), float32(e.Y), float32(e.W), float32(e.H))
-		fillShape = rs
-		strokeShape = rs
-	}
-
-	pushSceneTransform(s, &e.Attrs)
-	sceneApplyFillAndStroke(s, &e.Attrs, state, fillShape, strokeShape)
-	popSceneTransform(s, &e.Attrs)
-}
-
-// sceneRenderEllipse renders an SVG <ellipse> element to the scene.
-func sceneRenderEllipse(s *scene.Scene, e *EllipseElement, state *sceneRenderState) {
-	shape := scene.NewEllipseShape(float32(e.CX), float32(e.CY), float32(e.RX), float32(e.RY))
-
-	pushSceneTransform(s, &e.Attrs)
-	sceneApplyFillAndStroke(s, &e.Attrs, state, shape, shape)
-	popSceneTransform(s, &e.Attrs)
-}
-
-// sceneRenderLine renders an SVG <line> element to the scene.
-// Lines are stroke-only by default.
-func sceneRenderLine(s *scene.Scene, e *LineElement, state *sceneRenderState) {
-	shape := scene.NewLineShape(float32(e.X1), float32(e.Y1), float32(e.X2), float32(e.Y2))
-
-	pushSceneTransform(s, &e.Attrs)
-
-	// Lines are stroke-only in SVG.
-	strokeStr := resolveStroke(&e.Attrs, toRenderState(state))
-	if strokeStr == "" || strokeStr == colorNone {
-		// Default stroke for lines is currentColor, which we treat as black.
-		strokeStr = "black"
-	}
-	brush := resolveSceneBrush(strokeStr, state, e.Attrs.StrokeOpacity*e.Attrs.Opacity)
-	style := buildSceneStrokeStyle(&e.Attrs)
-	s.Stroke(style, scene.IdentityAffine(), brush, shape)
-
-	popSceneTransform(s, &e.Attrs)
-}
-
-// sceneRenderPolygon renders an SVG <polygon> element to the scene.
-func sceneRenderPolygon(s *scene.Scene, e *PolygonElement, state *sceneRenderState) {
-	if len(e.Points) < 4 {
-		return // need at least 2 points
-	}
-
-	pts := make([]float32, len(e.Points))
-	for i, v := range e.Points {
-		pts[i] = float32(v)
-	}
-	shape := scene.NewPolygonShape(pts...)
-
-	pushSceneTransform(s, &e.Attrs)
-	sceneApplyFillAndStroke(s, &e.Attrs, state, shape, shape)
-	popSceneTransform(s, &e.Attrs)
-}
-
-// sceneRenderPolyline renders an SVG <polyline> element to the scene.
-func sceneRenderPolyline(s *scene.Scene, e *PolylineElement, state *sceneRenderState) {
-	if len(e.Points) < 4 {
-		return
-	}
-
-	// Build a path from points (polyline = open path, not closed).
-	p := scene.NewPath()
-	for i := 0; i+1 < len(e.Points); i += 2 {
-		if i == 0 {
-			p.MoveTo(float32(e.Points[i]), float32(e.Points[i+1]))
-		} else {
-			p.LineTo(float32(e.Points[i]), float32(e.Points[i+1]))
-		}
-	}
-	shape := scene.NewPathShape(p)
-
-	pushSceneTransform(s, &e.Attrs)
-	sceneApplyFillAndStroke(s, &e.Attrs, state, shape, shape)
-	popSceneTransform(s, &e.Attrs)
-}
-
-// sceneRenderGroup renders an SVG <g> element and its children.
-func sceneRenderGroup(s *scene.Scene, e *GroupElement, state *sceneRenderState) {
-	pushSceneTransform(s, &e.Attrs)
-
-	// Create child state with inherited attrs.
-	childState := &sceneRenderState{
-		overrideColor: state.overrideColor,
-		parentFill:    state.parentFill,
-		parentStroke:  state.parentStroke,
-	}
-	if e.Attrs.Fill != "" {
-		childState.parentFill = e.Attrs.Fill
-	}
-	if e.Attrs.Stroke != "" {
-		childState.parentStroke = e.Attrs.Stroke
-	}
-
-	// Group-level opacity uses PushLayer for correct compositing.
-	hasGroupOpacity := e.Attrs.Opacity < 1.0
-	if hasGroupOpacity {
-		s.PushLayer(scene.BlendNormal, float32(e.Attrs.Opacity), nil)
-	}
-
-	sceneRenderElements(s, e.Children, childState)
-
-	if hasGroupOpacity {
-		s.PopLayer()
-	}
-
-	popSceneTransform(s, &e.Attrs)
-}
-
-// sceneApplyFillAndStroke applies fill and/or stroke to the scene for a shape.
-// Mirrors the logic of fillAndStroke in renderer.go.
-func sceneApplyFillAndStroke(
-	s *scene.Scene,
-	a *Attrs,
-	state *sceneRenderState,
-	fillShape, strokeShape scene.Shape,
-) {
-	// Use the shared state helpers via a temporary renderState adapter.
-	rs := toRenderState(state)
-	hasFill := shouldFill(a, rs)
-	hasStroke := shouldStroke(a, rs)
-
-	if !hasFill && !hasStroke {
-		// Default SVG behavior: fill with black if no fill/stroke specified.
-		if a.Fill == "" && a.Stroke == "" {
-			hasFill = true
-		}
-	}
-
-	if hasFill {
-		fillStyle := sceneFillStyle(a)
-		brush := resolveSceneFillBrush(a, state)
-		s.Fill(fillStyle, scene.IdentityAffine(), brush, fillShape)
-	}
-
-	if hasStroke {
-		brush := resolveSceneStrokeBrush(a, state)
-		style := buildSceneStrokeStyle(a)
-		s.Stroke(style, scene.IdentityAffine(), brush, strokeShape)
-	}
-}
-
-// --- Transform helpers ---
-
-// pushSceneTransform pushes the element's transform onto the scene's transform
-// stack, if the element has a transform attribute.
-func pushSceneTransform(s *scene.Scene, a *Attrs) {
-	if a.Transform == "" {
-		return
-	}
-	affine, err := parseSVGTransformAffine(a.Transform)
-	if err != nil {
-		return // silently ignore bad transforms (matching renderer.go behavior)
-	}
-	s.PushTransform(affine)
-}
-
-// popSceneTransform pops the transform if one was pushed.
-func popSceneTransform(s *scene.Scene, a *Attrs) {
-	if a.Transform == "" {
-		return
-	}
-	s.PopTransform()
-}
-
-// parseSVGTransformAffine parses an SVG transform attribute string into a
-// scene.Affine. This parallels applyTransform in transform.go but builds
-// a scene.Affine instead of modifying a gg.Context.
-func parseSVGTransformAffine(transform string) (scene.Affine, error) {
-	transform = strings.TrimSpace(transform)
-	if transform == "" {
-		return scene.IdentityAffine(), nil
-	}
-
-	result := scene.IdentityAffine()
-	pos := 0
-
-	for pos < len(transform) {
-		// Skip whitespace.
-		for pos < len(transform) && isSpace(transform[pos]) {
-			pos++
-		}
-		if pos >= len(transform) {
-			break
-		}
-
-		// Read function name.
-		nameStart := pos
-		for pos < len(transform) && transform[pos] != '(' && !isSpace(transform[pos]) {
-			pos++
-		}
-		name := transform[nameStart:pos]
-
-		// Skip whitespace before '('.
-		for pos < len(transform) && isSpace(transform[pos]) {
-			pos++
-		}
-		if pos >= len(transform) || transform[pos] != '(' {
-			return scene.IdentityAffine(), fmt.Errorf("svg: expected '(' after transform function %q", name)
-		}
-		pos++ // skip '('
-
-		// Find closing ')'.
-		parenStart := pos
-		for pos < len(transform) && transform[pos] != ')' {
-			pos++
-		}
-		if pos >= len(transform) {
-			return scene.IdentityAffine(), fmt.Errorf("svg: missing ')' in transform %q", name)
-		}
-		argsStr := transform[parenStart:pos]
-		pos++ // skip ')'
-
-		args, err := parseTransformArgsFloat32(argsStr)
-		if err != nil {
-			return scene.IdentityAffine(), fmt.Errorf("svg: transform %s: %w", name, err)
-		}
-
-		t, err := applyTransformAffine(name, args)
-		if err != nil {
-			return scene.IdentityAffine(), err
-		}
-		result = result.Multiply(t)
-	}
-
-	return result, nil
-}
-
-// applyTransformAffine builds a scene.Affine from a single SVG transform function.
-func applyTransformAffine(name string, args []float32) (scene.Affine, error) {
-	switch name {
-	case "translate":
-		if len(args) < 1 {
-			return scene.IdentityAffine(), fmt.Errorf("svg: translate requires at least 1 arg, got %d", len(args))
-		}
-		tx := args[0]
-		var ty float32
-		if len(args) >= 2 {
-			ty = args[1]
-		}
-		return scene.TranslateAffine(tx, ty), nil
-
-	case "rotate":
-		switch {
-		case len(args) == 1:
-			angle := args[0] * math.Pi / 180.0
-			return scene.RotateAffine(angle), nil
-		case len(args) >= 3:
-			angle := args[0] * math.Pi / 180.0
-			cx, cy := args[1], args[2]
-			// rotate(angle, cx, cy) = translate(cx,cy) * rotate(angle) * translate(-cx,-cy)
-			t := scene.TranslateAffine(cx, cy)
-			r := scene.RotateAffine(angle)
-			tInv := scene.TranslateAffine(-cx, -cy)
-			return t.Multiply(r).Multiply(tInv), nil
-		default:
-			return scene.IdentityAffine(), fmt.Errorf("svg: rotate requires 1 or 3 args, got %d", len(args))
-		}
-
-	case "scale":
-		if len(args) < 1 {
-			return scene.IdentityAffine(), fmt.Errorf("svg: scale requires at least 1 arg, got %d", len(args))
-		}
-		sx := args[0]
-		sy := sx
-		if len(args) >= 2 {
-			sy = args[1]
-		}
-		return scene.ScaleAffine(sx, sy), nil
-
-	case "matrix":
-		if len(args) != 6 {
-			return scene.IdentityAffine(), fmt.Errorf("svg: matrix requires 6 args, got %d", len(args))
-		}
-		// SVG matrix(a,b,c,d,e,f): x' = a*x + c*y + e, y' = b*x + d*y + f
-		// scene.Affine{A,B,C,D,E,F}: x' = A*x + B*y + C, y' = D*x + E*y + F
-		return scene.NewAffine(args[0], args[2], args[4], args[1], args[3], args[5]), nil
-
-	case "skewX":
-		if len(args) != 1 {
-			return scene.IdentityAffine(), fmt.Errorf("svg: skewX requires 1 arg, got %d", len(args))
-		}
-		angle := float32(math.Tan(float64(args[0]) * math.Pi / 180.0))
-		return scene.NewAffine(1, angle, 0, 0, 1, 0), nil
-
-	case "skewY":
-		if len(args) != 1 {
-			return scene.IdentityAffine(), fmt.Errorf("svg: skewY requires 1 arg, got %d", len(args))
-		}
-		angle := float32(math.Tan(float64(args[0]) * math.Pi / 180.0))
-		return scene.NewAffine(1, 0, 0, angle, 1, 0), nil
-
-	default:
-		return scene.IdentityAffine(), fmt.Errorf("svg: unsupported transform function %q", name)
-	}
-}
-
-// parseTransformArgsFloat32 parses comma/space-separated transform args as float32.
-func parseTransformArgsFloat32(s string) ([]float32, error) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return nil, nil
-	}
-
-	s = strings.ReplaceAll(s, ",", " ")
-	parts := strings.Fields(s)
-
-	args := make([]float32, 0, len(parts))
-	for _, p := range parts {
-		v, err := strconv.ParseFloat(p, 32)
-		if err != nil {
-			return nil, fmt.Errorf("invalid number %q: %w", p, err)
-		}
-		args = append(args, float32(v))
-	}
-	return args, nil
-}
-
-// --- Color/Brush helpers ---
-
-// colorToRGBA converts a color.Color to gg.RGBA with an opacity multiplier.
-func colorToRGBA(c color.Color, opacity float64) gg.RGBA {
-	if c == nil {
-		return gg.RGBA{R: 0, G: 0, B: 0, A: opacity}
-	}
-	r, g, b, a := c.RGBA()
-	// Un-premultiply from color.Color's premultiplied format.
-	if a == 0 {
-		return gg.RGBA{R: 0, G: 0, B: 0, A: 0}
-	}
-	fa := float64(a) / 65535.0
-	return gg.RGBA{
-		R: float64(r) / 65535.0 / fa,
-		G: float64(g) / 65535.0 / fa,
-		B: float64(b) / 65535.0 / fa,
-		A: fa * opacity,
-	}
-}
-
-// resolveSceneFillBrush creates a scene.Brush for filling, respecting override colors.
-func resolveSceneFillBrush(a *Attrs, state *sceneRenderState) scene.Brush {
-	fillStr := resolveFill(a, toRenderState(state))
-	opacity := a.FillOpacity * a.Opacity
-
-	if state.overrideColor != nil && fillStr != colorNone {
-		c := *state.overrideColor
-		c.A *= opacity
-		return scene.SolidBrush(c)
-	}
-
-	return resolveSceneBrush(fillStr, state, opacity)
-}
-
-// resolveSceneStrokeBrush creates a scene.Brush for stroking, respecting override colors.
-func resolveSceneStrokeBrush(a *Attrs, state *sceneRenderState) scene.Brush {
-	strokeStr := resolveStroke(a, toRenderState(state))
-	opacity := a.StrokeOpacity * a.Opacity
-
-	if state.overrideColor != nil && strokeStr != colorNone {
-		c := *state.overrideColor
-		c.A *= opacity
-		return scene.SolidBrush(c)
-	}
-
-	return resolveSceneBrush(strokeStr, state, opacity)
-}
-
-// resolveSceneBrush creates a scene.Brush from an SVG color string.
-func resolveSceneBrush(colorStr string, _ *sceneRenderState, opacity float64) scene.Brush {
-	c, err := parseColor(colorStr)
-	if err != nil || c == nil {
-		// Default fill is black per SVG spec.
-		return scene.SolidBrush(gg.RGBA{R: 0, G: 0, B: 0, A: opacity})
-	}
-	return scene.SolidBrush(colorToRGBA(c, opacity))
-}
-
-// sceneFillStyle converts SVG fill-rule to scene.FillStyle.
-func sceneFillStyle(a *Attrs) scene.FillStyle {
-	fillRule := a.FillRule
-	if fillRule == "" {
-		fillRule = a.ClipRule
-	}
-	if fillRule == "evenodd" {
-		return scene.FillEvenOdd
-	}
-	return scene.FillNonZero
-}
-
-// buildSceneStrokeStyle creates a scene.StrokeStyle from SVG stroke attributes.
-func buildSceneStrokeStyle(a *Attrs) *scene.StrokeStyle {
-	style := scene.DefaultStrokeStyle()
-	style.Width = float32(a.StrokeWidth)
-
-	switch a.StrokeCap {
-	case "round":
-		style.Cap = scene.LineCapRound
-	case "square":
-		style.Cap = scene.LineCapSquare
-	default:
-		style.Cap = scene.LineCapButt
-	}
-
-	switch a.StrokeJoin {
-	case "round":
-		style.Join = scene.LineJoinRound
-	case "bevel":
-		style.Join = scene.LineJoinBevel
-	default:
-		style.Join = scene.LineJoinMiter
-	}
-
-	return style
-}
-
-// toRenderState creates a temporary renderState adapter for reusing
-// shouldFill, shouldStroke, resolveFill, resolveStroke helpers.
-func toRenderState(state *sceneRenderState) *renderState {
+	root := gg.Translate(float64(x), float64(y)).
+		Multiply(gg.Scale(float64(width)/d.ViewBox.Width, float64(height)/d.ViewBox.Height)).
+		Multiply(gg.Translate(-d.ViewBox.MinX, -d.ViewBox.MinY))
 	var override color.Color
-	if state.overrideColor != nil {
-		override = state.overrideColor
+	if overrideColor == nil {
+		override = nil
+	} else {
+		override = *overrideColor
 	}
-	return &renderState{
+	state := &renderState{
 		overrideColor: override,
-		parentFill:    state.parentFill,
-		parentStroke:  state.parentStroke,
+		parentFill:    d.RootFill,
+		opacity:       1,
+		matrix:        root,
+		strokeHinting: math.Max(float64(width), float64(height)) <= strokeHintMaxCanvasSize &&
+			!strokeHintingDisabled(),
+		scaleX: float64(width) / d.ViewBox.Width,
+		scaleY: float64(height) / d.ViewBox.Height,
 	}
+	renderSceneElements(target, d.Elements, state)
+}
+
+func renderSceneElements(target *scene.Scene, elements []Element, state *renderState) {
+	for _, element := range elements {
+		renderSceneElement(target, element, state)
+	}
+}
+
+func renderSceneElement(target *scene.Scene, element Element, state *renderState) {
+	switch e := element.(type) {
+	case *PathElement:
+		if e.D == "" {
+			return
+		}
+		path, err := gg.ParseSVGPath(e.D)
+		if err == nil {
+			renderSceneGeometry(target, path, nil, &e.Attrs, state, true)
+		}
+	case *CircleElement:
+		path := gg.NewPath()
+		path.Circle(e.CX, e.CY, e.R)
+		native := scene.NewCircleShape(float32(e.CX), float32(e.CY), float32(e.R))
+		renderSceneGeometry(target, path, native, &e.Attrs, state, true)
+	case *RectElement:
+		path := gg.NewPath()
+		var native scene.Shape
+		if e.RX > 0 || e.RY > 0 {
+			radius := max(e.RX, e.RY)
+			path.RoundedRectangle(e.X, e.Y, e.W, e.H, radius)
+			native = scene.NewRoundRectShapeUniform(scene.Rect{
+				MinX: float32(e.X),
+				MinY: float32(e.Y),
+				MaxX: float32(e.X + e.W),
+				MaxY: float32(e.Y + e.H),
+			}, float32(radius))
+		} else {
+			path.Rectangle(e.X, e.Y, e.W, e.H)
+			native = scene.NewRectShape(float32(e.X), float32(e.Y), float32(e.W), float32(e.H))
+		}
+		renderSceneGeometry(target, path, native, &e.Attrs, state, true)
+	case *EllipseElement:
+		path := gg.NewPath()
+		path.Ellipse(e.CX, e.CY, e.RX, e.RY)
+		native := scene.NewEllipseShape(float32(e.CX), float32(e.CY), float32(e.RX), float32(e.RY))
+		renderSceneGeometry(target, path, native, &e.Attrs, state, true)
+	case *LineElement:
+		path := gg.NewPath()
+		path.MoveTo(e.X1, e.Y1)
+		path.LineTo(e.X2, e.Y2)
+		native := scene.NewLineShape(float32(e.X1), float32(e.Y1), float32(e.X2), float32(e.Y2))
+		renderSceneGeometry(target, path, native, &e.Attrs, state, false)
+	case *PolygonElement:
+		if path := pointsPath(e.Points, true); path != nil {
+			points := make([]float32, len(e.Points))
+			for i, point := range e.Points {
+				points[i] = float32(point)
+			}
+			renderSceneGeometry(target, path, scene.NewPolygonShape(points...), &e.Attrs, state, true)
+		}
+	case *PolylineElement:
+		if path := pointsPath(e.Points, false); path != nil {
+			renderSceneGeometry(target, path, nil, &e.Attrs, state, true)
+		}
+	case *GroupElement:
+		renderSceneGroup(target, e, state)
+	}
+}
+
+func renderSceneGroup(target *scene.Scene, group *GroupElement, state *renderState) {
+	child := *state
+	child.matrix = state.matrix.Multiply(elementTransformMatrix(&group.Attrs))
+	if group.Attrs.Fill != "" {
+		child.parentFill = group.Attrs.Fill
+	}
+	if group.Attrs.Stroke != "" {
+		child.parentStroke = group.Attrs.Stroke
+	}
+
+	layered := group.Attrs.Opacity < 1
+	if layered {
+		target.PushLayer(scene.BlendNormal, float32(group.Attrs.Opacity), nil)
+	}
+	renderSceneElements(target, group.Children, &child)
+	if layered {
+		target.PopLayer()
+	}
+}
+
+func renderSceneGeometry(
+	target *scene.Scene,
+	path *gg.Path,
+	native scene.Shape,
+	attrs *Attrs,
+	state *renderState,
+	allowFill bool,
+) {
+	complete := state.matrix.Multiply(elementTransformMatrix(attrs))
+	style := resolveStyle(attrs, state)
+	if !allowFill {
+		style.fill.present = false
+	}
+	transform := scene.AffineFromMatrix(complete)
+	if style.fill.present {
+		fillRule := scene.FillNonZero
+		if style.fill.rule == gg.FillRuleEvenOdd {
+			fillRule = scene.FillEvenOdd
+		}
+		fillShape := native
+		if fillShape == nil {
+			fillShape = scene.NewGGPathShape(path)
+		}
+		target.Fill(fillRule, transform, scene.SolidBrush(style.fill.color), fillShape)
+	}
+	if style.stroke.present {
+		strokePath := path
+		if shouldHintStroke(attrs, state) {
+			strokePath = hintSVGPath(path, state.scaleX, state.scaleY)
+		}
+		strokeShape := native
+		if strokeShape == nil || strokePath != path {
+			strokeShape = scene.NewGGPathShape(strokePath)
+		}
+		stroke := &scene.StrokeStyle{
+			Width:      float32(style.stroke.width),
+			MiterLimit: 10,
+			Cap:        sceneLineCap(style.stroke.cap),
+			Join:       sceneLineJoin(style.stroke.join),
+		}
+		target.Stroke(stroke, transform, scene.SolidBrush(style.stroke.color), strokeShape)
+	}
+}
+
+func sceneLineCap(lineCap gg.LineCap) scene.LineCap {
+	switch lineCap {
+	case gg.LineCapRound:
+		return scene.LineCapRound
+	case gg.LineCapSquare:
+		return scene.LineCapSquare
+	default:
+		return scene.LineCapButt
+	}
+}
+
+func sceneLineJoin(join gg.LineJoin) scene.LineJoin {
+	switch join {
+	case gg.LineJoinRound:
+		return scene.LineJoinRound
+	case gg.LineJoinBevel:
+		return scene.LineJoinBevel
+	default:
+		return scene.LineJoinMiter
+	}
+}
+
+// parseSVGTransformAffine preserves the retained-renderer helper while sharing
+// the immediate renderer's transform parser and composition semantics.
+func parseSVGTransformAffine(value string) (scene.Affine, error) {
+	matrix, err := transformMatrix(value)
+	return scene.AffineFromMatrix(matrix), err
 }

--- a/svg/scene_test.go
+++ b/svg/scene_test.go
@@ -1,0 +1,225 @@
+package svg
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"reflect"
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/scene"
+)
+
+const sceneSemanticSVG = `<svg viewBox="1 2 10 20" fill="none">
+<g transform="translate(2 3)" fill="#102030" stroke="#405060">
+  <path d="M0 0 L1 0 Q2 1 3 0 C4 0 5 1 6 0 A2 2 0 0 1 8 2 Z" fill-rule="evenodd" fill-opacity=".5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="bevel" stroke-opacity=".25"/>
+  <circle cx="2" cy="2" r="1"/><rect x="0" y="0" width="2" height="3" rx=".5"/>
+  <ellipse cx="3" cy="4" rx="2" ry="1"/><line x1="0" y1="1" x2="2" y2="1"/>
+  <polygon points="0,0 2,0 1,2"/><polyline points="0,0 1,1 2,0"/>
+</g></svg>`
+
+func TestRenderToSceneContract(t *testing.T) {
+	doc, err := Parse([]byte(sceneSemanticSVG))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc.RenderToScene(nil, 0, 0, 16, 16)
+	var nilDoc *Document
+	nilDoc.RenderToScene(scene.NewScene(), 0, 0, 16, 16)
+	for _, target := range []struct{ width, height float32 }{
+		{width: 0, height: 16}, {width: 16, height: 0}, {width: -1, height: 16},
+	} {
+		s := scene.NewScene()
+		doc.RenderToScene(s, 0, 0, target.width, target.height)
+		if len(s.Encoding().Tags()) != 0 {
+			t.Fatalf("invalid target %+v emitted commands", target)
+		}
+	}
+
+	s := scene.NewScene()
+	doc.RenderToScene(s, 4, 5, 20, 40)
+	tags := s.Encoding().Tags()
+	if !containsTag(tags, scene.TagFill) || !containsTag(tags, scene.TagStroke) {
+		t.Fatalf("tags %v do not contain fill and stroke", tags)
+	}
+	if containsTag(tags, scene.TagImage) {
+		t.Fatalf("retained SVG emitted image tag: %v", tags)
+	}
+
+	invalidDoc := *doc
+	invalidDoc.ViewBox.Width = 0
+	invalidScene := scene.NewScene()
+	invalidDoc.RenderToScene(invalidScene, 0, 0, 16, 16)
+	if len(invalidScene.Encoding().Tags()) != 0 {
+		t.Fatal("non-positive viewBox emitted commands")
+	}
+}
+
+func TestRenderToScenePreservesNativeRoundRect(t *testing.T) {
+	doc, err := Parse([]byte(`<svg viewBox="0 0 20 20"><rect x="2" y="3" width="16" height="14" rx="4" fill="#3979c3"/></svg>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := scene.NewScene()
+	doc.RenderToScene(s, 0, 0, 20, 20)
+	if tags := s.Encoding().Tags(); !containsTag(tags, scene.TagFillRoundRect) {
+		t.Fatalf("rounded rectangle lost native retained encoding: tags=%v", tags)
+	}
+}
+
+func TestRenderToSceneTransformStyleAndOverride(t *testing.T) {
+	doc, err := Parse([]byte(sceneSemanticSVG))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := scene.NewScene()
+	doc.RenderToSceneWithColor(s, 4, 5, 20, 40,
+		gg.FromColor(color.NRGBA{R: 200, G: 100, B: 50, A: 128}))
+
+	dec := scene.NewDecoder(s.Encoding())
+	var gotTransform scene.Affine
+	var gotFill bool
+	var gotStroke bool
+	var sawQuad, sawCubic, sawClose bool
+	for dec.Next() {
+		switch dec.Tag() {
+		case scene.TagTransform:
+			if gotTransform == (scene.Affine{}) {
+				gotTransform = dec.Transform()
+			} else {
+				_ = dec.Transform()
+			}
+		case scene.TagMoveTo:
+			_, _ = dec.MoveTo()
+		case scene.TagLineTo:
+			_, _ = dec.LineTo()
+		case scene.TagQuadTo:
+			sawQuad = true
+			_, _, _, _ = dec.QuadTo()
+		case scene.TagCubicTo:
+			sawCubic = true
+			_, _, _, _, _, _ = dec.CubicTo()
+		case scene.TagClosePath:
+			sawClose = true
+		case scene.TagFill:
+			brush, style := dec.Fill()
+			if !gotFill {
+				gotFill = true
+				if style != scene.FillEvenOdd {
+					t.Errorf("fill rule=%v, want evenodd", style)
+				}
+				if brush.Color.A < .24 || brush.Color.A > .26 {
+					t.Errorf("override fill alpha=%g, want about .25", brush.Color.A)
+				}
+			}
+		case scene.TagStroke:
+			brush, style := dec.Stroke()
+			if !gotStroke {
+				gotStroke = true
+				if style.Width != 1.5 || style.Cap != scene.LineCapRound || style.Join != scene.LineJoinBevel {
+					t.Errorf("stroke style=%+v", style)
+				}
+				if brush.Color.A < .12 || brush.Color.A > .13 {
+					t.Errorf("override stroke alpha=%g, want about .125", brush.Color.A)
+				}
+			}
+		}
+	}
+	// Root: translate(4,5)*scale(2,2)*translate(-1,-2), group translate(2,3).
+	want := scene.NewAffine(2, 0, 6, 0, 2, 7)
+	if gotTransform != want {
+		t.Errorf("first transform=%+v, want %+v", gotTransform, want)
+	}
+	if !gotFill || !gotStroke || !sawQuad || !sawCubic || !sawClose {
+		t.Errorf("semantic commands fill=%v stroke=%v quad=%v cubic=%v close=%v", gotFill, gotStroke, sawQuad, sawCubic, sawClose)
+	}
+}
+
+func TestRenderToSceneDeterministic(t *testing.T) {
+	doc, err := Parse([]byte(sceneSemanticSVG))
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, b := scene.NewScene(), scene.NewScene()
+	doc.RenderToScene(a, .25, .75, 24, 24)
+	doc.RenderToScene(b, .25, .75, 24, 24)
+	ea, eb := a.Encoding(), b.Encoding()
+	if !reflect.DeepEqual(ea.Tags(), eb.Tags()) || !reflect.DeepEqual(ea.PathData(), eb.PathData()) ||
+		!reflect.DeepEqual(ea.DrawData(), eb.DrawData()) || !reflect.DeepEqual(ea.Transforms(), eb.Transforms()) ||
+		!reflect.DeepEqual(ea.Brushes(), eb.Brushes()) {
+		t.Fatal("repeated lowering was not deterministic")
+	}
+}
+
+func TestRenderToSceneImmediateParity(t *testing.T) {
+	doc, err := Parse([]byte(`<svg viewBox="0 0 16 16"><path fill="#3979c3" fill-opacity=".7" d="M2 2h12v5H9v7H2z"/></svg>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, size := range []int{16, 32, 64} {
+		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+			immediate := gg.NewContext(size+4, size+4)
+			doc.RenderTo(immediate, 1.25, .75, float64(size), float64(size))
+
+			retained := gg.NewContext(size+4, size+4)
+			s := scene.NewScene()
+			doc.RenderToScene(s, 1.25, .75, float32(size), float32(size))
+			if err := scene.NewGPUSceneRenderer(retained).RenderScene(s); err != nil {
+				t.Fatal(err)
+			}
+			assertImagesNear(t, immediate.Image(), retained.Image(), 2)
+		})
+	}
+}
+
+func containsTag(tags []scene.Tag, wanted scene.Tag) bool {
+	for _, tag := range tags {
+		if tag == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func assertImagesNear(t *testing.T, a, b interface {
+	Bounds() image.Rectangle
+	At(int, int) color.Color
+}, tolerance uint32) {
+	t.Helper()
+	if a.Bounds() != b.Bounds() {
+		t.Fatalf("bounds differ: %v vs %v", a.Bounds(), b.Bounds())
+	}
+	for y := a.Bounds().Min.Y; y < a.Bounds().Max.Y; y++ {
+		for x := a.Bounds().Min.X; x < a.Bounds().Max.X; x++ {
+			ar, ag, ab, aa := a.At(x, y).RGBA()
+			br, bg, bb, ba := b.At(x, y).RGBA()
+			for _, pair := range [][2]uint32{{ar, br}, {ag, bg}, {ab, bb}, {aa, ba}} {
+				delta := pair[0]
+				if pair[1] > delta {
+					delta = pair[1] - delta
+				} else {
+					delta -= pair[1]
+				}
+				if delta > tolerance*257 {
+					t.Fatalf("pixel (%d,%d) differs beyond %d: %v vs %v", x, y, tolerance, a.At(x, y), b.At(x, y))
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkSVGScene(b *testing.B) {
+	doc, err := Parse([]byte(sceneSemanticSVG))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		s := scene.NewScene()
+		doc.RenderToScene(s, 0, 0, 24, 24)
+	}
+}

--- a/svg/svg.go
+++ b/svg/svg.go
@@ -60,7 +60,7 @@ func (d *Document) RenderToWithColor(dc *gg.Context, x, y, width, height float64
 
 // renderInternal is the shared rendering implementation.
 func (d *Document) renderInternal(dc *gg.Context, x, y, width, height float64, overrideColor color.Color) {
-	if d.ViewBox.Width <= 0 || d.ViewBox.Height <= 0 {
+	if d == nil || dc == nil || d.ViewBox.Width <= 0 || d.ViewBox.Height <= 0 || width <= 0 || height <= 0 {
 		return
 	}
 
@@ -97,6 +97,8 @@ func (d *Document) renderInternal(dc *gg.Context, x, y, width, height float64, o
 		strokeHinting: hinting,
 		scaleX:        sx,
 		scaleY:        sy,
+		opacity:       1,
+		matrix:        dc.GetTransform(),
 	}
 
 	renderElements(dc, d.Elements, state)

--- a/svg/svg_test.go
+++ b/svg/svg_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"math"
 	"testing"
+
+	"github.com/gogpu/gg"
 )
 
 // Real JetBrains SVG icons (Apache 2.0 license) for testing.
@@ -293,6 +296,26 @@ func TestParseTransformArgs(t *testing.T) {
 				t.Errorf("len(args) = %d, want %d", len(args), tt.want)
 			}
 		})
+	}
+}
+
+func TestTransformMatrixCompositionAndBestEffort(t *testing.T) {
+	m, err := transformMatrix("translate(10 20) scale(2) rotate(90 1 1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := m.TransformPoint(gg.Pt(1, 1))
+	if math.Abs(p.X-12) > 1e-9 || math.Abs(p.Y-22) > 1e-9 {
+		t.Fatalf("composed point=%+v, want (12,22)", p)
+	}
+
+	partial, err := transformMatrix("translate(3 4) unsupported(1) scale(9)")
+	if err == nil {
+		t.Fatal("unsupported transform returned nil error")
+	}
+	p = partial.TransformPoint(gg.Pt(1, 2))
+	if p != (gg.Point{X: 4, Y: 6}) {
+		t.Fatalf("best-effort point=%+v, want (4,6)", p)
 	}
 }
 

--- a/svg/transform.go
+++ b/svg/transform.go
@@ -9,19 +9,20 @@ import (
 	"github.com/gogpu/gg"
 )
 
-// applyTransform parses an SVG transform attribute string and applies
-// the transforms to the given gg.Context. Multiple transforms are
-// applied left-to-right (as specified by SVG).
+// transformMatrix parses an SVG transform list into a matrix. The returned
+// matrix includes all valid transforms before an error, preserving the
+// renderer's historical best-effort handling of malformed lists.
 //
 // Supported transform functions:
 //   - translate(tx [, ty])
 //   - rotate(angle [, cx, cy]) — angle in degrees
 //   - scale(sx [, sy])
 //   - matrix(a, b, c, d, e, f)
-func applyTransform(dc *gg.Context, transform string) error {
+func transformMatrix(transform string) (gg.Matrix, error) {
+	m := gg.Identity()
 	transform = strings.TrimSpace(transform)
 	if transform == "" {
-		return nil
+		return m, nil
 	}
 
 	// Parse sequence of transform functions: "translate(1 3) rotate(-45 3 3)"
@@ -47,7 +48,7 @@ func applyTransform(dc *gg.Context, transform string) error {
 			pos++
 		}
 		if pos >= len(transform) || transform[pos] != '(' {
-			return fmt.Errorf("svg: expected '(' after transform function %q", name)
+			return m, fmt.Errorf("svg: expected '(' after transform function %q", name)
 		}
 		pos++ // skip '('
 
@@ -57,7 +58,7 @@ func applyTransform(dc *gg.Context, transform string) error {
 			pos++
 		}
 		if pos >= len(transform) {
-			return fmt.Errorf("svg: missing ')' in transform %q", name)
+			return m, fmt.Errorf("svg: missing ')' in transform %q", name)
 		}
 		argsStr := transform[parenStart:pos]
 		pos++ // skip ')'
@@ -65,88 +66,89 @@ func applyTransform(dc *gg.Context, transform string) error {
 		// Parse args.
 		args, err := parseTransformArgs(argsStr)
 		if err != nil {
-			return fmt.Errorf("svg: transform %s: %w", name, err)
+			return m, fmt.Errorf("svg: transform %s: %w", name, err)
 		}
 
-		if err := applyTransformFunc(dc, name, args); err != nil {
-			return err
+		part, err := transformFuncMatrix(name, args)
+		if err != nil {
+			return m, err
 		}
+		m = m.Multiply(part)
 	}
-	return nil
+	return m, nil
 }
 
-// applyTransformFunc applies a single transform function with parsed arguments.
-func applyTransformFunc(dc *gg.Context, name string, args []float64) error {
+// transformFuncMatrix returns one SVG transform function as a gg matrix.
+func transformFuncMatrix(name string, args []float64) (gg.Matrix, error) {
 	switch name {
 	case "translate":
 		if len(args) < 1 {
-			return fmt.Errorf("svg: translate requires at least 1 arg, got %d", len(args))
+			return gg.Identity(), fmt.Errorf("svg: translate requires at least 1 arg, got %d", len(args))
 		}
 		tx := args[0]
 		ty := 0.0
 		if len(args) >= 2 {
 			ty = args[1]
 		}
-		dc.Translate(tx, ty)
+		return gg.Translate(tx, ty), nil
 
 	case "rotate":
 		switch {
 		case len(args) == 1:
 			// rotate(angle) — angle in degrees, about origin
-			dc.Rotate(args[0] * math.Pi / 180.0)
+			return gg.Rotate(args[0] * math.Pi / 180.0), nil
 		case len(args) >= 3:
-			// rotate(angle, cx, cy) — rotate about (cx, cy)
-			dc.RotateAbout(args[0]*math.Pi/180.0, args[1], args[2])
+			angle := args[0] * math.Pi / 180.0
+			return gg.Translate(args[1], args[2]).Multiply(gg.Rotate(angle)).Multiply(gg.Translate(-args[1], -args[2])), nil
 		default:
-			return fmt.Errorf("svg: rotate requires 1 or 3 args, got %d", len(args))
+			return gg.Identity(), fmt.Errorf("svg: rotate requires 1 or 3 args, got %d", len(args))
 		}
 
 	case "scale":
 		if len(args) < 1 {
-			return fmt.Errorf("svg: scale requires at least 1 arg, got %d", len(args))
+			return gg.Identity(), fmt.Errorf("svg: scale requires at least 1 arg, got %d", len(args))
 		}
 		sx := args[0]
 		sy := sx
 		if len(args) >= 2 {
 			sy = args[1]
 		}
-		dc.Scale(sx, sy)
+		return gg.Scale(sx, sy), nil
 
 	case "matrix":
 		if len(args) != 6 {
-			return fmt.Errorf("svg: matrix requires 6 args, got %d", len(args))
+			return gg.Identity(), fmt.Errorf("svg: matrix requires 6 args, got %d", len(args))
 		}
 		// SVG matrix(a,b,c,d,e,f): x' = a*x + c*y + e, y' = b*x + d*y + f
 		// gg Matrix{A,B,C,D,E,F}: x' = A*x + B*y + C, y' = D*x + E*y + F
-		dc.Transform(gg.Matrix{
+		return gg.Matrix{
 			A: args[0], B: args[2], C: args[4],
 			D: args[1], E: args[3], F: args[5],
-		})
+		}, nil
 
 	case "skewX":
 		if len(args) != 1 {
-			return fmt.Errorf("svg: skewX requires 1 arg, got %d", len(args))
+			return gg.Identity(), fmt.Errorf("svg: skewX requires 1 arg, got %d", len(args))
 		}
 		angle := args[0] * math.Pi / 180.0
-		dc.Transform(gg.Matrix{
+		return gg.Matrix{
 			A: 1, B: math.Tan(angle), C: 0,
 			D: 0, E: 1, F: 0,
-		})
+		}, nil
 
 	case "skewY":
 		if len(args) != 1 {
-			return fmt.Errorf("svg: skewY requires 1 arg, got %d", len(args))
+			return gg.Identity(), fmt.Errorf("svg: skewY requires 1 arg, got %d", len(args))
 		}
 		angle := args[0] * math.Pi / 180.0
-		dc.Transform(gg.Matrix{
+		return gg.Matrix{
 			A: 1, B: 0, C: 0,
 			D: math.Tan(angle), E: 1, F: 0,
-		})
+		}, nil
 
 	default:
-		return fmt.Errorf("svg: unsupported transform function %q", name)
+		return gg.Identity(), fmt.Errorf("svg: unsupported transform function %q", name)
 	}
-	return nil
 }
 
 // parseTransformArgs splits a comma/space-separated argument string into float64 values.

--- a/svg/transform_boundary_test.go
+++ b/svg/transform_boundary_test.go
@@ -1,0 +1,110 @@
+package svg
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/gogpu/gg"
+)
+
+func TestTransformMatrixSupportedForms(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  gg.Matrix
+	}{
+		{name: "empty", input: "", want: gg.Identity()},
+		{name: "translate x only", input: "translate(3)", want: gg.Translate(3, 0)},
+		{name: "translate x y", input: "translate(3 4)", want: gg.Translate(3, 4)},
+		{name: "rotate origin", input: "rotate(90)", want: gg.Rotate(math.Pi / 2)},
+		{
+			name:  "rotate about point",
+			input: "rotate(90 2 3)",
+			want: gg.Translate(2, 3).Multiply(gg.Rotate(math.Pi / 2)).
+				Multiply(gg.Translate(-2, -3)),
+		},
+		{name: "uniform scale", input: "scale(2)", want: gg.Scale(2, 2)},
+		{name: "nonuniform scale", input: "scale(2 3)", want: gg.Scale(2, 3)},
+		{
+			name:  "svg matrix ordering",
+			input: "matrix(1 2 3 4 5 6)",
+			want:  gg.Matrix{A: 1, B: 3, C: 5, D: 2, E: 4, F: 6},
+		},
+		{
+			name:  "skew x",
+			input: "skewX(45)",
+			want:  gg.Matrix{A: 1, B: 1, E: 1},
+		},
+		{
+			name:  "skew y",
+			input: "skewY(45)",
+			want:  gg.Matrix{A: 1, D: 1, E: 1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := transformMatrix(test.input)
+			if err != nil {
+				t.Fatalf("transformMatrix(%q): %v", test.input, err)
+			}
+			assertMatrixNear(t, got, test.want)
+		})
+	}
+
+	got, err := transformMatrix("translate(1 2) \n scale (2 3)")
+	if err != nil {
+		t.Fatalf("whitespace-separated transform list: %v", err)
+	}
+	assertMatrixNear(t, got, gg.Translate(1, 2).Multiply(gg.Scale(2, 3)))
+}
+
+func TestTransformMatrixRejectsMalformedForms(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		message string
+		want    gg.Matrix
+	}{
+		{name: "missing open parenthesis", input: "translate 1", message: "expected '('", want: gg.Identity()},
+		{name: "missing close parenthesis", input: "translate(1", message: "missing ')'", want: gg.Identity()},
+		{name: "invalid number", input: "translate(nope)", message: "invalid number", want: gg.Identity()},
+		{name: "translate arity", input: "translate()", message: "translate requires", want: gg.Identity()},
+		{name: "rotate arity", input: "rotate(1 2)", message: "rotate requires", want: gg.Identity()},
+		{name: "scale arity", input: "scale()", message: "scale requires", want: gg.Identity()},
+		{name: "matrix arity", input: "matrix(1 2 3)", message: "matrix requires", want: gg.Identity()},
+		{name: "skew x arity", input: "skewX(1 2)", message: "skewX requires", want: gg.Identity()},
+		{name: "skew y arity", input: "skewY()", message: "skewY requires", want: gg.Identity()},
+		{name: "unsupported", input: "perspective(1)", message: "unsupported transform", want: gg.Identity()},
+		{
+			name: "preserves valid prefix", input: "translate(4 5) scale()", message: "scale requires",
+			want: gg.Translate(4, 5),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := transformMatrix(test.input)
+			if err == nil || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("transformMatrix(%q) error=%v, want containing %q", test.input, err, test.message)
+			}
+			assertMatrixNear(t, got, test.want)
+		})
+	}
+
+	args, err := parseTransformArgs(" \t\n ")
+	if err != nil || args != nil {
+		t.Fatalf("parseTransformArgs(whitespace)=(%v,%v), want (nil,nil)", args, err)
+	}
+}
+
+func assertMatrixNear(t *testing.T, got, want gg.Matrix) {
+	t.Helper()
+	gotValues := [...]float64{got.A, got.B, got.C, got.D, got.E, got.F}
+	wantValues := [...]float64{want.A, want.B, want.C, want.D, want.E, want.F}
+	for i := range gotValues {
+		if math.Abs(gotValues[i]-wantValues[i]) > 1e-12 {
+			t.Fatalf("matrix=%+v, want %+v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add a retained-vector lowering path for parsed SVG documents:

- introduce `Document.RenderToScene` with explicit logical destination bounds and optional color override
- convert supported paths and primitives into ordinary `scene.Fill` / `scene.Stroke` commands
- share geometry construction, transform composition, and style resolution with the immediate renderer
- preserve fill rules, opacity, stroke width/cap/join, nested groups, and SVG transforms
- keep documents reusable across sizes without recording `TagImage` commands

## Why

The existing SVG API rasterizes into a fixed-size image before scene composition. That locks resolution early and makes non-integer scaling depend on bitmap filtering. Retaining paths and paint commands lets the final Scene backend rasterize at the actual display resolution.

## Design

`RenderToScene` deliberately uses the existing generic Scene protocol rather than adding SVG-specific commands. Unsupported parser features remain unchanged; this PR only lowers the subset already represented by `svg.Document`.

The immediate and retained routes use the same private geometry/style/transform core so semantic fixes do not drift between renderers.

## Validation

- `go test ./svg -run 'Test.*(Scene|Render|Transform|Fill|Stroke)' -count=1`
- `go test -race ./svg -count=1`
- `go test ./scene ./svg -count=1`
- `go vet ./...`
- `go build ./...`
- `go test -tags nogpu ./... -count=1`
- `BenchmarkSVGScene`: 12.985 µs/op, 19,848 B/op, 110 allocs/op on Apple M1

Tests cover every supported element type, path verbs including arc-derived cubics, nested transforms, fill/stroke semantics, color overrides, deterministic repeated lowering, immediate/retained pixel parity at multiple sizes, nil/invalid inputs, and the invariant that no image command is emitted.

## Scope and follow-up

This is the `gogpu/gg` API half of #464. The `gogpu/ui` full-icon migration is intentionally a dependent follow-up after this API is available from gg; it cannot be included in a cross-repository PR without making ui depend on an unpublished module revision.

Part of #464.
