### PR TITLE
fix(text): make GPU glyph-mask compositing portable and correct

### DIFF
--- a/accelerator.go
+++ b/accelerator.go
@@ -521,16 +521,15 @@ type PathClipAware interface {
 	ClearClipPath()
 }
 
-// LCDLayoutAware is an optional interface for accelerators that support
-// LCD subpixel (ClearType) text rendering. When the Context calls
-// SetLCDLayout, it propagates the layout to the accelerator so the
-// glyph mask engine can rasterize glyphs with 3x horizontal oversampling
-// and the GPU pipeline selects the LCD fragment shader.
+// LCDLayoutAware is an optional interface for accelerators that accept a
+// requested physical subpixel layout. Accepting the preference does not imply
+// exact LCD output: a backend may conservatively render grayscale masks when
+// it cannot composite per-channel coverage correctly.
 //
 // Use LCDLayoutRGB for most monitors, LCDLayoutBGR for rare BGR panels,
-// or LCDLayoutNone to disable subpixel rendering (grayscale, the default).
+// or LCDLayoutNone to request grayscale (the default).
 type LCDLayoutAware interface {
-	// SetLCDLayout sets the LCD subpixel layout for ClearType rendering.
+	// SetLCDLayout records the requested LCD subpixel layout.
 	SetLCDLayout(layout LCDLayout)
 }
 

--- a/context.go
+++ b/context.go
@@ -351,15 +351,16 @@ func (c *Context) TextMode() TextMode {
 	return c.textMode
 }
 
-// SetLCDLayout sets the LCD subpixel layout for ClearType text rendering.
-// Use LCDLayoutRGB for most monitors, LCDLayoutBGR for rare BGR panels,
-// or LCDLayoutNone to disable subpixel rendering (grayscale, the default).
+// SetLCDLayout requests an LCD subpixel layout from the registered accelerator.
+// Use LCDLayoutRGB for most monitors, LCDLayoutBGR for rare BGR panels, or
+// LCDLayoutNone to request grayscale (the default).
 //
-// When a GPU accelerator is registered and implements LCDLayoutAware,
-// the layout is propagated so the glyph mask engine rasterizes glyphs
-// with 3x horizontal oversampling and the GPU uses the LCD fragment shader.
+// A requested layout is not a guarantee of per-channel output. Current GPU
+// backends lack exact per-channel destination blending and therefore render
+// portable grayscale glyph masks for None, RGB, and BGR alike.
 //
-// The setting is per-Context. Call this before drawing text.
+// Call this before drawing text. If no LCDLayoutAware accelerator is
+// registered, the request has no effect.
 func (c *Context) SetLCDLayout(layout LCDLayout) {
 	a := Accelerator()
 	if a == nil {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,11 +82,19 @@ dispatches shapes and text to six rendering tiers:
 | **3** | Textured Quad | DrawImage, GPU textures | GPU textured quad pipeline |
 | **4** | MSDF Text | Text glyphs (dynamic/animated) | Multi-channel SDF with median+smoothstep shader |
 | **5** | Compute | Full scenes (many paths) | Vello-style 9-stage compute pipeline (GPU or CPU fallback) |
-| **6** | Glyph Mask | Text glyphs (static/UI, ≤48px) | CPU-rasterized R8 alpha atlas, GPU textured quads, ClearType LCD subpixel, font hinting |
+| **6** | Glyph Mask | Text glyphs (static/UI, ≤64 physical px) | CPU-rasterized R8 grayscale atlas, GPU textured quads, font hinting |
 
 Tiers 1–4, 6 use a render-pass pipeline (one render pass, multiple pipeline switches).
 Tier 5 uses a compute-only pipeline (9 dispatch stages, no render pass).
-Auto-selection routes horizontal text ≤48px to Tier 6 (pixel-perfect with font hinting and optional ClearType LCD subpixel rendering), else Tier 4 (scalable MSDF).
+Auto-selection routes axis-aligned text up to 64 effective device pixels to Tier 6
+(pixel-perfect grayscale masks with font hinting), else Tier 4 (scalable MSDF).
+`SetLCDLayout` retains the requested None/RGB/BGR preference, but current WebGPU
+backends conservatively downgrade all layouts to grayscale: scalar blend factors
+cannot attenuate destination RGB independently for per-channel coverage. The
+grayscale shader receives one CPU-premultiplied color and computes
+`(premul.rgb * mask * clip, alpha * mask * clip)` before premultiplied
+source-over blending. The dormant LCD shader and uniform ABI are not routed
+until a backend can provide exact per-channel compositing.
 
 This mirrors enterprise engines (Skia Ganesh/Graphite, Flutter Impeller, Gio).
 
@@ -277,12 +285,13 @@ dc.SetRasterizerMode(gg.RasterizerAuto)          // restore auto-selection
 | `RasterizerTileCompute` | Force 16×16 tiles via `ForceableFiller` |
 | `RasterizerSDF` | Force SDF for shapes, bypass min-size check |
 
-## Text Rendering Pipeline (v0.29.0+, CPU Transform v0.32.1, Hinting+ClearType v0.36.0)
+## Text Rendering Pipeline (v0.29.0+, CPU Transform v0.32.1, Hinting v0.36.0)
 
 Text rendering uses a multi-tier strategy. GPU MSDF handles text when available;
 the CPU pipeline uses a hybrid decision tree for transform-aware rendering.
-Glyph Mask (Tier 6) provides pixel-perfect rendering with auto-hinting and
-optional ClearType LCD subpixel rendering for small axis-aligned text.
+Glyph Mask (Tier 6) provides pixel-perfect grayscale rendering with auto-hinting
+for small axis-aligned text. Auto mode uses an inclusive 64 physical-pixel
+threshold after device and CTM scaling; explicit text modes remain independent.
 
 ### Pipeline Flow
 
@@ -413,7 +422,7 @@ gg/
 ├── path.go                 # Vector path operations (SetPath, DrawPath, FillPath)
 ├── path_svg.go             # SVG path data parser (ParseSVGPath)
 ├── paint.go                # Fill and stroke styles
-├── lcd_layout.go           # LCD ClearType layout types (LCDLayoutRGB/BGR/None)
+├── lcd_layout.go           # Requested LCD layout preference (current GPU output is grayscale)
 ├── pixmap.go               # Pixel buffer operations
 ├── text.go                 # Text rendering
 │
@@ -533,7 +542,7 @@ gg/
 │   │       ├── strip.wgsl         # Strip rendering
 │   │       ├── msdf_text.wgsl     # MSDF text rendering (Tier 4)
 │   │       ├── glyph_mask.wgsl    # Glyph mask rendering (Tier 6)
-│   │       └── glyph_mask_lcd.wgsl # LCD ClearType subpixel (Tier 6)
+│   │       └── glyph_mask_lcd.wgsl # Dormant LCD ABI (not routed by current engines)
 │   │
 │   ├── cache/              # LRU caching infrastructure
 │   │   ├── cache.go        # Generic cache
@@ -757,7 +766,7 @@ The `integration/ggcanvas/` package bridges gg with gogpu for windowed rendering
 import "github.com/gogpu/gg/integration/ggcanvas"
 
 canvas := ggcanvas.New(provider, width, height)
-// Auto-configures: device scale, LCD ClearType (ADR-024), resource tracking
+// Auto-configures: device scale, requested LCD layout, resource tracking
 
 // Draw() marks canvas dirty atomically — recommended pattern:
 canvas.Draw(func(dc *gg.Context) {
@@ -910,7 +919,7 @@ gg and gogpu are **independent libraries** that can interoperate via gpucontext:
 | **Atlas Compact** | Skia GrDrawOpAtlas | Frame-based page eviction (32-frame stale threshold) |
 | **Pressure Hysteresis** | Skia/Chrome | Enter bucketed mode at 50%, exit at 25% — prevents oscillation |
 | **Font Hinting** | FreeType auto-hinter | Grid-fit outline Y/X coordinates for crisp stems at small sizes |
-| **ClearType LCD** | FreeType/Microsoft | 3× horizontal oversampling + 5-tap FIR filter for per-channel RGB alpha |
+| **Deferred LCD ABI** | FreeType/Microsoft | Retains 3× mask/filter machinery, but current GPU routing downgrades to grayscale until exact per-channel destination blending exists |
 | **Command Pattern** | Cairo/Skia | Recording system for vector export |
 | **Driver Pattern** | database/sql | Backend registration via blank import |
 | **Device Sharing** | Skia Graphite | DeviceProviderAware for gogpu integration |

--- a/internal/gpu/glyph_mask_engine.go
+++ b/internal/gpu/glyph_mask_engine.go
@@ -54,9 +54,9 @@ func NewGlyphMaskEngine() *GlyphMaskEngine {
 	}
 }
 
-// SetLCDLayout sets the LCD subpixel layout for ClearType rendering.
-// Use LCDLayoutRGB for most monitors, LCDLayoutBGR for rare BGR panels,
-// or LCDLayoutNone to disable subpixel rendering (grayscale).
+// SetLCDLayout records the requested LCD subpixel layout. Production GPU
+// routing currently downgrades it to grayscale because WebGPU lacks exact
+// per-channel destination blending.
 func (e *GlyphMaskEngine) SetLCDLayout(layout text.LCDLayout) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -71,7 +71,13 @@ func (e *GlyphMaskEngine) SetLCDLayout(layout text.LCDLayout) {
 func (e *GlyphMaskEngine) SetLCDFilter(filter text.LCDFilter) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if e.lcdFilter == filter {
+		return
+	}
 	e.lcdFilter = filter
+	// Filter weights affect rasterized LCD masks. The force-LCD debug path can
+	// populate these entries even while production routing stays grayscale.
+	e.atlas.Clear()
 }
 
 // LCDLayout returns the current LCD subpixel layout.
@@ -134,13 +140,10 @@ func (e *GlyphMaskEngine) LayoutText(
 	lcdLayout := e.lcdLayout
 	lcdFilter := e.lcdFilter
 
-	// Pass straight-alpha color to the shader. The fragment shader performs
-	// premultiplication: output.rgb = color.rgb * (coverage * color.a).
-	// Passing premultiplied color here would cause double-application of alpha
-	// (color.rgb already has A baked in, then shader multiplies by color.a again).
+	premul := color.Premultiply()
 	batchColor := [4]float32{
-		float32(color.R), float32(color.G),
-		float32(color.B), float32(color.A),
+		float32(premul.R), float32(premul.G),
+		float32(premul.B), float32(premul.A),
 	}
 
 	var shaped []text.ShapedGlyph
@@ -193,10 +196,10 @@ func (e *GlyphMaskEngine) LayoutTextAliased(
 	// is incompatible with 3x horizontal oversampling.
 	useLCD := false
 
-	// Pass straight-alpha color to the shader (same as LayoutText).
+	premul := color.Premultiply()
 	batchColor := [4]float32{
-		float32(color.R), float32(color.G),
-		float32(color.B), float32(color.A),
+		float32(premul.R), float32(premul.G),
+		float32(premul.B), float32(premul.A),
 	}
 
 	var shaped []text.ShapedGlyph
@@ -239,10 +242,10 @@ func (e *GlyphMaskEngine) LayoutShapedGlyphs(
 	hinting := selectGlyphMaskHinting(fontSize, matrix, isCJK, deviceScale)
 	useLCD := e.lcdLayout != text.LCDLayoutNone && selectGlyphMaskLCD(fontSize, matrix)
 
-	// Pass straight-alpha color to the shader (same as LayoutText).
+	premul := color.Premultiply()
 	batchColor := [4]float32{
-		float32(color.R), float32(color.G),
-		float32(color.B), float32(color.A),
+		float32(premul.R), float32(premul.G),
+		float32(premul.B), float32(premul.A),
 	}
 
 	lcdFilter := e.lcdFilter

--- a/internal/gpu/glyph_mask_engine_test.go
+++ b/internal/gpu/glyph_mask_engine_test.go
@@ -110,9 +110,31 @@ func TestGlyphMaskEngine_SetLCDLayout(t *testing.T) {
 func TestGlyphMaskEngine_SetLCDFilter(t *testing.T) {
 	engine := NewGlyphMaskEngine()
 
-	// Custom filter should not panic.
+	key := text.MakeGlyphMaskKey(1, 1, 12, 0, 0)
+	if _, err := engine.Atlas().Put(key, []byte{255}, 1, 1, 0, 0); err != nil {
+		t.Fatalf("populate atlas: %v", err)
+	}
+
+	// Reapplying the same filter preserves compatible cached masks.
+	engine.SetLCDFilter(text.DefaultLCDFilter())
+	if entries := glyphMaskAtlasEntryCount(engine); entries != 1 {
+		t.Fatalf("same filter cleared atlas: entries = %d, want 1", entries)
+	}
+
+	// A changed filter invalidates masks that may have used its weights.
 	custom := text.LCDFilter{Weights: [5]float32{0.1, 0.2, 0.4, 0.2, 0.1}}
 	engine.SetLCDFilter(custom)
+	if entries := glyphMaskAtlasEntryCount(engine); entries != 0 {
+		t.Fatalf("changed filter retained atlas: entries = %d, want 0", entries)
+	}
+}
+
+func glyphMaskAtlasEntryCount(engine *GlyphMaskEngine) int {
+	hits, misses, entries, pages := engine.Atlas().Stats()
+	_ = hits
+	_ = misses
+	_ = pages
+	return entries
 }
 
 func TestSelectGlyphMaskHinting(t *testing.T) {

--- a/internal/gpu/glyph_mask_lcd_test.go
+++ b/internal/gpu/glyph_mask_lcd_test.go
@@ -5,10 +5,14 @@ package gpu
 import (
 	"encoding/binary"
 	"math"
+	"strings"
 	"testing"
+
+	"golang.org/x/image/font/gofont/goregular"
 
 	"github.com/gogpu/gg"
 	"github.com/gogpu/gg/text"
+	"github.com/gogpu/wgpu"
 )
 
 func TestMakeGlyphMaskLCDUniform(t *testing.T) {
@@ -139,4 +143,171 @@ func TestGlyphMaskLCDUniformSize(t *testing.T) {
 	if glyphMaskLCDUniformSize <= glyphMaskUniformSize {
 		t.Error("LCD uniform should be larger than grayscale uniform")
 	}
+}
+
+// compositeGlyphMaskOracle is a pure source-over reference for the glyph-mask
+// shader contract. color is straight-alpha input; dst and the result are
+// premultiplied. The CPU premultiplies color exactly once, then mask and clip
+// coverage scale the already-premultiplied source.
+func compositeGlyphMaskOracle(color gg.RGBA, mask, clip float32, dst [4]float32) [4]float32 {
+	premul := color.Premultiply()
+	coverage := mask * clip
+	src := [4]float32{
+		float32(premul.R) * coverage,
+		float32(premul.G) * coverage,
+		float32(premul.B) * coverage,
+		float32(premul.A) * coverage,
+	}
+	oneMinusSrcAlpha := 1 - src[3]
+	return [4]float32{
+		src[0] + dst[0]*oneMinusSrcAlpha,
+		src[1] + dst[1]*oneMinusSrcAlpha,
+		src[2] + dst[2]*oneMinusSrcAlpha,
+		src[3] + dst[3]*oneMinusSrcAlpha,
+	}
+}
+
+func TestGlyphMaskPremulCompositeOracle(t *testing.T) {
+	semiOrange := gg.RGBA{R: 1, G: 0.5, B: 0, A: 0.5}
+	tests := []struct {
+		name       string
+		color      gg.RGBA
+		mask, clip float32
+		dst, want  [4]float32
+	}{
+		{name: "zero_coverage_transparent", color: semiOrange, mask: 0, clip: 1, dst: [4]float32{}, want: [4]float32{}},
+		{name: "zero_coverage_white", color: semiOrange, mask: 0, clip: 1, dst: [4]float32{1, 1, 1, 1}, want: [4]float32{1, 1, 1, 1}},
+		{name: "zero_alpha", color: gg.RGBA{R: 1, G: 0, B: 0, A: 0}, mask: 1, clip: 1, dst: [4]float32{0, 0, 1, 1}, want: [4]float32{0, 0, 1, 1}},
+		{name: "full_coverage_transparent", color: semiOrange, mask: 1, clip: 1, dst: [4]float32{}, want: [4]float32{0.5, 0.25, 0, 0.5}},
+		{name: "opaque_alpha_half_coverage", color: gg.RGBA{R: 1, G: 0, B: 0, A: 1}, mask: 0.5, clip: 1, dst: [4]float32{}, want: [4]float32{0.5, 0, 0, 0.5}},
+		{name: "opaque_black_destination", color: semiOrange, mask: 1, clip: 1, dst: [4]float32{0, 0, 0, 1}, want: [4]float32{0.5, 0.25, 0, 1}},
+		{name: "opaque_white_destination", color: semiOrange, mask: 1, clip: 1, dst: [4]float32{1, 1, 1, 1}, want: [4]float32{1, 0.75, 0.5, 1}},
+		{name: "saturated_red_destination", color: semiOrange, mask: 1, clip: 1, dst: [4]float32{1, 0, 0, 1}, want: [4]float32{1, 0.25, 0, 1}},
+		{name: "saturated_green_destination", color: semiOrange, mask: 1, clip: 1, dst: [4]float32{0, 1, 0, 1}, want: [4]float32{0.5, 0.75, 0, 1}},
+		{name: "saturated_blue_destination", color: semiOrange, mask: 1, clip: 1, dst: [4]float32{0, 0, 1, 1}, want: [4]float32{0.5, 0.25, 0.5, 1}},
+		{name: "clip_multiplies_coverage", color: semiOrange, mask: 1, clip: 0.5, dst: [4]float32{}, want: [4]float32{0.25, 0.125, 0, 0.25}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compositeGlyphMaskOracle(tt.color, tt.mask, tt.clip, tt.dst)
+			if got != tt.want {
+				t.Errorf("composite = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGlyphMaskPremulShaderContract(t *testing.T) {
+	for _, required := range []string{
+		"var straight_rgb = vec3<f32>(0.0);",
+		"if color.a > 0.0 {",
+		"straight_rgb = color.rgb / color.a;",
+		"let alpha = apply_mask_gamma(raw_alpha, straight_rgb);",
+		"let coverage = alpha * clip_cov;",
+		"return vec4<f32>(color.rgb * coverage, color.a * coverage);",
+	} {
+		if !strings.Contains(glyphMaskShaderSource, required) {
+			t.Errorf("grayscale shader missing one-premultiplication contract %q", required)
+		}
+	}
+	if strings.Contains(glyphMaskShaderSource, "color.rgb * a") {
+		t.Error("grayscale shader multiplies premultiplied RGB by alpha again")
+	}
+	if strings.Contains(glyphMaskShaderSource, "apply_mask_gamma(raw_alpha, color.rgb)") {
+		t.Error("mask gamma uses opacity-dependent premultiplied luminance")
+	}
+
+	for _, forbidden := range []string{"color.r * a_r", "color.g * a_g", "color.b * a_b"} {
+		if strings.Contains(glyphMaskLCDShaderSource, forbidden) {
+			t.Errorf("dormant LCD shader multiplies premultiplied color twice: %q", forbidden)
+		}
+	}
+	if !strings.Contains(glyphMaskLCDShaderSource, "scalar destination alpha is inexact") {
+		t.Error("dormant LCD shader does not document its scalar-blend limitation")
+	}
+}
+
+func TestGlyphMaskEnginePremultipliesBatchColor(t *testing.T) {
+	source, err := text.NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("NewFontSource: %v", err)
+	}
+	t.Cleanup(func() { _ = source.Close() })
+	face := source.Face(16)
+	color := gg.RGBA{R: 0.8, G: 0.4, B: 0.2, A: 0.5}
+	want := [4]float32{0.4, 0.2, 0.1, 0.5}
+
+	var shaped []text.ShapedGlyph
+	for glyph := range face.Glyphs("A") {
+		shaped = append(shaped, text.ShapedGlyph{GID: glyph.GID, X: glyph.X, Y: glyph.Y})
+	}
+
+	engine := NewGlyphMaskEngine()
+	engine.SetLCDLayout(text.LCDLayoutRGB)
+	tests := []struct {
+		name   string
+		layout func() (GlyphMaskBatch, error)
+	}{
+		{
+			name: "text",
+			layout: func() (GlyphMaskBatch, error) {
+				return engine.LayoutText(face, "A", 0, 20, color, gg.Identity(), 1)
+			},
+		},
+		{
+			name: "aliased",
+			layout: func() (GlyphMaskBatch, error) {
+				return engine.LayoutTextAliased(face, "A", 0, 20, color, gg.Identity(), 1)
+			},
+		},
+		{
+			name: "shaped",
+			layout: func() (GlyphMaskBatch, error) {
+				return engine.LayoutShapedGlyphs(face, shaped, 0, 20, color, gg.Identity(), 1, false)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			batch, err := tt.layout()
+			if err != nil {
+				t.Fatalf("layout: %v", err)
+			}
+			if len(batch.Quads) == 0 {
+				t.Fatal("layout produced no quads")
+			}
+			if batch.Color != want {
+				t.Errorf("batch color = %v, want one CPU premultiplication %v", batch.Color, want)
+			}
+			if batch.IsLCD {
+				t.Error("current engine produced an LCD batch")
+			}
+		})
+	}
+}
+
+func TestGlyphMaskRecordDrawsRejectsLCDWithoutPipeline(t *testing.T) {
+	pipeline := &GlyphMaskPipeline{}
+	resources := &glyphMaskFrameResources{
+		isLCD:     true,
+		drawCalls: []glyphMaskDrawCall{{indexCount: 6}},
+	}
+
+	// A nil render pass is safe only if RecordDraws rejects the unsupported LCD
+	// resource before attempting to bind the grayscale fallback pipeline.
+	pipeline.RecordDraws(nil, resources, nil)
+}
+
+func TestGlyphMaskRecordDrawsRejectsLCDDepthClip(t *testing.T) {
+	pipeline := &GlyphMaskPipeline{lcdPipelineWithStencil: new(wgpu.RenderPipeline)}
+	resources := &glyphMaskFrameResources{
+		isLCD:     true,
+		drawCalls: []glyphMaskDrawCall{{indexCount: 6}},
+	}
+
+	// No LCD depth-clip pipeline exists. Reject the incompatible combination
+	// rather than drawing unclipped or binding the grayscale depth pipeline.
+	pipeline.RecordDraws(nil, resources, nil, true)
 }

--- a/internal/gpu/glyph_mask_pipeline.go
+++ b/internal/gpu/glyph_mask_pipeline.go
@@ -92,9 +92,9 @@ type GlyphMaskPipeline struct {
 	// alpha interpolation at subpixel positions).
 	sampler *wgpu.Sampler
 
-	// LCD pipeline: separate shader + pipeline for ClearType rendering.
-	// Uses a different uniform struct (96 bytes with atlas_size) and a
-	// different fragment shader (per-channel alpha compositing).
+	// Dormant LCD pipeline: retained for deferred ABI compatibility, but routing
+	// stays disabled until exact per-channel destination blending is available.
+	// Uses a different uniform struct (96 bytes with atlas_size) and shader.
 	// This avoids the Intel Vulkan null pipeline handle bug caused by
 	// adding is_lcd to the grayscale uniform struct.
 	lcdShader              *wgpu.ShaderModule
@@ -346,15 +346,24 @@ func (p *GlyphMaskPipeline) RecordDraws(rp *wgpu.RenderPassEncoder, resources *g
 		return
 	}
 
-	useDepthClip := len(depthClipped) > 0 && depthClipped[0] && p.pipelineWithDepthClip != nil
+	depthClipRequested := len(depthClipped) > 0 && depthClipped[0]
+	useDepthClip := depthClipRequested && p.pipelineWithDepthClip != nil
 
-	// Select pipeline: depth-clipped variant takes priority, then LCD, then grayscale.
+	// Never reinterpret a 3x-wide LCD atlas resource as a grayscale mask. There
+	// is no LCD depth-clip variant either, so that combination must also remain
+	// undrawn rather than binding the incompatible grayscale pipeline.
+	if resources.isLCD && (p.lcdPipelineWithStencil == nil || depthClipRequested) {
+		return
+	}
+
+	// Select the pipeline only after validating that the resource format has an
+	// exact matching pipeline.
 	selectedPipeline := p.pipelineWithStencil
 	switch {
+	case resources.isLCD:
+		selectedPipeline = p.lcdPipelineWithStencil
 	case useDepthClip:
 		selectedPipeline = p.pipelineWithDepthClip
-	case resources.isLCD && p.lcdPipelineWithStencil != nil:
-		selectedPipeline = p.lcdPipelineWithStencil
 	}
 
 	rp.SetPipeline(selectedPipeline)
@@ -372,9 +381,10 @@ func (p *GlyphMaskPipeline) RecordDraws(rp *wgpu.RenderPassEncoder, resources *g
 	}
 }
 
-// ensureLCDPipelineWithStencil creates the LCD pipeline variant for ClearType
-// rendering. Uses a separate shader (glyph_mask_lcd.wgsl) with a different
-// uniform struct (96 bytes: includes atlas_size for texel stepping).
+// ensureLCDPipelineWithStencil creates the dormant LCD pipeline variant. It is
+// retained for ABI compatibility but must not be routed to until the backend
+// has exact per-channel destination blending. It uses a separate shader
+// (glyph_mask_lcd.wgsl) with a 96-byte uniform including atlas_size.
 //
 // This is a separate pipeline from the grayscale one (Skia pattern) to avoid
 // the Intel Vulkan null pipeline handle bug that occurs when adding fields to
@@ -603,13 +613,12 @@ type GlyphMaskBatch struct {
 	// Transform is the 2D affine transform for this batch.
 	Transform gg.Matrix
 
-	// Color is the text color (RGBA, straight alpha) for this batch.
-	// The fragment shader performs premultiplication: out.rgb = color.rgb * (cov * color.a).
+	// Color is the text color (RGBA, premultiplied alpha) for this batch.
 	// All glyphs in a batch share the same color (set per DrawString call).
 	Color [4]float32
 
-	// IsLCD indicates this batch uses LCD subpixel rendering.
-	// When true, the LCD pipeline is used with per-channel alpha compositing.
+	// IsLCD indicates this batch contains deferred LCD subpixel resources.
+	// Current engines downgrade before rasterization, so normal output is false.
 	// The atlas region contains 3 R8 texels per logical pixel (R, G, B coverage).
 	IsLCD bool
 
@@ -702,7 +711,7 @@ func makeGlyphMaskUniform(transform gg.Matrix, color [4]float32) []byte {
 		off += 4
 	}
 
-	// Color (vec4<f32>): straight-alpha RGBA. Shader premultiplies.
+	// Color (vec4<f32>): premultiplied RGBA.
 	for i := range 4 {
 		binary.LittleEndian.PutUint32(buf[off:], math.Float32bits(color[i]))
 		off += 4
@@ -731,7 +740,7 @@ func makeGlyphMaskLCDUniform(transform gg.Matrix, color [4]float32, atlasW, atla
 		off += 4
 	}
 
-	// Color (vec4<f32>): straight-alpha RGBA. Shader premultiplies.
+	// Color (vec4<f32>): premultiplied RGBA.
 	for i := range 4 {
 		binary.LittleEndian.PutUint32(buf[off:], math.Float32bits(color[i]))
 		off += 4

--- a/internal/gpu/shaders/glyph_mask.wgsl
+++ b/internal/gpu/shaders/glyph_mask.wgsl
@@ -3,13 +3,10 @@
 // Renders CPU-rasterized glyph alpha masks as textured quads. The atlas
 // stores R8 (single-channel) coverage data produced by AnalyticFiller.
 //
-// The fragment shader outputs premultiplied alpha.
-// Color is passed via uniform buffer (per-batch) in STRAIGHT alpha:
-//   color.rgb = original RGB (not pre-multiplied)
-//   color.a   = alpha
-// The shader computes: out.rgb = color.rgb * (coverage * color.a)
-//                      out.a   = coverage * color.a
-// This produces correct premultiplied output.
+// The fragment shader outputs premultiplied alpha. Color is passed via the
+// uniform buffer already premultiplied by the CPU. The shader temporarily
+// recovers straight RGB for alpha-independent mask-gamma luminance, then
+// scales the premultiplied color by coverage exactly once.
 //
 // Mask gamma correction (Skia SkMaskGamma pattern):
 //   Light text on dark backgrounds appears perceptually thinner because
@@ -116,10 +113,16 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let raw_alpha = textureSample(atlas_texture, atlas_sampler, in.tex_coord).r;
     let clip_cov = rrect_clip_coverage(in.position.xy);
     let color = uniforms.color;
-
-    // Apply mask gamma correction: boost coverage for light text on dark bg.
-    let alpha = apply_mask_gamma(raw_alpha, color.rgb);
-
-    let a = alpha * color.a * clip_cov;
-    return vec4<f32>(color.rgb * a, a);
+    // Mask gamma depends on the source hue/luminance, not its opacity. Recover
+    // straight RGB safely so translucent light text is not treated as dark.
+    var straight_rgb = vec3<f32>(0.0);
+    if color.a > 0.0 {
+        straight_rgb = color.rgb / color.a;
+    }
+    let alpha = apply_mask_gamma(raw_alpha, straight_rgb);
+    // The CPU supplied color is already premultiplied. Coverage scales its
+    // premultiplied RGB and alpha once; multiplying RGB by color.a here would
+    // introduce alpha-squared darkening.
+    let coverage = alpha * clip_cov;
+    return vec4<f32>(color.rgb * coverage, color.a * coverage);
 }

--- a/internal/gpu/shaders/glyph_mask_lcd.wgsl
+++ b/internal/gpu/shaders/glyph_mask_lcd.wgsl
@@ -1,4 +1,4 @@
-// glyph_mask_lcd.wgsl - LCD Subpixel (ClearType) Text Rendering Shader
+// glyph_mask_lcd.wgsl - Dormant LCD Subpixel Text Rendering Shader
 //
 // NOTE: This shader is currently unused for the GPU pipeline (BUG-TEXT-001,
 // ADR-060). The GPU always uses grayscale (glyph_mask.wgsl) because standard
@@ -10,11 +10,12 @@
 // alpha compositing. The R8 atlas stores 3 texels per logical pixel
 // (R coverage, G coverage, B coverage), arranged horizontally.
 //
-// The fragment shader samples 3 adjacent horizontal texels to get per-channel
-// coverage, then composites each color channel independently for ClearType
-// subpixel rendering with 3x effective horizontal resolution.
+// IMPORTANT: this shader must remain disabled. WebGPU's scalar blend means
+// scalar destination alpha is inexact for LCD coverage; source-over would need
+// a distinct destination attenuation factor for each RGB channel. It is retained
+// only for deferred ABI compatibility until an exact backend capability exists.
 //
-// Color is passed via uniform buffer in STRAIGHT alpha (same as glyph_mask.wgsl).
+// Color is passed via the uniform buffer premultiplied (same as glyph_mask.wgsl).
 //
 // TODO: When this shader is re-enabled (FEAT-TEXT-002 dual-source blending),
 // apply mask gamma correction per-channel as in glyph_mask.wgsl. The same
@@ -101,15 +102,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let clip_cov = rrect_clip_coverage(in.position.xy);
     let color = uniforms.color;
 
-    // Per-channel premultiplied alpha compositing:
-    //   output.r = color.r * cov_r * color.a * clip_cov
-    //   output.g = color.g * cov_g * color.a * clip_cov
-    //   output.b = color.b * cov_b * color.a * clip_cov
-    //   output.a = max(cov_r, cov_g, cov_b) * color.a * clip_cov
-    let a_r = cov_r * color.a * clip_cov;
-    let a_g = cov_g * color.a * clip_cov;
-    let a_b = cov_b * color.a * clip_cov;
-    let a_max = max(a_r, max(a_g, a_b));
+    // color is already premultiplied by the CPU. Per-channel coverage scales
+    // premultiplied RGB once; color.a is used only for the scalar source alpha.
+    // This keeps the dormant source convention correct even though scalar
+    // destination blending cannot composite these channels exactly.
+    let covered_r = cov_r * clip_cov;
+    let covered_g = cov_g * clip_cov;
+    let covered_b = cov_b * clip_cov;
+    let covered_max = max(covered_r, max(covered_g, covered_b));
 
-    return vec4<f32>(color.r * a_r, color.g * a_g, color.b * a_b, a_max);
+    return vec4<f32>(color.r * covered_r, color.g * covered_g, color.b * covered_b, color.a * covered_max);
 }

--- a/lcd_layout.go
+++ b/lcd_layout.go
@@ -2,26 +2,25 @@ package gg
 
 import "github.com/gogpu/gg/text"
 
-// LCDLayout describes the physical subpixel arrangement on the display.
+// LCDLayout describes a requested physical subpixel arrangement on the display.
 // Most LCD monitors use horizontal RGB stripe ordering, where each pixel
 // consists of three vertical subpixel columns (red, green, blue) from
-// left to right. ClearType-style rendering exploits this to triple the
-// effective horizontal resolution for text.
+// left to right. Backends without exact per-channel compositing may honor any
+// requested layout by rendering a portable grayscale glyph mask instead.
 //
 // Re-exported from text.LCDLayout for convenience so users do not need
 // to import the text subpackage for this common setting.
 type LCDLayout = text.LCDLayout
 
 const (
-	// LCDLayoutNone disables subpixel rendering (grayscale fallback).
-	// This is the default.
+	// LCDLayoutNone requests grayscale rendering. This is the default.
 	LCDLayoutNone = text.LCDLayoutNone
 
-	// LCDLayoutRGB is horizontal RGB ordering (most common: Windows, most monitors).
+	// LCDLayoutRGB requests horizontal RGB ordering (most monitors).
 	// Physical subpixels left-to-right: Red, Green, Blue.
 	LCDLayoutRGB = text.LCDLayoutRGB
 
-	// LCDLayoutBGR is horizontal BGR ordering (rare, some monitors).
+	// LCDLayoutBGR requests horizontal BGR ordering (rare, some monitors).
 	// Physical subpixels left-to-right: Blue, Green, Red.
 	LCDLayoutBGR = text.LCDLayoutBGR
 )

--- a/text.go
+++ b/text.go
@@ -337,7 +337,7 @@ func (c *Context) tryGPUGlyphMaskTextAliased(s string, x, y float64) bool {
 //
 // When TextModeAuto, the strategy is selected based on the current
 // transformation matrix and font size:
-//   - Horizontal text (no rotation/skew) at size < 48px: GlyphMask (Tier 6)
+//   - Horizontal text (no rotation/skew) at size <= 64px: GlyphMask (Tier 6)
 //     if a GPUGlyphMaskAccelerator is registered.
 //   - Everything else: falls through to TextModeAuto (MSDF -> CPU).
 //
@@ -392,6 +392,9 @@ func (c *Context) isCJKText(s string) bool {
 // glyphMaskDeviceSize returns the effective font size in device pixels,
 // accounting for deviceScale and the Y scale component of the matrix.
 func (c *Context) glyphMaskDeviceSize() float64 {
+	if c.face == nil {
+		return 0
+	}
 	deviceSize := c.face.Size() * c.deviceScale
 	absScale := c.matrix.E
 	if absScale < 0 {

--- a/text_strategy_test.go
+++ b/text_strategy_test.go
@@ -1,0 +1,141 @@
+package gg
+
+import (
+	"math"
+	"testing"
+
+	"golang.org/x/image/font/gofont/goregular"
+
+	"github.com/gogpu/gg/text"
+)
+
+type textStrategyGlyphMaskAccelerator struct {
+	*mockAccelerator
+	drawTextCalls int
+}
+
+func (*textStrategyGlyphMaskAccelerator) DrawGlyphMaskText(
+	GPURenderTarget, any, string, float64, float64, RGBA, Matrix, float64,
+) error {
+	return nil
+}
+
+func (a *textStrategyGlyphMaskAccelerator) DrawText(
+	GPURenderTarget, any, string, float64, float64, RGBA, Matrix, float64,
+) error {
+	a.drawTextCalls++
+	return nil
+}
+
+func installTextStrategyAccelerator(t *testing.T) *textStrategyGlyphMaskAccelerator {
+	t.Helper()
+	installed := &textStrategyGlyphMaskAccelerator{
+		mockAccelerator: &mockAccelerator{name: "glyph-mask-test", canAccel: AccelText},
+	}
+	accelMu.Lock()
+	previous := accel
+	accel = installed
+	accelMu.Unlock()
+	t.Cleanup(func() {
+		accelMu.Lock()
+		accel = previous
+		accelMu.Unlock()
+	})
+	return installed
+}
+
+func TestTextStrategyGlyphMaskDeviceThreshold(t *testing.T) {
+	t.Setenv("GOGPU_TEXT_MODE", "")
+	installTextStrategyAccelerator(t)
+
+	source, err := text.NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("NewFontSource: %v", err)
+	}
+	t.Cleanup(func() { _ = source.Close() })
+
+	tests := []struct {
+		name        string
+		faceSize    float64
+		deviceScale float64
+		matrix      Matrix
+		deviceSize  float64
+		want        TextMode
+	}{
+		{name: "63.99_at_1x", faceSize: 63.99, deviceScale: 1, matrix: Identity(), deviceSize: 63.99, want: TextModeGlyphMask},
+		{name: "64_at_1x", faceSize: 64, deviceScale: 1, matrix: Identity(), deviceSize: 64, want: TextModeGlyphMask},
+		{name: "64.01_at_1x", faceSize: 64.01, deviceScale: 1, matrix: Identity(), deviceSize: 64.01, want: TextModeAuto},
+		{name: "63.99_at_2x", faceSize: 63.99 / 2, deviceScale: 2, matrix: Identity(), deviceSize: 63.99, want: TextModeGlyphMask},
+		{name: "64_at_2x", faceSize: 32, deviceScale: 2, matrix: Identity(), deviceSize: 64, want: TextModeGlyphMask},
+		{name: "64.01_at_2x", faceSize: 64.01 / 2, deviceScale: 2, matrix: Identity(), deviceSize: 64.01, want: TextModeAuto},
+		{name: "63.99_uniform_CTM_scale", faceSize: 63.99 / 2, deviceScale: 1, matrix: Scale(2, 2), deviceSize: 63.99, want: TextModeGlyphMask},
+		{name: "64_uniform_CTM_scale", faceSize: 32, deviceScale: 1, matrix: Scale(2, 2), deviceSize: 64, want: TextModeGlyphMask},
+		{name: "64.01_uniform_CTM_scale", faceSize: 64.01 / 2, deviceScale: 1, matrix: Scale(2, 2), deviceSize: 64.01, want: TextModeAuto},
+		{name: "translation_is_allowed", faceSize: 12, deviceScale: 1, matrix: Translate(8, 13), deviceSize: 12, want: TextModeGlyphMask},
+		{name: "rotation_is_rejected", faceSize: 12, deviceScale: 1, matrix: Rotate(math.Pi / 4), deviceSize: 12 * math.Cos(math.Pi/4), want: TextModeAuto},
+		{name: "skew_is_rejected", faceSize: 12, deviceScale: 1, matrix: Shear(0.25, 0), deviceSize: 12, want: TextModeAuto},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dc := NewContext(16, 16, WithDeviceScale(tt.deviceScale))
+			t.Cleanup(func() { _ = dc.Close() })
+			dc.SetFont(source.Face(tt.faceSize))
+			dc.matrix = tt.matrix
+
+			if got := dc.glyphMaskDeviceSize(); math.Abs(got-tt.deviceSize) > 1e-9 {
+				t.Fatalf("glyphMaskDeviceSize() = %g, want %g", got, tt.deviceSize)
+			}
+			if got := dc.selectTextStrategy(); got != tt.want {
+				t.Errorf("selectTextStrategy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTextStrategyExplicitModesIgnoreAutoThresholds(t *testing.T) {
+	t.Setenv("GOGPU_TEXT_MODE", "")
+	dc := NewContext(16, 16)
+	t.Cleanup(func() { _ = dc.Close() })
+
+	for _, mode := range []TextMode{
+		TextModeGlyphMask,
+		TextModeAliased,
+		TextModeMSDF,
+		TextModeVector,
+		TextModeBitmap,
+	} {
+		dc.SetTextMode(mode)
+		dc.matrix = Rotate(math.Pi / 3)
+		if got := dc.selectTextStrategy(); got != mode {
+			t.Errorf("explicit %v selected %v", mode, got)
+		}
+	}
+}
+
+func TestTextStrategyAutoFallsThroughToMSDF(t *testing.T) {
+	t.Setenv("GOGPU_TEXT_MODE", "")
+	accelerator := installTextStrategyAccelerator(t)
+
+	source, err := text.NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("NewFontSource: %v", err)
+	}
+	t.Cleanup(func() { _ = source.Close() })
+
+	dc := NewContext(16, 16)
+	t.Cleanup(func() { _ = dc.Close() })
+	dc.SetFont(source.Face(glyphMaskMaxSize + 0.01))
+	dc.DrawString("A", 1, 12)
+	if accelerator.drawTextCalls != 1 {
+		t.Fatalf("MSDF DrawText calls = %d, want 1", accelerator.drawTextCalls)
+	}
+}
+
+func TestGlyphMaskDeviceSizeWithoutFont(t *testing.T) {
+	dc := NewContext(1, 1)
+	t.Cleanup(func() { _ = dc.Close() })
+	if got := dc.glyphMaskDeviceSize(); got != 0 {
+		t.Fatalf("glyphMaskDeviceSize() = %g, want 0 without a font", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implement ADR-060's portable Tier 1 GPU text policy:

- downgrade every current RGB/BGR LCD request to a genuine grayscale mask before rasterization
- retain `SetLCDLayout` / `LCDLayout` as a requested preference for future exact backends
- fix grayscale shader compositing so premultiplied color is applied exactly once
- preserve the latest main branch's inclusive `≤64` effective-device-pixel auto-routing boundary
- reject LCD resources when no exact LCD pipeline exists instead of reinterpreting them as grayscale
- invalidate cached masks when LCD filter weights actually change

## Root cause

The existing LCD shader emitted per-channel source coverage but standard WebGPU blending attenuated all destination channels with one scalar alpha. That cannot produce correct ClearType composition. The same path also premultiplied text color on the CPU and multiplied RGB by alpha again in the shader, darkening translucent text with an `alpha²` effect.

## Behavior after this change

Current GPU backends always rasterize R8 grayscale masks. For atlas coverage `m` and clip coverage `k`, the shader emits:

```text
(premul.rgb * m * k, color.a * m * k)
```

and uses ordinary premultiplied source-over blending. No destination readback or speculative capability API is introduced. The dormant LCD shader and 96-byte uniform ABI remain isolated for a future backend with exact per-channel destination blending.

Explicit text modes remain explicit; automatic glyph-mask selection keeps main's inclusive 64-physical-pixel boundary. CPU fallback, shaping, hinting, spacing, atlas layout, and render-session behavior are preserved.

## Validation

- `go test . -run 'Test.*(GlyphMask|TextStrategy|LCD)' -count=1`
- `go test ./internal/gpu -run 'Test(SelectGlyphMaskLCD|GlyphMaskEngine|GlyphMask.*LCD|MakeGlyphMask|HasLCDBatches|GlyphMask.*(Premul|Composite|RenderFrame|Spacing|Hint))' -count=1`
- `go test -race ./internal/gpu -run 'Test(SelectGlyphMaskLCD|GlyphMaskEngine)' -count=1`
- `go vet ./...`
- `go build ./...`
- `go test -tags nogpu ./... -count=1`

Tests cover opaque/translucent compositing over transparent, dark, light, and saturated destinations; coverage endpoints; None/RGB/BGR preference round-tripping with grayscale batches; layout-time downgrade; 63.99/64/64.01 boundaries under device/CTM scale; rotation/skew; LCD ABI isolation; pipeline mismatch refusal; cache invalidation; spacing; and hinting.

Closes #462.

