### PR TITLE
fix(svg): hint thin strokes at small physical sizes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -437,6 +437,7 @@ gg/
 │   ├── parser.go           # SVG XML parser → Document tree
 │   ├── renderer.go         # Shared geometry/transform/style resolution
 │   ├── scene_renderer.go   # Document.RenderToScene retained Fill/Stroke lowering
+│   ├── hinting.go          # Conservative small-stroke device-grid snapping
 │   ├── colors.go           # SVG color parsing (#hex, rgb(), named)
 │   ├── transform.go        # SVG transform parsing (translate, rotate, scale)
 │   └── document.go         # Document, Element types

--- a/svg/doc.go
+++ b/svg/doc.go
@@ -40,6 +40,7 @@
 //	s := scene.NewScene()
 //	doc.RenderToScene(s, 0, 0, 24, 24)
 //
-// RenderToScene keeps geometry vector-based so the Scene renderer resolves it
-// at the final display resolution.
+// RenderToScene keeps geometry vector-based. For targets no larger than 32
+// physical pixels it conservatively aligns thin horizontal and vertical stroke
+// centers when the complete transform is translation plus uniform axis scale.
 package svg

--- a/svg/hinting.go
+++ b/svg/hinting.go
@@ -1,0 +1,211 @@
+package svg
+
+import (
+	"math"
+	"os"
+
+	"github.com/gogpu/gg"
+)
+
+// strokeHintPolicy is deliberately local to SVG lowering. Generic gg paths and
+// Scene commands remain independent of target size and pixel alignment.
+type strokeHintPolicy struct {
+	physical gg.Matrix
+	eligible bool
+	scale    float64
+}
+
+func newStrokeHintPolicy(width, height, deviceScale float64, transform gg.Matrix) strokeHintPolicy {
+	if strokeHintingDisabled() {
+		return strokeHintPolicy{}
+	}
+	if deviceScale <= 0 {
+		deviceScale = 1
+	}
+	if width <= 0 || height <= 0 || math.Max(width*deviceScale, height*deviceScale) > 32 {
+		return strokeHintPolicy{}
+	}
+
+	// Only translation plus a uniform, axis-preserving scale is safe: a
+	// perpendicular SVG coordinate must still be perpendicular in device space.
+	sx, sy := math.Abs(transform.A), math.Abs(transform.E)
+	if transform.B != 0 || transform.D != 0 || sx == 0 || sy == 0 || sx != sy {
+		return strokeHintPolicy{}
+	}
+
+	physical := gg.Scale(deviceScale, deviceScale).Multiply(transform)
+	return strokeHintPolicy{physical: physical, eligible: true, scale: sx * deviceScale}
+}
+
+func strokeHintingDisabled() bool {
+	return os.Getenv("GOGPU_SVG_NO_HINT") != ""
+}
+
+func (p strokeHintPolicy) permits(strokeWidth float64) bool {
+	physicalWidth := strokeWidth * p.scale
+	return p.eligible && physicalWidth > 0 && physicalWidth <= 1.5
+}
+
+type hintCommand struct {
+	verb   gg.PathVerb
+	coords []float64
+}
+
+type hintPoint struct {
+	command int
+	blocked bool
+}
+
+type hintSegment struct {
+	from, to   int
+	horizontal bool
+	vertical   bool
+}
+
+type hintPathBuilder struct {
+	policy       strokeHintPolicy
+	commands     []hintCommand
+	points       []hintPoint
+	segments     []hintSegment
+	current      int
+	subpathStart int
+}
+
+func newHintPathBuilder(capacity int, policy strokeHintPolicy) *hintPathBuilder {
+	return &hintPathBuilder{
+		policy:       policy,
+		commands:     make([]hintCommand, 0, capacity),
+		points:       make([]hintPoint, 0, capacity),
+		segments:     make([]hintSegment, 0, capacity),
+		current:      -1,
+		subpathStart: -1,
+	}
+}
+
+// hintStrokePath returns an independent stroke path. Ineligible input is
+// returned unchanged; eligible input is copied even when it has no cardinal
+// segments, which makes source immutability explicit at the lowering boundary.
+func hintStrokePath(path *gg.Path, policy strokeHintPolicy, strokeWidth float64) *gg.Path {
+	if path == nil || !policy.permits(strokeWidth) {
+		return path
+	}
+
+	builder := newHintPathBuilder(path.NumVerbs(), policy)
+	path.Iterate(func(verb gg.PathVerb, coords []float64) {
+		builder.addCommand(verb, coords)
+	})
+
+	for _, segment := range builder.segments {
+		if builder.points[segment.from].blocked || builder.points[segment.to].blocked {
+			continue
+		}
+		if segment.horizontal {
+			snapHintPoint(builder.commands, builder.points[segment.from], policy.physical, false)
+			snapHintPoint(builder.commands, builder.points[segment.to], policy.physical, false)
+		}
+		if segment.vertical {
+			snapHintPoint(builder.commands, builder.points[segment.from], policy.physical, true)
+			snapHintPoint(builder.commands, builder.points[segment.to], policy.physical, true)
+		}
+	}
+	return buildHintedPath(builder.commands)
+}
+
+func (b *hintPathBuilder) addCommand(verb gg.PathVerb, coords []float64) {
+	b.commands = append(b.commands, hintCommand{verb: verb, coords: append([]float64(nil), coords...)})
+	commandIndex := len(b.commands) - 1
+
+	switch verb {
+	case gg.MoveTo:
+		b.points = append(b.points, hintPoint{command: commandIndex})
+		b.current = len(b.points) - 1
+		b.subpathStart = b.current
+	case gg.LineTo:
+		b.addLine(commandIndex)
+	case gg.QuadTo, gg.CubicTo:
+		b.blockCurveEndpoint()
+	case gg.Close:
+		b.closeSubpath()
+	}
+}
+
+func (b *hintPathBuilder) addLine(commandIndex int) {
+	b.points = append(b.points, hintPoint{command: commandIndex})
+	destination := len(b.points) - 1
+	if b.current >= 0 {
+		// A zero-length line blocks its node just like any other non-cardinal line.
+		b.connect(b.current, destination, true)
+	}
+	b.current = destination
+}
+
+func (b *hintPathBuilder) blockCurveEndpoint() {
+	if b.current >= 0 {
+		b.points[b.current].blocked = true
+	}
+	// A curve endpoint is intentionally not exposed as a snappable node.
+	b.current = -1
+}
+
+func (b *hintPathBuilder) closeSubpath() {
+	if b.current >= 0 && b.subpathStart >= 0 {
+		// A coincident close is structural rather than a zero-length line.
+		b.connect(b.current, b.subpathStart, false)
+	}
+	b.current = b.subpathStart
+}
+
+func (b *hintPathBuilder) connect(fromIndex, toIndex int, blockCoincident bool) {
+	from := b.physicalPoint(fromIndex)
+	to := b.physicalPoint(toIndex)
+	horizontal := from.Y == to.Y && from.X != to.X
+	vertical := from.X == to.X && from.Y != to.Y
+	b.segments = append(b.segments, hintSegment{
+		from: fromIndex, to: toIndex, horizontal: horizontal, vertical: vertical,
+	})
+	if !horizontal && !vertical && (blockCoincident || from != to) {
+		b.points[fromIndex].blocked = true
+		b.points[toIndex].blocked = true
+	}
+}
+
+func (b *hintPathBuilder) physicalPoint(pointIndex int) gg.Point {
+	coords := b.commands[b.points[pointIndex].command].coords
+	return b.policy.physical.TransformPoint(gg.Pt(coords[len(coords)-2], coords[len(coords)-1]))
+}
+
+func buildHintedPath(commands []hintCommand) *gg.Path {
+	result := gg.NewPath()
+	for _, command := range commands {
+		switch command.verb {
+		case gg.MoveTo:
+			result.MoveTo(command.coords[0], command.coords[1])
+		case gg.LineTo:
+			result.LineTo(command.coords[0], command.coords[1])
+		case gg.QuadTo:
+			result.QuadraticTo(command.coords[0], command.coords[1], command.coords[2], command.coords[3])
+		case gg.CubicTo:
+			result.CubicTo(command.coords[0], command.coords[1], command.coords[2], command.coords[3], command.coords[4], command.coords[5])
+		case gg.Close:
+			result.Close()
+		}
+	}
+	return result
+}
+
+func snapHintPoint(commands []hintCommand, point hintPoint, physical gg.Matrix, xAxis bool) {
+	coords := commands[point.command].coords
+	x, y := coords[len(coords)-2], coords[len(coords)-1]
+	device := physical.TransformPoint(gg.Pt(x, y))
+	if xAxis {
+		device.X = snapPixelCenter(device.X)
+		coords[len(coords)-2] = (device.X - physical.C) / physical.A
+	} else {
+		device.Y = snapPixelCenter(device.Y)
+		coords[len(coords)-1] = (device.Y - physical.F) / physical.E
+	}
+}
+
+func snapPixelCenter(value float64) float64 {
+	return math.Floor(value) + 0.5
+}

--- a/svg/hinting_test.go
+++ b/svg/hinting_test.go
@@ -1,0 +1,175 @@
+package svg
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/gogpu/gg"
+)
+
+func TestHintPolicyTargetAndWidthBoundaries(t *testing.T) {
+	for _, target := range []float64{16, 24, 32, 33} {
+		for _, width := range []float64{0, .99, 1, 1.5, 1.5001} {
+			policy := newStrokeHintPolicy(target, target, 1, gg.Identity())
+			want := target <= 32 && width > 0 && width <= 1.5
+			if got := policy.permits(width); got != want {
+				t.Errorf("target=%g width=%g permits=%v, want %v", target, width, got, want)
+			}
+		}
+	}
+}
+
+func TestHintPolicyDefaultsInvalidDeviceScale(t *testing.T) {
+	for _, deviceScale := range []float64{0, -1} {
+		policy := newStrokeHintPolicy(16, 16, deviceScale, gg.Identity())
+		if !policy.permits(1) || policy.scale != 1 {
+			t.Fatalf("deviceScale=%g produced policy=%#v, want eligible 1x policy", deviceScale, policy)
+		}
+	}
+}
+
+func TestHintPolicyTransformEligibility(t *testing.T) {
+	tests := []struct {
+		name string
+		m    gg.Matrix
+		want bool
+	}{
+		{"translation", gg.Translate(2, -3), true},
+		{"uniform", gg.Translate(1, 2).Multiply(gg.Scale(2, 2)), true},
+		{"reflection", gg.Translate(1, 2).Multiply(gg.Scale(-2, 2)), true},
+		{"nonuniform", gg.Scale(2, 3), false},
+		{"rotation", gg.Rotate(math.Pi / 8), false},
+		{"shear", gg.Shear(.2, 0), false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := newStrokeHintPolicy(16, 16, 1, test.m).permits(.5)
+			if got != test.want {
+				t.Fatalf("permits=%v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestHintStrokePathSnapsCardinalCenters(t *testing.T) {
+	path := gg.NewPath()
+	path.MoveTo(-1.2, 2.2)
+	path.LineTo(3.8, 2.2)
+	path.MoveTo(-2.2, -3.8)
+	path.LineTo(-2.2, 4.1)
+	original := append([]float64(nil), path.Coords()...)
+	policy := newStrokeHintPolicy(16, 16, 1, gg.Translate(.25, -.25))
+
+	hinted := hintStrokePath(path, policy, 1)
+	want := []float64{-1.2, 1.75, 3.8, 1.75, -1.75, -3.8, -1.75, 4.1}
+	if !reflect.DeepEqual(hinted.Coords(), want) {
+		t.Fatalf("hinted coords=%v, want %v", hinted.Coords(), want)
+	}
+	if !reflect.DeepEqual(path.Coords(), original) {
+		t.Fatalf("source mutated: got %v, want %v", path.Coords(), original)
+	}
+
+	twice := hintStrokePath(hinted, policy, 1)
+	if !reflect.DeepEqual(twice.Coords(), hinted.Coords()) {
+		t.Fatalf("hinting not idempotent: once=%v twice=%v", hinted.Coords(), twice.Coords())
+	}
+}
+
+func TestHintStrokePathPreservesIneligibleAndNonCardinalGeometry(t *testing.T) {
+	path := gg.NewPath()
+	path.MoveTo(.2, .3)
+	path.LineTo(2.2, 2.3)
+	path.QuadraticTo(3, 4, 5, 6)
+	path.CubicTo(7, 8, 9, 10, 11, 12)
+	path.Close()
+	coords := append([]float64(nil), path.Coords()...)
+	verbs := append([]gg.PathVerb(nil), path.Verbs()...)
+
+	for _, policy := range []strokeHintPolicy{
+		newStrokeHintPolicy(33, 33, 1, gg.Identity()),
+		newStrokeHintPolicy(16, 16, 1, gg.Rotate(.1)),
+		newStrokeHintPolicy(16, 16, 1, gg.Scale(1, 2)),
+	} {
+		if got := hintStrokePath(path, policy, 1); got != path {
+			t.Error("ineligible path was copied")
+		}
+	}
+
+	eligibleCopy := hintStrokePath(path, newStrokeHintPolicy(16, 16, 1, gg.Identity()), 1)
+	if !reflect.DeepEqual(eligibleCopy.Coords(), coords) || !reflect.DeepEqual(eligibleCopy.Verbs(), verbs) {
+		t.Fatalf("non-cardinal geometry changed: coords=%v verbs=%v", eligibleCopy.Coords(), eligibleCopy.Verbs())
+	}
+}
+
+func TestHintStrokePathPreservesCloseAfterCurve(t *testing.T) {
+	path := gg.NewPath()
+	path.MoveTo(1, 1)
+	path.QuadraticTo(2, 3, 4, 5)
+	path.Close()
+
+	hinted := hintStrokePath(path, newStrokeHintPolicy(16, 16, 1, gg.Identity()), 1)
+	if !reflect.DeepEqual(hinted.Verbs(), path.Verbs()) || !reflect.DeepEqual(hinted.Coords(), path.Coords()) {
+		t.Fatalf("curve-close path changed: verbs=%v coords=%v", hinted.Verbs(), hinted.Coords())
+	}
+
+	closedLines := gg.NewPath()
+	closedLines.MoveTo(1.2, 1.2)
+	closedLines.LineTo(4.2, 1.2)
+	closedLines.LineTo(4.2, 4.2)
+	closedLines.Close()
+	hinted = hintStrokePath(closedLines, newStrokeHintPolicy(16, 16, 1, gg.Identity()), 1)
+	if got, want := hinted.Verbs(), closedLines.Verbs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("closed line verbs=%v, want %v", got, want)
+	}
+}
+
+func TestRenderHintPixelRowsAndColumns(t *testing.T) {
+	for _, width := range []float64{1, 1.5} {
+		for _, vertical := range []bool{false, true} {
+			name := fmt.Sprintf("width_%g/vertical_%v", width, vertical)
+			t.Run(name, func(t *testing.T) {
+				coordinates := `x1="2" y1="4" x2="14" y2="4"`
+				if vertical {
+					coordinates = `x1="4" y1="2" x2="4" y2="14"`
+				}
+				doc, err := Parse([]byte(fmt.Sprintf(`<svg viewBox="0 0 16 16"><line %s stroke="black" stroke-width="%g"/></svg>`, coordinates, width)))
+				if err != nil {
+					t.Fatal(err)
+				}
+				img := doc.Render(16, 16)
+				coverage := func(offset int) uint32 {
+					x, y := 8, 4+offset
+					if vertical {
+						x, y = 4+offset, 8
+					}
+					_, _, _, alpha := img.At(x, y).RGBA()
+					return alpha / 257
+				}
+				if coverage(0) != 255 {
+					t.Fatalf("center coverage=%d, want 255", coverage(0))
+				}
+				if width == 1 && (coverage(-1) != 0 || coverage(1) != 0) {
+					t.Fatalf("one-pixel neighboring coverage=(%d,%d), want zero", coverage(-1), coverage(1))
+				}
+				if width == 1.5 && (coverage(-1) == 0 || coverage(1) == 0 || coverage(-1) != coverage(1)) {
+					t.Fatalf("1.5-pixel neighboring coverage=(%d,%d), want equal nonzero AA", coverage(-1), coverage(1))
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkSVGHint(b *testing.B) {
+	path, err := gg.ParseSVGPath("M1.2 1.2 H14.2 V14.2 H1.2 Z")
+	if err != nil {
+		b.Fatal(err)
+	}
+	policy := newStrokeHintPolicy(16, 16, 2, gg.Identity())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = hintStrokePath(path, policy, .5)
+	}
+}

--- a/svg/renderer.go
+++ b/svg/renderer.go
@@ -1,18 +1,8 @@
 package svg
 
 import (
-	"image/color"
-	"math"
-	"os"
-
 	"github.com/gogpu/gg"
-)
-
-const (
-	// strokeHintMaxCanvasSize limits automatic hinting to icon-sized targets.
-	strokeHintMaxCanvasSize = 48
-	// strokeHintMaxWidth limits hinting to thin strokes in device pixels.
-	strokeHintMaxWidth = 1.5
+	"image/color"
 )
 
 // renderState is shared by immediate and retained traversal. Matrix is the
@@ -23,9 +13,10 @@ type renderState struct {
 	parentStroke  string
 	opacity       float64
 	matrix        gg.Matrix
-	strokeHinting bool
-	scaleX        float64
-	scaleY        float64
+	targetWidth   float64
+	targetHeight  float64
+	deviceScale   float64
+	outerMatrix   gg.Matrix
 }
 
 type resolvedFill struct {
@@ -104,6 +95,7 @@ func renderElement(dc *gg.Context, elem Element, state *renderState) {
 
 func renderGeometry(dc *gg.Context, path *gg.Path, attrs *Attrs, state *renderState, allowFill bool) {
 	local := elementTransformMatrix(attrs)
+	complete := state.matrix.Multiply(local)
 	style := resolveStyle(attrs, state)
 	if !allowFill {
 		style.fill.present = false
@@ -121,10 +113,8 @@ func renderGeometry(dc *gg.Context, path *gg.Path, attrs *Attrs, state *renderSt
 		_ = dc.Fill()
 	}
 	if style.stroke.present {
-		strokePath := path
-		if shouldHintStroke(attrs, state) {
-			strokePath = hintSVGPath(path, state.scaleX, state.scaleY)
-		}
+		policy := newStrokeHintPolicy(state.targetWidth, state.targetHeight, state.deviceScale, complete)
+		strokePath := hintStrokePath(path, policy, style.stroke.width)
 		dc.SetLineWidth(style.stroke.width)
 		dc.SetLineCap(style.stroke.cap)
 		dc.SetLineJoin(style.stroke.join)
@@ -133,109 +123,6 @@ func renderGeometry(dc *gg.Context, path *gg.Path, attrs *Attrs, state *renderSt
 		_ = dc.Stroke()
 	}
 	dc.Pop()
-}
-
-// shouldHintStroke reports whether stroke hinting should be applied to this
-// element's stroke. Checks stroke width in device pixels against the threshold.
-func shouldHintStroke(a *Attrs, state *renderState) bool {
-	if !state.strokeHinting {
-		return false
-	}
-	// Compute device-pixel stroke width. Use the average scale when sx != sy
-	// (non-uniform scaling). For typical icon rendering sx == sy.
-	avgScale := (state.scaleX + state.scaleY) / 2.0
-	deviceWidth := a.StrokeWidth * avgScale
-	return deviceWidth <= strokeHintMaxWidth
-}
-
-// hintSVGPath creates a copy of an SVG path with line endpoints snapped to
-// pixel centers in device space. The path coordinates are in viewBox space;
-// we compute device positions via the scale factors, snap to pixel centers,
-// and convert back.
-//
-// Curve verbs (QuadTo, CubicTo) are passed through unchanged — curves don't
-// align to the pixel grid, and snapping control points would distort the shape.
-//
-// This is modeled after Java2D's VALUE_STROKE_NORMALIZE which snaps stroke
-// edges to pixel boundaries for crisp 1px lines in small icons.
-func hintSVGPath(src *gg.Path, sx, sy float64) *gg.Path {
-	if src == nil || src.NumVerbs() == 0 {
-		return src
-	}
-
-	// Don't hint paths that contain curves — snapping line endpoints while
-	// leaving curve endpoints unsnapped creates misaligned joints and
-	// garbage pixels at corners. Only hint pure line/polyline paths.
-	hasCurves := false
-	src.Iterate(func(verb gg.PathVerb, _ []float64) {
-		if verb == gg.QuadTo || verb == gg.CubicTo {
-			hasCurves = true
-		}
-	})
-	if hasCurves {
-		return src
-	}
-
-	result := gg.NewPath()
-	src.Iterate(func(verb gg.PathVerb, coords []float64) {
-		switch verb {
-		case gg.MoveTo:
-			result.MoveTo(
-				snapViewBoxCoord(coords[0], sx),
-				snapViewBoxCoord(coords[1], sy),
-			)
-		case gg.LineTo:
-			result.LineTo(
-				snapViewBoxCoord(coords[0], sx),
-				snapViewBoxCoord(coords[1], sy),
-			)
-		case gg.QuadTo:
-			// Don't snap curve control points — would distort curve shape.
-			result.QuadraticTo(coords[0], coords[1], coords[2], coords[3])
-		case gg.CubicTo:
-			result.CubicTo(coords[0], coords[1], coords[2], coords[3], coords[4], coords[5])
-		case gg.Close:
-			result.Close()
-		}
-	})
-	return result
-}
-
-// snapViewBoxCoord converts a viewBox coordinate to device space, snaps it
-// to the nearest pixel center, and converts back to viewBox space.
-//
-// For a viewBox coordinate v with scale s:
-//
-//	device = v * s
-//	snapped_device = floor(device) + 0.5
-//	snapped_viewbox = snapped_device / s
-//
-// This ensures a 1px stroke centered at the snapped position covers exactly
-// one full pixel after stroke expansion by ±0.5.
-func snapViewBoxCoord(v, scale float64) float64 {
-	if scale == 0 {
-		return v
-	}
-	device := v * scale
-	snapped := math.Floor(device) + 0.5
-	return snapped / scale
-}
-
-// hintPoints snaps alternating x,y coordinate pairs to pixel centers.
-// Returns a new slice; the original is not modified.
-func hintPoints(pts []float64, sx, sy float64) []float64 {
-	out := make([]float64, len(pts))
-	for i := 0; i+1 < len(pts); i += 2 {
-		out[i] = snapViewBoxCoord(pts[i], sx)
-		out[i+1] = snapViewBoxCoord(pts[i+1], sy)
-	}
-	return out
-}
-
-// strokeHintingDisabled reports whether the GOGPU_SVG_NO_HINT environment
-// variable is set to disable stroke hinting.
-func strokeHintingDisabled() bool {
-	return os.Getenv("GOGPU_SVG_NO_HINT") != ""
 }
 
 func renderGroup(dc *gg.Context, group *GroupElement, state *renderState) {

--- a/svg/scene_renderer.go
+++ b/svg/scene_renderer.go
@@ -24,6 +24,8 @@ func (d *Document) renderToSceneInternal(
 	root := gg.Translate(float64(x), float64(y)).
 		Multiply(gg.Scale(float64(width)/d.ViewBox.Width, float64(height)/d.ViewBox.Height)).
 		Multiply(gg.Translate(-d.ViewBox.MinX, -d.ViewBox.MinY))
+	outer := matrixFromSceneAffine(target.Transform())
+	outerScale := uniformAxisScale(outer)
 	var override color.Color
 	if overrideColor == nil {
 		override = nil
@@ -35,10 +37,10 @@ func (d *Document) renderToSceneInternal(
 		parentFill:    d.RootFill,
 		opacity:       1,
 		matrix:        root,
-		strokeHinting: math.Max(float64(width), float64(height)) <= strokeHintMaxCanvasSize &&
-			!strokeHintingDisabled(),
-		scaleX: float64(width) / d.ViewBox.Width,
-		scaleY: float64(height) / d.ViewBox.Height,
+		targetWidth:   float64(width) * outerScale,
+		targetHeight:  float64(height) * outerScale,
+		deviceScale:   1,
+		outerMatrix:   outer,
 	}
 	renderSceneElements(target, d.Elements, state)
 }
@@ -138,6 +140,7 @@ func renderSceneGeometry(
 	allowFill bool,
 ) {
 	complete := state.matrix.Multiply(elementTransformMatrix(attrs))
+	hintComplete := state.outerMatrix.Multiply(complete)
 	style := resolveStyle(attrs, state)
 	if !allowFill {
 		style.fill.present = false
@@ -155,10 +158,8 @@ func renderSceneGeometry(
 		target.Fill(fillRule, transform, scene.SolidBrush(style.fill.color), fillShape)
 	}
 	if style.stroke.present {
-		strokePath := path
-		if shouldHintStroke(attrs, state) {
-			strokePath = hintSVGPath(path, state.scaleX, state.scaleY)
-		}
+		policy := newStrokeHintPolicy(state.targetWidth, state.targetHeight, state.deviceScale, hintComplete)
+		strokePath := hintStrokePath(path, policy, style.stroke.width)
 		strokeShape := native
 		if strokeShape == nil || strokePath != path {
 			strokeShape = scene.NewGGPathShape(strokePath)
@@ -200,4 +201,19 @@ func sceneLineJoin(join gg.LineJoin) scene.LineJoin {
 func parseSVGTransformAffine(value string) (scene.Affine, error) {
 	matrix, err := transformMatrix(value)
 	return scene.AffineFromMatrix(matrix), err
+}
+
+func matrixFromSceneAffine(a scene.Affine) gg.Matrix {
+	return gg.Matrix{
+		A: float64(a.A), B: float64(a.B), C: float64(a.C),
+		D: float64(a.D), E: float64(a.E), F: float64(a.F),
+	}
+}
+
+func uniformAxisScale(matrix gg.Matrix) float64 {
+	sx, sy := math.Abs(matrix.A), math.Abs(matrix.E)
+	if matrix.B == 0 && matrix.D == 0 && sx > 0 && sx == sy {
+		return sx
+	}
+	return 1
 }

--- a/svg/scene_test.go
+++ b/svg/scene_test.go
@@ -154,6 +154,62 @@ func TestRenderToSceneDeterministic(t *testing.T) {
 	}
 }
 
+func TestRenderToSceneHintUsesIndependentStrokePath(t *testing.T) {
+	doc, err := Parse([]byte(`<svg viewBox="0 0 16 16"><path d="M2 4 L14 4" fill="red" stroke="black" stroke-width="1"/></svg>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := scene.NewScene()
+	doc.RenderToScene(s, 0, 0, 16, 16)
+
+	var lineYs []float32
+	dec := scene.NewDecoder(s.Encoding())
+	for dec.Next() {
+		switch dec.Tag() {
+		case scene.TagMoveTo:
+			_, _ = dec.MoveTo()
+		case scene.TagLineTo:
+			_, y := dec.LineTo()
+			lineYs = append(lineYs, y)
+		case scene.TagFill:
+			_, _ = dec.Fill()
+		case scene.TagStroke:
+			_, _ = dec.Stroke()
+		}
+	}
+	if !reflect.DeepEqual(lineYs, []float32{4, 4.5}) {
+		t.Fatalf("fill/stroke line centers=%v, want original 4 then hinted 4.5", lineYs)
+	}
+}
+
+func TestRenderToSceneHintIncludesExistingSceneTransform(t *testing.T) {
+	doc, err := Parse([]byte(`<svg viewBox="0 0 16 16"><path d="M2 4 L14 4" fill="none" stroke="black"/></svg>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := scene.NewScene()
+	s.SetTransform(scene.RotateAffine(.2))
+	doc.RenderToScene(s, 0, 0, 16, 16)
+
+	dec := scene.NewDecoder(s.Encoding())
+	var lineY float32
+	for dec.Next() {
+		switch dec.Tag() {
+		case scene.TagTransform:
+			_ = dec.Transform()
+		case scene.TagMoveTo:
+			_, _ = dec.MoveTo()
+		case scene.TagLineTo:
+			_, lineY = dec.LineTo()
+		case scene.TagStroke:
+			_, _ = dec.Stroke()
+		}
+	}
+	if lineY != 4 {
+		t.Fatalf("rotated Scene stroke was hinted to y=%g, want unchanged 4", lineY)
+	}
+}
+
 func TestRenderToSceneImmediateParity(t *testing.T) {
 	doc, err := Parse([]byte(`<svg viewBox="0 0 16 16"><path fill="#3979c3" fill-opacity=".7" d="M2 2h12v5H9v7H2z"/></svg>`))
 	if err != nil {

--- a/svg/stroke_hint_test.go
+++ b/svg/stroke_hint_test.go
@@ -2,94 +2,13 @@ package svg
 
 import (
 	"image"
-	"math"
 	"testing"
-
-	"github.com/gogpu/gg"
 )
 
 const toolTerminalSVG = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M3 5L7 8L3 11" stroke="#6C707E" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M9 11H13" stroke="#6C707E" stroke-linecap="round"/>
 </svg>`
-
-// --- snapViewBoxCoord unit tests ---
-
-func TestSnapViewBoxCoord(t *testing.T) {
-	tests := []struct {
-		name  string
-		v     float64
-		scale float64
-		want  float64
-	}{
-		// Scale 1:1 (16x16 viewBox → 16x16 canvas).
-		// device = v * 1.0, snapped = floor(v) + 0.5
-		{"integer at 1:1", 6.0, 1.0, 6.5},
-		{"half at 1:1", 6.5, 1.0, 6.5},      // already at pixel center
-		{"frac at 1:1", 6.3, 1.0, 6.5},      // rounds to pixel center
-		{"frac high at 1:1", 6.8, 1.0, 6.5}, // floor(6.8)+0.5 = 6.5
-		{"zero at 1:1", 0.0, 1.0, 0.5},
-
-		// Scale 2:1 (16x16 viewBox → 32x32 canvas).
-		// device = v * 2.0, snapped = floor(v*2) + 0.5
-		// viewBox result = snapped / 2.0
-		{"integer at 2:1", 6.0, 2.0, 6.25}, // device=12 → 12.5 → vb=6.25
-		{"half at 2:1", 6.5, 2.0, 6.75},    // device=13 → 13.5 → vb=6.75
-		{"frac at 2:1", 6.3, 2.0, 6.25},    // device=12.6 → 12.5 → vb=6.25
-		{"3 at 2:1", 3.0, 2.0, 3.25},       // device=6 → 6.5 → vb=3.25
-
-		// Scale 0.5:1 (32x32 viewBox → 16x16 canvas).
-		{"integer at 0.5:1", 6.0, 0.5, 7.0}, // device=3 → 3.5 → vb=7.0
-		{"frac at 0.5:1", 5.0, 0.5, 5.0},    // device=2.5 → 2.5 → vb=5.0
-
-		// Zero scale edge case.
-		{"zero scale", 6.3, 0.0, 6.3}, // unchanged
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := snapViewBoxCoord(tt.v, tt.scale)
-			if math.Abs(got-tt.want) > 1e-9 {
-				t.Errorf("snapViewBoxCoord(%v, %v) = %v, want %v", tt.v, tt.scale, got, tt.want)
-			}
-		})
-	}
-}
-
-// --- shouldHintStroke unit tests ---
-
-func TestShouldHintStroke(t *testing.T) {
-	tests := []struct {
-		name        string
-		hinting     bool
-		strokeWidth float64
-		scaleX      float64
-		scaleY      float64
-		want        bool
-	}{
-		{"hinting disabled", false, 1.0, 1.0, 1.0, false},
-		{"thin stroke 1:1", true, 1.0, 1.0, 1.0, true},
-		{"thin stroke 2:1", true, 0.5, 2.0, 2.0, true},   // device width = 1.0
-		{"thick stroke 1:1", true, 2.0, 1.0, 1.0, false}, // device width = 2.0 > 1.5
-		{"thick stroke 2:1", true, 1.0, 2.0, 2.0, false}, // device width = 2.0 > 1.5
-		{"at threshold", true, 1.5, 1.0, 1.0, true},      // device width = 1.5 <= 1.5
-		{"just over", true, 1.6, 1.0, 1.0, false},        // device width = 1.6 > 1.5
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			state := &renderState{
-				strokeHinting: tt.hinting,
-				scaleX:        tt.scaleX,
-				scaleY:        tt.scaleY,
-			}
-			a := &Attrs{StrokeWidth: tt.strokeWidth}
-			got := shouldHintStroke(a, state)
-			if got != tt.want {
-				t.Errorf("shouldHintStroke(width=%v, scale=%v/%v, hinting=%v) = %v, want %v",
-					tt.strokeWidth, tt.scaleX, tt.scaleY, tt.hinting, got, tt.want)
-			}
-		})
-	}
-}
 
 // --- Rendering quality tests ---
 
@@ -170,7 +89,7 @@ func TestStrokeHintFewerPartialPixels(t *testing.T) {
 }
 
 // TestStrokeHintLargeCanvasNoEffect verifies that hinting is NOT applied
-// at large canvas sizes (> strokeHintMaxCanvasSize).
+// at large canvas sizes (above the 32-physical-pixel policy limit).
 func TestStrokeHintLargeCanvasNoEffect(t *testing.T) {
 	svg := `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
   <path d="M3 8 H13" stroke="black" fill="none"/>
@@ -195,7 +114,7 @@ func TestStrokeHintLargeCanvasNoEffect(t *testing.T) {
 }
 
 // TestStrokeHintThickStrokeNoEffect verifies that hinting is NOT applied
-// to thick strokes (device width > strokeHintMaxWidth).
+// to thick strokes (device width > 1.5 pixels).
 func TestStrokeHintThickStrokeNoEffect(t *testing.T) {
 	svg := `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
   <path d="M3 8 H13" stroke="black" stroke-width="3" fill="none"/>
@@ -356,54 +275,7 @@ func TestStrokeHintTerminalIcon(t *testing.T) {
 	}
 }
 
-// TestHintSVGPath tests the path hinting function directly.
-func TestHintSVGPath(t *testing.T) {
-	// Build a simple path: M3,8 L13,8 (horizontal line at y=8 in viewBox).
-	// With 1:1 scale, device coords = viewBox coords.
-	// Hinting: M3.5,8.5 L13.5,8.5.
-	src, err := parseTestPath("M3 8 L13 8")
-	if err != nil {
-		t.Fatalf("parse path: %v", err)
-	}
-
-	hinted := hintSVGPath(src, 1.0, 1.0)
-
-	// Verify hinted coords.
-	coords := hinted.Coords()
-	wantCoords := []float64{3.5, 8.5, 13.5, 8.5}
-	if len(coords) != len(wantCoords) {
-		t.Fatalf("hinted coords len = %d, want %d", len(coords), len(wantCoords))
-	}
-	for i, want := range wantCoords {
-		if math.Abs(coords[i]-want) > 1e-9 {
-			t.Errorf("coords[%d] = %v, want %v", i, coords[i], want)
-		}
-	}
-}
-
-// TestHintPoints tests the coordinate pair hinting helper.
-func TestHintPoints(t *testing.T) {
-	pts := []float64{3.0, 8.0, 13.0, 8.0, 8.0, 3.0}
-	hinted := hintPoints(pts, 1.0, 1.0)
-
-	want := []float64{3.5, 8.5, 13.5, 8.5, 8.5, 3.5}
-	for i := range want {
-		if math.Abs(hinted[i]-want[i]) > 1e-9 {
-			t.Errorf("hintPoints[%d] = %v, want %v", i, hinted[i], want[i])
-		}
-	}
-
-	// Verify original is not modified.
-	if pts[0] != 3.0 {
-		t.Error("hintPoints modified original slice")
-	}
-}
-
 // --- Test helpers ---
-
-func parseTestPath(d string) (*gg.Path, error) {
-	return gg.ParseSVGPath(d)
-}
 
 // peakAlpha returns the highest alpha value in the image (0-255).
 func peakAlpha(img *image.RGBA) uint8 {

--- a/svg/svg.go
+++ b/svg/svg.go
@@ -81,24 +81,14 @@ func (d *Document) renderInternal(dc *gg.Context, x, y, width, height float64, o
 		dc.Translate(-d.ViewBox.MinX, -d.ViewBox.MinY)
 	}
 
-	// Enable stroke hinting for small canvases (icon-sized SVGs).
-	// At small sizes, thin strokes land at fractional pixel positions and get
-	// anti-aliased across 2-3 pixels instead of rendering as crisp 1px lines.
-	// Hinting snaps stroke endpoints to pixel centers (Java2D STROKE_NORMALIZE pattern).
-	maxDim := width
-	if height > maxDim {
-		maxDim = height
-	}
-	hinting := maxDim <= strokeHintMaxCanvasSize && !strokeHintingDisabled()
-
 	state := &renderState{
 		overrideColor: overrideColor,
 		parentFill:    d.RootFill,
-		strokeHinting: hinting,
-		scaleX:        sx,
-		scaleY:        sy,
 		opacity:       1,
 		matrix:        dc.GetTransform(),
+		targetWidth:   width,
+		targetHeight:  height,
+		deviceScale:   dc.DeviceScale(),
 	}
 
 	renderElements(dc, d.Elements, state)


### PR DESCRIPTION
## Summary

Add conservative SVG-local stroke hinting for small icons:

- snap eligible horizontal and vertical stroke centers to physical pixel centers
- apply hinting only to an independent stroke-path copy; fill/source geometry is never mutated
- cover both immediate `gg.Context` rendering and retained `Document.RenderToScene` lowering
- keep curves, diagonals, rotations, shear, non-uniform transforms, large targets, and thick strokes unchanged

## Dependency / review order

**Depends on #466.** This is a two-commit stacked branch: the first commit is exactly #466, and the second commit (`e14bfa2`) is the #463 change. Review the second commit or the comparison from `bc59c93..e14bfa2`; once #466 lands, this PR reduces to the hinting change.

Stacking is intentional: target-aware snapping belongs at the shared SVG submission boundary and must cover the retained-vector route rather than creating an immediate-renderer-only fix.

## Eligibility contract

Hinting is enabled only when all of these are true:

- maximum target dimension is at most 32 physical pixels
- effective physical stroke width is in `(0, 1.5]`
- the complete transform is translation plus uniform axis-preserving scale (reflection is allowed)
- the segment is strictly horizontal or vertical in physical space

Eligible perpendicular coordinates use `floor(coord) + 0.5`, then map back to SVG-local coordinates. Rotation, shear, non-uniform scale, ambiguous curve/diagonal endpoints, and ineligible sizes/widths are byte-for-byte geometrically unchanged.

## Validation

- `go test ./svg -run 'Test.*(Scene|Hint|Render|Transform|Fill|Stroke)' -count=1`
- `go test -race ./svg -count=1`
- `go test ./scene ./svg -count=1`
- `go vet ./...`
- `go build ./...`
- `go test -tags nogpu ./... -count=1`
- `BenchmarkSVGHint`: median 415.7 ns/op, 1,456 B/op, 8 allocs/op across five runs on Apple M1

Tests cover 16/24/32/33px targets, width boundaries through 1.5001px, negative/fractional coordinates, translations, reflection, uniform/non-uniform scale, rotation, shear, line/curve/close verbs, idempotence, source immutability, fill/stroke separation, retained Scene transforms, and pixel-row/column coverage for 1px and 1.5px strokes.

Closes #463.



