### PR TITLE
feat(text): add bounded CFF1 Type 2 outline support

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -330,6 +330,14 @@ dc.DrawString(s, x, y)
 | `text/glyph_outline.go` | `OutlineExtractor`, `GlyphOutline`, `OutlineSegment` |
 | `text/face.go` | `Face.Glyphs()`, `Face.Source()`, `Face.Size()` |
 
+OpenType outline extraction remains centralized in `text`. `ownParsedFont`
+lazily parses bounded CFF1 structures, including CID `FDArray`/`FDSelect` data
+and per-FD subroutines, behind `sync.Once`; `OutlineExtractor` keeps `glyf` as
+its first choice and otherwise executes bounded Type 2 charstrings into the
+existing cubic `GlyphOutline` representation before shared scaling and
+rasterization. Type 2 hint operators are consumed structurally but not
+executed; CFF2 outlines are explicitly unsupported.
+
 ## HiDPI/Retina Device Scale
 
 gg uses the Cairo-pattern `device_scale` for DPI-transparent drawing. User code

--- a/text/cff.go
+++ b/text/cff.go
@@ -1,0 +1,548 @@
+package text
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+type cffPrivate struct {
+	localSubrs   [][]byte
+	defaultWidth float64
+	nominalWidth float64
+}
+
+// cffFont contains only immutable data required to execute CFF1 glyphs.
+type cffFont struct {
+	charStrings [][]byte
+	globalSubrs [][]byte
+	private     cffPrivate
+	fdSelect    []uint16
+	fds         []cffPrivate
+}
+
+//nolint:gocognit,gocyclo,cyclop,funlen,nestif // CFF parsing is a linear, bounded validation pipeline; splitting it would obscure offset ownership.
+func parseCFF1(data []byte) (*cffFont, error) {
+	fail := func(format string, args ...any) (*cffFont, error) {
+		return nil, fmt.Errorf("text: CFF1: "+format, args...)
+	}
+	if len(data) < 4 {
+		return fail("truncated header")
+	}
+	if data[0] != 1 {
+		return fail("unsupported major version %d (CFF2 is unsupported)", data[0])
+	}
+	hdrSize := int(data[2])
+	if hdrSize < 4 || hdrSize > len(data) {
+		return fail("invalid header size %d", hdrSize)
+	}
+	if data[3] < 1 || data[3] > 4 {
+		return fail("invalid header offSize %d", data[3])
+	}
+	pos := hdrSize
+	names, pos, err := parseCFFIndex(data, pos, "Name INDEX")
+	if err != nil {
+		return fail("%v", err)
+	}
+	if len(names) != 1 {
+		return fail("Name INDEX has %d entries, want 1", len(names))
+	}
+	tops, pos, err := parseCFFIndex(data, pos, "Top DICT INDEX")
+	if err != nil {
+		return fail("%v", err)
+	}
+	if len(tops) != 1 {
+		return fail("Top DICT INDEX has %d entries, want 1", len(tops))
+	}
+	top, err := parseCFFDict(tops[0])
+	if err != nil {
+		return fail("Top DICT: %v", err)
+	}
+	_, pos, err = parseCFFIndex(data, pos, "String INDEX")
+	if err != nil {
+		return fail("%v", err)
+	}
+	global, _, err := parseCFFIndex(data, pos, "Global Subrs INDEX")
+	if err != nil {
+		return fail("%v", err)
+	}
+
+	charOff, err := dictOneInt(top, 17, true)
+	if err != nil {
+		return fail("CharStrings: %v", err)
+	}
+	charStrings, _, err := parseCFFIndex(data, charOff, "CharStrings INDEX")
+	if err != nil {
+		return fail("%v", err)
+	}
+	if len(charStrings) == 0 {
+		return fail("empty CharStrings INDEX")
+	}
+
+	f := &cffFont{charStrings: charStrings, globalSubrs: global}
+	if vals, ok := top[18]; ok {
+		if len(vals) != 2 {
+			return fail("Private DICT requires size and offset")
+		}
+		size, sizeErr := cffExactInt(vals[0])
+		off, offErr := cffExactInt(vals[1])
+		if sizeErr != nil || offErr != nil {
+			return fail("Private DICT has non-integer size or offset")
+		}
+		f.private, err = parseCFFPrivate(data, size, off)
+		if err != nil {
+			return fail("Top Private DICT: %v", err)
+		}
+	}
+	_, cid := top[1230] // ROS
+	if cid {
+		if len(top[1230]) != 3 {
+			return fail("ROS requires Registry, Ordering, and Supplement")
+		}
+		fdArrayOff, e := dictOneInt(top, 1236, true)
+		if e != nil {
+			return fail("FDArray: %v", e)
+		}
+		fdSelectOff, e := dictOneInt(top, 1237, true)
+		if e != nil {
+			return fail("FDSelect: %v", e)
+		}
+		fdDicts, _, e := parseCFFIndex(data, fdArrayOff, "FDArray INDEX")
+		if e != nil {
+			return fail("%v", e)
+		}
+		if len(fdDicts) == 0 {
+			return fail("empty FDArray INDEX")
+		}
+		f.fds = make([]cffPrivate, len(fdDicts))
+		for i, raw := range fdDicts {
+			d, e := parseCFFDict(raw)
+			if e != nil {
+				return fail("FDArray DICT %d: %v", i, e)
+			}
+			vals, ok := d[18]
+			if !ok || len(vals) != 2 {
+				return fail("FDArray DICT %d missing valid Private", i)
+			}
+			size, sizeErr := cffExactInt(vals[0])
+			off, offErr := cffExactInt(vals[1])
+			if sizeErr != nil || offErr != nil {
+				return fail("FDArray DICT %d Private has non-integer size or offset", i)
+			}
+			f.fds[i], e = parseCFFPrivate(data, size, off)
+			if e != nil {
+				return fail("FDArray DICT %d Private: %v", i, e)
+			}
+		}
+		f.fdSelect, e = parseCFFFDSelect(data, fdSelectOff, len(charStrings), len(f.fds))
+		if e != nil {
+			return fail("FDSelect: %v", e)
+		}
+	}
+	if off, ok := dictOptionalInt(top, 15); ok && off > 2 {
+		if err = parseCFFCharset(data, off, len(charStrings)); err != nil {
+			return fail("charset: %v", err)
+		}
+	}
+	if off, ok := dictOptionalInt(top, 16); ok && off > 1 && !cid {
+		if err = parseCFFEncoding(data, off); err != nil {
+			return fail("Encoding: %v", err)
+		}
+	}
+	return f, nil
+}
+
+func (f *cffFont) glyph(gid uint16) ([]byte, [][]byte, cffPrivate, error) {
+	if int(gid) >= len(f.charStrings) {
+		return nil, nil, cffPrivate{}, fmt.Errorf("text: CFF1: glyph ID %d out of range", gid)
+	}
+	p := f.private
+	if len(f.fds) != 0 {
+		if int(gid) >= len(f.fdSelect) {
+			return nil, nil, cffPrivate{}, fmt.Errorf("text: CFF1: missing FD selection for glyph %d", gid)
+		}
+		fd := int(f.fdSelect[gid])
+		if fd < 0 || fd >= len(f.fds) {
+			return nil, nil, cffPrivate{}, fmt.Errorf("text: CFF1: FD %d out of range", fd)
+		}
+		p = f.fds[fd]
+	}
+	return f.charStrings[gid], f.globalSubrs, p, nil
+}
+
+func parseCFFIndex(data []byte, pos int, label string) ([][]byte, int, error) {
+	if pos < 0 || pos+2 > len(data) {
+		return nil, pos, fmt.Errorf("%s truncated count", label)
+	}
+	count := int(binary.BigEndian.Uint16(data[pos : pos+2]))
+	pos += 2
+	if count == 0 {
+		return nil, pos, nil
+	}
+	if pos >= len(data) {
+		return nil, pos, fmt.Errorf("%s truncated offSize", label)
+	}
+	offSize := int(data[pos])
+	pos++
+	if offSize < 1 || offSize > 4 {
+		return nil, pos, fmt.Errorf("%s invalid offSize %d", label, offSize)
+	}
+	if count > 65535 || count+1 > (len(data)-pos)/offSize {
+		return nil, pos, fmt.Errorf("%s truncated offsets", label)
+	}
+	offs := make([]uint32, count+1)
+	for i := range offs {
+		var v uint32
+		for j := 0; j < offSize; j++ {
+			v = v<<8 | uint32(data[pos])
+			pos++
+		}
+		offs[i] = v
+	}
+	if offs[0] != 1 {
+		return nil, pos, fmt.Errorf("%s first offset is %d, want 1", label, offs[0])
+	}
+	last := uint64(offs[count])
+	if last < 1 {
+		return nil, pos, fmt.Errorf("%s invalid final offset", label)
+	}
+	dataLen := last - 1
+	if dataLen > uint64(len(data)-pos) {
+		return nil, pos, fmt.Errorf("%s data truncated", label)
+	}
+	objects := make([][]byte, count)
+	for i := range count {
+		if offs[i] < 1 || offs[i] > offs[i+1] || uint64(offs[i+1]) > last {
+			return nil, pos, fmt.Errorf("%s invalid offsets at entry %d", label, i)
+		}
+		start := pos + int(offs[i]-1)
+		end := pos + int(offs[i+1]-1)
+		objects[i] = data[start:end]
+	}
+	return objects, pos + int(dataLen), nil
+}
+
+func parseCFFDict(data []byte) (map[int][]float64, error) {
+	out := make(map[int][]float64)
+	operands := make([]float64, 0, 16)
+	for pos := 0; pos < len(data); {
+		b := data[pos]
+		if b >= 32 || b == 28 || b == 29 || b == 30 {
+			v, next, err := readCFFDictNumber(data, pos)
+			if err != nil {
+				return nil, err
+			}
+			if len(operands) >= 48 {
+				return nil, fmt.Errorf("operand stack overflow")
+			}
+			operands = append(operands, v)
+			pos = next
+			continue
+		}
+		pos++
+		op := int(b)
+		if b == 12 {
+			if pos >= len(data) {
+				return nil, fmt.Errorf("truncated escaped operator")
+			}
+			op = 1200 + int(data[pos])
+			pos++
+		}
+		if b == 31 || b == 255 {
+			return nil, fmt.Errorf("reserved operator byte %d", b)
+		}
+		vals := append([]float64(nil), operands...)
+		out[op] = vals
+		operands = operands[:0]
+	}
+	if len(operands) != 0 {
+		return nil, fmt.Errorf("trailing operands without operator")
+	}
+	return out, nil
+}
+
+//nolint:gocognit,gocyclo,cyclop // The branches directly mirror CFF DICT's finite numeric encodings.
+func readCFFDictNumber(data []byte, pos int) (float64, int, error) {
+	if pos >= len(data) {
+		return 0, pos, fmt.Errorf("truncated number")
+	}
+	b := data[pos]
+	switch {
+	case b >= 32 && b <= 246:
+		return float64(int(b) - 139), pos + 1, nil
+	case b >= 247 && b <= 250:
+		if pos+2 > len(data) {
+			return 0, pos, fmt.Errorf("truncated positive integer")
+		}
+		return float64((int(b)-247)*256 + int(data[pos+1]) + 108), pos + 2, nil
+	case b >= 251 && b <= 254:
+		if pos+2 > len(data) {
+			return 0, pos, fmt.Errorf("truncated negative integer")
+		}
+		return float64(-(int(b)-251)*256 - int(data[pos+1]) - 108), pos + 2, nil
+	case b == 28:
+		if pos+3 > len(data) {
+			return 0, pos, fmt.Errorf("truncated short integer")
+		}
+		return float64(int16(binary.BigEndian.Uint16(data[pos+1 : pos+3]))), pos + 3, nil
+	case b == 29:
+		if pos+5 > len(data) {
+			return 0, pos, fmt.Errorf("truncated long integer")
+		}
+		return float64(int32(binary.BigEndian.Uint32(data[pos+1 : pos+5]))), pos + 5, nil
+	case b == 30:
+		var s strings.Builder
+		done := false
+		for i := pos + 1; i < len(data); i++ {
+			for _, n := range []byte{data[i] >> 4, data[i] & 15} {
+				switch n {
+				case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9:
+					s.WriteByte('0' + n)
+				case 10:
+					s.WriteByte('.')
+				case 11:
+					s.WriteByte('E')
+				case 12:
+					s.WriteString("E-")
+				case 14:
+					s.WriteByte('-')
+				case 15:
+					done = true
+				default:
+					return 0, pos, fmt.Errorf("reserved real nibble %d", n)
+				}
+				if done {
+					v, e := strconv.ParseFloat(s.String(), 64)
+					if e != nil {
+						return 0, pos, fmt.Errorf("invalid real %q", s.String())
+					}
+					return v, i + 1, nil
+				}
+			}
+		}
+		return 0, pos, fmt.Errorf("truncated real")
+	default:
+		return 0, pos, fmt.Errorf("byte %d is not a DICT number", b)
+	}
+}
+
+func cffExactInt(v float64) (int, error) {
+	if math.IsNaN(v) || math.IsInf(v, 0) || v > float64(math.MaxInt) || v < float64(math.MinInt) || v != math.Trunc(v) {
+		return 0, fmt.Errorf("%v is not an integer", v)
+	}
+	return int(v), nil
+}
+func dictOneInt(d map[int][]float64, op int, required bool) (int, error) {
+	v, ok := d[op]
+	if !ok {
+		if required {
+			return 0, fmt.Errorf("missing operator %d", op)
+		}
+		return 0, nil
+	}
+	if len(v) != 1 {
+		return 0, fmt.Errorf("operator %d has %d operands", op, len(v))
+	}
+	n, err := cffExactInt(v[0])
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("operator %d has invalid offset %v", op, v[0])
+	}
+	return n, nil
+}
+func dictOptionalInt(d map[int][]float64, op int) (int, bool) {
+	v, ok := d[op]
+	if !ok || len(v) != 1 {
+		return 0, false
+	}
+	n, err := cffExactInt(v[0])
+	return n, err == nil && n >= 0
+}
+
+func parseCFFPrivate(data []byte, size, off int) (cffPrivate, error) {
+	var p cffPrivate
+	if size < 0 || off < 0 || off > len(data) || size > len(data)-off {
+		return p, fmt.Errorf("range [%d,%d) outside table", off, off+size)
+	}
+	d, err := parseCFFDict(data[off : off+size])
+	if err != nil {
+		return p, err
+	}
+	if v, ok := d[20]; ok {
+		if len(v) != 1 {
+			return p, fmt.Errorf("defaultWidthX has %d operands", len(v))
+		}
+		p.defaultWidth = v[0]
+	}
+	if v, ok := d[21]; ok {
+		if len(v) != 1 {
+			return p, fmt.Errorf("nominalWidthX has %d operands", len(v))
+		}
+		p.nominalWidth = v[0]
+	}
+	if rel, ok := dictOptionalInt(d, 19); ok {
+		absolute := off + rel
+		if absolute < off || absolute > len(data) {
+			return p, fmt.Errorf("subrs offset outside table")
+		}
+		p.localSubrs, _, err = parseCFFIndex(data, absolute, "Local Subrs INDEX")
+		if err != nil {
+			return p, err
+		}
+	}
+	return p, nil
+}
+
+//nolint:gocognit,gocyclo,cyclop // Keeping formats 0 and 3 together makes their shared bounds invariant explicit.
+func parseCFFFDSelect(data []byte, off, nGlyphs, nFDs int) ([]uint16, error) {
+	if off < 0 || off >= len(data) {
+		return nil, fmt.Errorf("offset %d outside table", off)
+	}
+	format := data[off]
+	off++
+	out := make([]uint16, nGlyphs)
+	switch format {
+	case 0:
+		if nGlyphs > len(data)-off {
+			return nil, fmt.Errorf("format 0 truncated")
+		}
+		for i := range nGlyphs {
+			fd := int(data[off+i])
+			if fd >= nFDs {
+				return nil, fmt.Errorf("glyph %d selects FD %d out of range", i, fd)
+			}
+			out[i] = uint16(fd)
+		}
+	case 3:
+		if off+2 > len(data) {
+			return nil, fmt.Errorf("format 3 truncated range count")
+		}
+		n := int(binary.BigEndian.Uint16(data[off : off+2]))
+		off += 2
+		if n == 0 || n > (len(data)-off)/3 {
+			return nil, fmt.Errorf("format 3 truncated ranges")
+		}
+		firsts := make([]int, n)
+		fds := make([]int, n)
+		for i := range n {
+			firsts[i] = int(binary.BigEndian.Uint16(data[off : off+2]))
+			fds[i] = int(data[off+2])
+			off += 3
+			if fds[i] >= nFDs {
+				return nil, fmt.Errorf("range %d selects FD %d out of range", i, fds[i])
+			}
+			if i == 0 && firsts[i] != 0 {
+				return nil, fmt.Errorf("first range starts at glyph %d", firsts[i])
+			}
+			if i > 0 && firsts[i] <= firsts[i-1] {
+				return nil, fmt.Errorf("ranges not increasing")
+			}
+		}
+		if off+2 > len(data) {
+			return nil, fmt.Errorf("format 3 missing sentinel")
+		}
+		sentinel := int(binary.BigEndian.Uint16(data[off : off+2]))
+		if sentinel != nGlyphs {
+			return nil, fmt.Errorf("sentinel %d does not equal glyph count %d", sentinel, nGlyphs)
+		}
+		for i := range n {
+			end := sentinel
+			if i+1 < n {
+				end = firsts[i+1]
+			}
+			for g := firsts[i]; g < end; g++ {
+				out[g] = uint16(fds[i])
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unsupported format %d", format)
+	}
+	return out, nil
+}
+
+func parseCFFCharset(data []byte, off, nGlyphs int) error {
+	if off < 0 || off >= len(data) {
+		return fmt.Errorf("offset outside table")
+	}
+	if nGlyphs <= 1 {
+		return nil
+	}
+	format := data[off]
+	off++
+	left := nGlyphs - 1
+	switch format {
+	case 0:
+		if left > (len(data)-off)/2 {
+			return fmt.Errorf("format 0 truncated")
+		}
+		return nil
+	case 1, 2:
+		for left > 0 {
+			need := 3
+			if format == 2 {
+				need = 4
+			}
+			if off+need > len(data) {
+				return fmt.Errorf("format %d truncated", format)
+			}
+			var n int
+			if format == 1 {
+				n = int(data[off+2])
+			} else {
+				n = int(binary.BigEndian.Uint16(data[off+2 : off+4]))
+			}
+			if n+1 > left {
+				return fmt.Errorf("format %d range exceeds glyph count", format)
+			}
+			left -= n + 1
+			off += need
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported format %d", format)
+	}
+}
+func parseCFFEncoding(data []byte, off int) error {
+	if off < 0 || off >= len(data) {
+		return fmt.Errorf("offset outside table")
+	}
+	format := data[off]
+	off++
+	base := format & 0x7f
+	switch base {
+	case 0:
+		if off >= len(data) {
+			return fmt.Errorf("format 0 truncated")
+		}
+		n := int(data[off])
+		off++
+		if n > len(data)-off {
+			return fmt.Errorf("format 0 codes truncated")
+		}
+		off += n
+	case 1:
+		if off >= len(data) {
+			return fmt.Errorf("format 1 truncated")
+		}
+		n := int(data[off])
+		off++
+		if n > (len(data)-off)/2 {
+			return fmt.Errorf("format 1 ranges truncated")
+		}
+		off += n * 2
+	default:
+		return fmt.Errorf("unsupported format %d", base)
+	}
+	if format&0x80 != 0 {
+		if off >= len(data) {
+			return fmt.Errorf("supplements truncated")
+		}
+		n := int(data[off])
+		off++
+		if n > (len(data)-off)/3 {
+			return fmt.Errorf("supplements truncated")
+		}
+	}
+	return nil
+}

--- a/text/cff_boundaries_test.go
+++ b/text/cff_boundaries_test.go
@@ -1,0 +1,257 @@
+package text
+
+import "testing"
+
+// cffWithTop builds the smallest complete CFF around a caller-supplied Top
+// DICT. Fixed-width offset operands make the second builder call stable.
+func cffWithTop(buildTop func(charStringsOffset, extraOffset int) []byte, charStrings, extra []byte) []byte {
+	name := cffIndexForTest([][]byte{[]byte("B")}, 1)
+	strings := cffIndexForTest(nil, 1)
+	globals := cffIndexForTest(nil, 1)
+	topObject := buildTop(0, 0)
+	charStringsOffset := 4 + len(name) + 5 + len(topObject) + len(strings) + len(globals)
+	extraOffset := charStringsOffset + len(charStrings)
+	topObject = buildTop(charStringsOffset, extraOffset)
+	top := cffIndexForTest([][]byte{topObject}, 1)
+	out := []byte{1, 0, 4, 1}
+	for _, part := range [][]byte{name, top, strings, globals, charStrings, extra} {
+		out = append(out, part...)
+	}
+	return out
+}
+
+func cffTopCharStrings(charStringsOffset int) []byte {
+	top := append([]byte(nil), cffLong(charStringsOffset)...)
+	return append(top, 17)
+}
+
+func requireCFFParseError(t *testing.T, data []byte) {
+	t.Helper()
+	if _, err := parseCFF1(data); err == nil {
+		t.Fatal("malformed CFF accepted")
+	}
+}
+
+func TestCFFTopPrivateAndOffsetBoundaries(t *testing.T) {
+	chars := cffIndexForTest([][]byte{{14}}, 1)
+	tests := map[string][]byte{
+		"missing CharStrings operator": cffWithTop(func(_, _ int) []byte { return nil }, chars, nil),
+		"malformed CharStrings INDEX":  cffWithTop(func(charOff, _ int) []byte { return cffTopCharStrings(charOff) }, []byte{0, 1, 0}, nil),
+		"empty CharStrings INDEX":      cffWithTop(func(charOff, _ int) []byte { return cffTopCharStrings(charOff) }, []byte{0, 0}, nil),
+		"Private arity": cffWithTop(func(charOff, _ int) []byte {
+			return append(cffTopCharStrings(charOff), 139, 18)
+		}, chars, nil),
+		"Private fractional size": cffWithTop(func(charOff, extraOff int) []byte {
+			top := append(cffTopCharStrings(charOff), 30, 0x1a, 0x5f)
+			top = append(top, cffLong(extraOff)...)
+			return append(top, 18)
+		}, chars, nil),
+		"Private fractional offset": cffWithTop(func(charOff, _ int) []byte {
+			top := append(cffTopCharStrings(charOff), 139, 30, 0x1a, 0x5f)
+			return append(top, 18)
+		}, chars, nil),
+		"Private outside table": cffWithTop(func(charOff, _ int) []byte {
+			top := append(cffTopCharStrings(charOff), 140)
+			top = append(top, cffLong(1<<20)...)
+			return append(top, 18)
+		}, chars, nil),
+	}
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) { requireCFFParseError(t, data) })
+	}
+
+	valid := cffWithTop(func(charOff, extraOff int) []byte {
+		top := append(cffTopCharStrings(charOff), 141)
+		top = append(top, cffLong(extraOff)...)
+		return append(top, 18)
+	}, chars, []byte{140, 20})
+	font, err := parseCFF1(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if font.private.defaultWidth != 1 {
+		t.Fatalf("defaultWidth=%g, want 1", font.private.defaultWidth)
+	}
+}
+
+// cffCIDWithFD builds a one-glyph CID CFF. fdKind selects an FD DICT
+// boundary while preserving valid surrounding offsets.
+func cffCIDWithFD(fdKind string, fdSelect []byte) []byte {
+	name := cffIndexForTest([][]byte{[]byte("D")}, 1)
+	strings, globals := cffIndexForTest(nil, 1), cffIndexForTest(nil, 1)
+	chars := cffIndexForTest([][]byte{{14}}, 1)
+	const topObjectLen = 25
+	charOff := 4 + len(name) + 5 + topObjectLen + len(strings) + len(globals)
+	fdArrayOff := charOff + len(chars)
+	dictLen := 7
+	switch fdKind {
+	case "malformed":
+		dictLen = 1
+	case "missing-private":
+		dictLen = 1
+	case "fractional-private":
+		dictLen = 9
+	}
+	fdArrayLen := 5 + dictLen
+	fdSelectOff := fdArrayOff + fdArrayLen
+	privateOff := fdSelectOff + len(fdSelect)
+	var private []byte
+	var fdDict []byte
+	switch fdKind {
+	case "malformed":
+		fdDict = []byte{31}
+	case "missing-private":
+		fdDict = []byte{17}
+	case "fractional-private":
+		fdDict = []byte{30, 0x1a, 0x5f}
+		fdDict = append(fdDict, cffLong(privateOff)...)
+		fdDict = append(fdDict, 18)
+	case "bad-private":
+		fdDict = append([]byte{140}, cffLong(privateOff)...)
+		fdDict = append(fdDict, 18)
+		private = []byte{31}
+	default:
+		fdDict = append([]byte{139}, cffLong(privateOff)...)
+		fdDict = append(fdDict, 18)
+	}
+	fdArray := cffIndexForTest([][]byte{fdDict}, 1)
+	top := make([]byte, 0, topObjectLen)
+	top = append(top, 139, 139, 139, 12, 30)
+	top = append(top, cffLong(charOff)...)
+	top = append(top, 17)
+	top = append(top, cffLong(fdArrayOff)...)
+	top = append(top, 12, 36)
+	top = append(top, cffLong(fdSelectOff)...)
+	top = append(top, 12, 37)
+	topIndex := cffIndexForTest([][]byte{top}, 1)
+	out := []byte{1, 0, 4, 1}
+	for _, part := range [][]byte{name, topIndex, strings, globals, chars, fdArray, fdSelect, private} {
+		out = append(out, part...)
+	}
+	return out
+}
+
+func TestCFFCIDStructuralErrorBoundaries(t *testing.T) {
+	chars := cffIndexForTest([][]byte{{14}}, 1)
+	ros := func(values ...byte) func(int, int) []byte {
+		return func(charOff, _ int) []byte {
+			top := append(cffTopCharStrings(charOff), values...)
+			return append(top, 12, 30)
+		}
+	}
+	tests := map[string][]byte{
+		"ROS arity":       cffWithTop(ros(139, 139), chars, nil),
+		"missing FDArray": cffWithTop(ros(139, 139, 139), chars, nil),
+		"missing FDSelect": cffWithTop(func(charOff, extraOff int) []byte {
+			top := ros(139, 139, 139)(charOff, extraOff)
+			top = append(top, cffLong(extraOff)...)
+			return append(top, 12, 36)
+		}, chars, nil),
+		"malformed FDArray": cffWithTop(func(charOff, extraOff int) []byte {
+			top := ros(139, 139, 139)(charOff, extraOff)
+			top = append(top, cffLong(extraOff)...)
+			top = append(top, 12, 36)
+			top = append(top, cffLong(extraOff)...)
+			return append(top, 12, 37)
+		}, chars, []byte{0}),
+		"empty FDArray": cffWithTop(func(charOff, extraOff int) []byte {
+			top := ros(139, 139, 139)(charOff, extraOff)
+			top = append(top, cffLong(extraOff)...)
+			top = append(top, 12, 36)
+			top = append(top, cffLong(extraOff+2)...)
+			return append(top, 12, 37)
+		}, chars, []byte{0, 0}),
+		"malformed FD DICT":     cffCIDWithFD("malformed", []byte{0, 0}),
+		"missing FD Private":    cffCIDWithFD("missing-private", []byte{0, 0}),
+		"fractional FD Private": cffCIDWithFD("fractional-private", []byte{0, 0}),
+		"malformed FD Private":  cffCIDWithFD("bad-private", []byte{0, 0}),
+		"malformed FDSelect":    cffCIDWithFD("valid", []byte{2}),
+	}
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) { requireCFFParseError(t, data) })
+	}
+}
+
+func TestCFFIntegratedCharsetAndEncodingErrors(t *testing.T) {
+	chars := cffIndexForTest([][]byte{{14}, {14}}, 1)
+	for name, op := range map[string]byte{"charset": 15, "encoding": 16} {
+		t.Run(name, func(t *testing.T) {
+			data := cffWithTop(func(charOff, extraOff int) []byte {
+				top := cffTopCharStrings(charOff)
+				top = append(top, cffLong(extraOff)...)
+				return append(top, op)
+			}, chars, []byte{3})
+			requireCFFParseError(t, data)
+		})
+	}
+}
+
+func TestCFFLowLevelUntrustedOffsetBoundaries(t *testing.T) {
+	for name, raw := range map[string][]byte{
+		"zero final offset":   {0, 1, 1, 1, 0},
+		"decreasing offsets":  {0, 2, 1, 1, 0, 1},
+		"object beyond final": {0, 2, 1, 1, 2, 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := parseCFFIndex(raw, 0, "boundary"); err == nil {
+				t.Fatal("invalid INDEX accepted")
+			}
+		})
+	}
+	if _, _, err := readCFFDictNumber(nil, 0); err == nil {
+		t.Fatal("out-of-range DICT number read accepted")
+	}
+	if _, _, err := readCFFDictNumber([]byte{30, 0xaf}, 0); err == nil {
+		t.Fatal("syntactically invalid real accepted")
+	}
+	if _, err := parseCFFPrivate([]byte{141, 19, 0}, 2, 0); err == nil {
+		t.Fatal("truncated Local Subrs INDEX accepted")
+	}
+	if _, err := parseCFFFDSelect([]byte{3, 0, 1, 0, 0, 0}, 0, 1, 1); err == nil {
+		t.Fatal("FDSelect without sentinel accepted")
+	}
+	if err := parseCFFCharset([]byte{1, 0, 1, 2}, 0, 3); err == nil {
+		t.Fatal("charset range exceeding glyph count accepted")
+	}
+	for name, data := range map[string][]byte{
+		"format 0 missing count": {0},
+		"format 1 missing count": {1},
+		"truncated supplements":  {0x80, 0, 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := parseCFFEncoding(data, 0); err == nil {
+				t.Fatal("invalid encoding accepted")
+			}
+		})
+	}
+}
+
+func TestCFFOutlineIntegrationErrorPropagation(t *testing.T) {
+	extractor := NewOutlineExtractor()
+	valid := &ownParsedFont{
+		upem:      1000,
+		numGlyphs: 2,
+		tables:    map[string][]byte{"CFF ": syntheticCFF1()},
+	}
+	if outline, err := extractor.extractCFF(valid, 9, 16, 10); err == nil || outline != nil {
+		t.Fatalf("out-of-range glyph: outline=%#v err=%v", outline, err)
+	}
+
+	chars := cffIndexForTest([][]byte{{14}, {2}}, 1)
+	malformedType2 := cffWithTop(func(charOff, _ int) []byte { return cffTopCharStrings(charOff) }, chars, nil)
+	invalidGlyph := &ownParsedFont{
+		upem:      1000,
+		numGlyphs: 2,
+		tables:    map[string][]byte{"CFF ": malformedType2},
+	}
+	if outline, err := extractor.extractCFF(invalidGlyph, 1, 16, 10); err == nil || outline != nil {
+		t.Fatalf("malformed Type 2: outline=%#v err=%v", outline, err)
+	}
+
+	// glyf remains authoritative when present, including its own zero-upem
+	// boundary rather than falling through to CFF.
+	glyfZeroUPEM := &ownParsedFont{upem: 0, tables: map[string][]byte{"glyf": {}}}
+	if bounds := glyfZeroUPEM.GlyphBounds(0, 16); bounds != (Rect{}) {
+		t.Fatalf("zero-upem glyf bounds=%v", bounds)
+	}
+}

--- a/text/cff_test.go
+++ b/text/cff_test.go
@@ -1,0 +1,650 @@
+package text
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+)
+
+func cffIndexForTest(objects [][]byte, offSize int) []byte {
+	if len(objects) == 0 {
+		return []byte{0, 0}
+	}
+	payloadLen := 0
+	for _, object := range objects {
+		payloadLen += len(object)
+	}
+	headerLen := 3 + (len(objects)+1)*offSize
+	b := make([]byte, headerLen, headerLen+payloadLen)
+	binary.BigEndian.PutUint16(b, uint16(len(objects)))
+	b[2] = byte(offSize)
+	pos := 1
+	write := func(at, v int) {
+		for j := offSize - 1; j >= 0; j-- {
+			b[at+j] = byte(v)
+			v >>= 8
+		}
+	}
+	at := 3
+	write(at, pos)
+	at += offSize
+	for _, o := range objects {
+		pos += len(o)
+		write(at, pos)
+		at += offSize
+	}
+	for _, o := range objects {
+		b = append(b, o...)
+	}
+	return b
+}
+func cffLong(v int) []byte {
+	return []byte{29, byte(uint32(v) >> 24), byte(uint32(v) >> 16), byte(uint32(v) >> 8), byte(v)}
+}
+
+func syntheticCFF1() []byte {
+	name := cffIndexForTest([][]byte{[]byte("T")}, 1)
+	strings := cffIndexForTest(nil, 1)
+	globals := cffIndexForTest([][]byte{t2prog(300, 0, byte(5), byte(11))}, 1)
+	g0 := []byte{14}
+	g1 := t2prog(100, 200, byte(21), -107, byte(29), 0, 400, -300, 0, byte(5), byte(14))
+	chars := cffIndexForTest([][]byte{g0, g1}, 1)
+	// The fixed-width long DICT operand makes the offset independent of value.
+	topLen := 2 + 1 + 2 + 6
+	charOff := 4 + len(name) + topLen + len(strings) + len(globals)
+	topObj := append(cffLong(charOff), 17)
+	top := cffIndexForTest([][]byte{topObj}, 1)
+	b := make([]byte, 0, 4+len(name)+len(top)+len(strings)+len(globals)+len(chars))
+	b = append(b, 1, 0, 4, 1)
+	b = append(b, name...)
+	b = append(b, top...)
+	b = append(b, strings...)
+	b = append(b, globals...)
+	b = append(b, chars...)
+	return b
+}
+
+func syntheticCIDCFF(fdSelectFormat byte) []byte {
+	name := cffIndexForTest([][]byte{[]byte("C")}, 1)
+	strings, globals := cffIndexForTest(nil, 1), cffIndexForTest(nil, 1)
+	chars := cffIndexForTest([][]byte{{14}, t2prog(0, 0, byte(21), -107, byte(10), byte(14))}, 1)
+	topObjectLen := 5 + 6 + 7 + 7 // ROS, CharStrings, FDArray, FDSelect.
+	prefixLen := 4 + len(name) + (2 + 1 + 2 + topObjectLen) + len(strings) + len(globals)
+	charOff := prefixLen
+	fdArrayOff := charOff + len(chars)
+	var fdSelect []byte
+	if fdSelectFormat == 0 {
+		fdSelect = []byte{0, 0, 1}
+	} else {
+		fdSelect = []byte{3, 0, 2, 0, 0, 0, 0, 1, 1, 0, 2}
+	}
+	// Each FD DICT is seven bytes (size, long offset, Private operator), so
+	// the two-entry INDEX is twenty bytes. Each four-byte Private DICT points
+	// to the Local Subrs INDEX immediately following it.
+	private0Off := fdArrayOff + 20 + len(fdSelect)
+	private0 := []byte{143, 19, 149, 21} // Subrs=+4, nominalWidthX=10.
+	local0 := cffIndexForTest([][]byte{{11}}, 1)
+	private1Off := private0Off + len(private0) + len(local0)
+	private1 := []byte{143, 19, 159, 21} // Subrs=+4, nominalWidthX=20.
+	local1 := cffIndexForTest([][]byte{{11}, {11}}, 1)
+	fd0 := append([]byte{143}, cffLong(private0Off)...)
+	fd0 = append(fd0, 18)
+	fd1 := append([]byte{143}, cffLong(private1Off)...)
+	fd1 = append(fd1, 18)
+	fdArray := cffIndexForTest([][]byte{fd0, fd1}, 1)
+	fdSelectOff := fdArrayOff + len(fdArray)
+	topObj := make([]byte, 0, topObjectLen)
+	topObj = append(topObj, 139, 139, 139, 12, 30)
+	topObj = append(topObj, cffLong(charOff)...)
+	topObj = append(topObj, 17)
+	topObj = append(topObj, cffLong(fdArrayOff)...)
+	topObj = append(topObj, 12, 36)
+	topObj = append(topObj, cffLong(fdSelectOff)...)
+	topObj = append(topObj, 12, 37)
+	top := cffIndexForTest([][]byte{topObj}, 1)
+	b := []byte{1, 0, 4, 1}
+	for _, part := range [][]byte{name, top, strings, globals, chars, fdArray, fdSelect, private0, local0, private1, local1} {
+		b = append(b, part...)
+	}
+	return b
+}
+
+func TestCFFIndexOffSizesAndMalformed(t *testing.T) {
+	for offSize := 1; offSize <= 4; offSize++ {
+		t.Run(fmt.Sprintf("offSize%d", offSize), func(t *testing.T) {
+			raw := cffIndexForTest([][]byte{[]byte("a"), []byte("bc")}, offSize)
+			got, next, err := parseCFFIndex(raw, 0, "test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if next != len(raw) || string(got[0]) != "a" || string(got[1]) != "bc" {
+				t.Fatalf("got=%q next=%d", got, next)
+			}
+		})
+	}
+	bad := [][]byte{{0}, {0, 1}, {0, 1, 0}, {0, 1, 1, 2, 1}, {0, 1, 1, 1, 5, 0}}
+	for i, raw := range bad {
+		if _, _, err := parseCFFIndex(raw, 0, "bad"); err == nil {
+			t.Errorf("bad case %d accepted", i)
+		}
+	}
+}
+
+func TestCFFDictNumbersAndReal(t *testing.T) {
+	// -1, 108, int16(-32768), int32(65536), real 1.5, then operator 17.
+	raw := []byte{138, 247, 0, 28, 0x80, 0, 29, 0, 1, 0, 0, 30, 0x1a, 0x5f, 17}
+	d, err := parseCFFDict(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := d[17]
+	want := []float64{-1, 108, -32768, 65536, 1.5}
+	if len(v) != len(want) {
+		t.Fatalf("values=%v", v)
+	}
+	for i := range want {
+		if v[i] != want[i] {
+			t.Errorf("value %d=%v want %v", i, v[i], want[i])
+		}
+	}
+	for _, raw := range [][]byte{{28, 1}, {29, 0}, {30, 0x1a}, {12}, {31}} {
+		if _, err := parseCFFDict(raw); err == nil {
+			t.Errorf("accepted malformed DICT %v", raw)
+		}
+	}
+}
+
+func TestCFFHelperBoundaryValidation(t *testing.T) {
+	for name, data := range map[string][]byte{
+		"header size":    {1, 0, 3, 1},
+		"header offSize": {1, 0, 4, 0},
+		"empty name":     append([]byte{1, 0, 4, 1}, cffIndexForTest(nil, 1)...),
+		"two names":      append([]byte{1, 0, 4, 1}, cffIndexForTest([][]byte{[]byte("A"), []byte("B")}, 1)...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseCFF1(data); err == nil {
+				t.Fatal("malformed CFF accepted")
+			}
+		})
+	}
+
+	validName := cffIndexForTest([][]byte{[]byte("A")}, 1)
+	for name, top := range map[string][]byte{
+		"empty top":      cffIndexForTest(nil, 1),
+		"two top dicts":  cffIndexForTest([][]byte{{17}, {17}}, 1),
+		"malformed dict": cffIndexForTest([][]byte{{31}}, 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			data := append([]byte{1, 0, 4, 1}, validName...)
+			data = append(data, top...)
+			if _, err := parseCFF1(data); err == nil {
+				t.Fatal("malformed Top DICT accepted")
+			}
+		})
+	}
+
+	if value, next, err := readCFFDictNumber([]byte{251, 0}, 0); err != nil || value != -108 || next != 2 {
+		t.Fatalf("negative DICT number = (%g,%d,%v), want (-108,2,nil)", value, next, err)
+	}
+	for name, raw := range map[string][]byte{
+		"positive truncated": {247},
+		"negative truncated": {251},
+		"reserved nibble":    {30, 0xd0},
+		"invalid byte":       {31},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := readCFFDictNumber(raw, 0); err == nil {
+				t.Fatal("malformed DICT number accepted")
+			}
+		})
+	}
+	for name, raw := range map[string][]byte{
+		"exponent":          {30, 0x1b, 0x2f},
+		"negative exponent": {30, 0x1c, 0x2f},
+		"minus":             {30, 0xe1, 0xf0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := readCFFDictNumber(raw, 0); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+	for _, value := range []float64{math.NaN(), math.Inf(1), 1.5} {
+		if _, err := cffExactInt(value); err == nil {
+			t.Errorf("cffExactInt(%v) accepted", value)
+		}
+	}
+	if _, err := dictOneInt(map[int][]float64{}, 17, true); err == nil {
+		t.Fatal("missing required DICT operator accepted")
+	}
+	if value, err := dictOneInt(map[int][]float64{}, 17, false); err != nil || value != 0 {
+		t.Fatalf("optional DICT operator = (%d,%v), want (0,nil)", value, err)
+	}
+	if _, err := dictOneInt(map[int][]float64{17: {1, 2}}, 17, true); err == nil {
+		t.Fatal("multi-operand singleton operator accepted")
+	}
+	if _, err := dictOneInt(map[int][]float64{17: {-1}}, 17, true); err == nil {
+		t.Fatal("negative DICT offset accepted")
+	}
+
+	private, err := parseCFFPrivate([]byte{140, 20, 141, 21}, 4, 0)
+	if err != nil || private.defaultWidth != 1 || private.nominalWidth != 2 {
+		t.Fatalf("private=%#v err=%v", private, err)
+	}
+	for name, data := range map[string][]byte{
+		"bad dict":        {31},
+		"default arity":   {139, 140, 20},
+		"nominal arity":   {139, 140, 21},
+		"subrs out range": {239, 19},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseCFFPrivate(data, len(data), 0); err == nil {
+				t.Fatal("malformed Private DICT accepted")
+			}
+		})
+	}
+
+	if err := parseCFFCharset([]byte{0}, 0, 1); err != nil {
+		t.Fatalf("single-glyph predefined charset: %v", err)
+	}
+	if err := parseCFFCharset(nil, -1, 2); err == nil {
+		t.Fatal("negative charset offset accepted")
+	}
+	if err := parseCFFEncoding(nil, -1); err == nil {
+		t.Fatal("negative encoding offset accepted")
+	}
+
+	for name, test := range map[string]struct {
+		data    []byte
+		nGlyphs int
+		nFDs    int
+	}{
+		"offset":           {[]byte{0}, 1, 1},
+		"format0 fd":       {[]byte{0, 2}, 1, 2},
+		"format3 count":    {[]byte{3}, 1, 1},
+		"format3 fd":       {[]byte{3, 0, 1, 0, 0, 2, 0, 1}, 1, 2},
+		"format3 order":    {[]byte{3, 0, 2, 0, 0, 0, 0, 0, 1, 0, 2}, 2, 2},
+		"format3 sentinel": {[]byte{3, 0, 1, 0, 0, 0}, 1, 1},
+		"format3 glyphs":   {[]byte{3, 0, 1, 0, 0, 0, 0, 1}, 2, 1},
+	} {
+		t.Run("fdselect "+name, func(t *testing.T) {
+			offset := 0
+			if name == "offset" {
+				offset = 1
+			}
+			if _, err := parseCFFFDSelect(test.data, offset, test.nGlyphs, test.nFDs); err == nil {
+				t.Fatal("malformed FDSelect accepted")
+			}
+		})
+	}
+
+	for name, raw := range map[string][]byte{
+		"operand overflow": append(make([]byte, 49), 17),
+		"trailing operand": {139},
+	} {
+		if name == "operand overflow" {
+			for i := range raw[:49] {
+				raw[i] = 139
+			}
+		}
+		t.Run("dict "+name, func(t *testing.T) {
+			if _, err := parseCFFDict(raw); err == nil {
+				t.Fatal("malformed DICT accepted")
+			}
+		})
+	}
+
+	for name, font := range map[string]*cffFont{
+		"missing selection": {charStrings: [][]byte{{14}}, fdSelect: nil, fds: []cffPrivate{{}}},
+		"fd out of range":   {charStrings: [][]byte{{14}}, fdSelect: []uint16{1}, fds: []cffPrivate{{}}},
+	} {
+		t.Run("glyph "+name, func(t *testing.T) {
+			if _, _, _, err := font.glyph(0); err == nil {
+				t.Fatal("invalid CID glyph selection accepted")
+			}
+		})
+	}
+}
+
+func TestCFFOrdinaryParseAndGlyph(t *testing.T) {
+	f, err := parseCFF1(syntheticCFF1())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.charStrings) != 2 {
+		t.Fatalf("glyph count=%d", len(f.charStrings))
+	}
+	cs, global, p, err := f.glyph(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := decodeType2(cs, p.localSubrs, global, p.nominalWidth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.segments) != 4 {
+		t.Fatalf("segments=%#v", r.segments)
+	}
+	if _, _, _, err = f.glyph(2); err == nil {
+		t.Fatal("expected glyph range error")
+	}
+	bad := syntheticCFF1()
+	bad[0] = 2
+	if _, err = parseCFF1(bad); err == nil {
+		t.Fatal("CFF2 major version accepted")
+	}
+	for n := 0; n < len(syntheticCFF1()); n++ {
+		if _, err := parseCFF1(syntheticCFF1()[:n]); err == nil {
+			t.Fatalf("truncation at %d accepted", n)
+		}
+	}
+}
+
+func TestCFFFDSelectFormats(t *testing.T) {
+	f0 := []byte{0, 0, 1, 1}
+	got, err := parseCFFFDSelect(f0, 0, 3, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fmt.Sprint(got) != "[0 1 1]" {
+		t.Fatalf("format0=%v", got)
+	}
+	f3 := []byte{3, 0, 2, 0, 0, 0, 0, 2, 1, 0, 4}
+	got, err = parseCFFFDSelect(f3, 0, 4, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fmt.Sprint(got) != "[0 0 1 1]" {
+		t.Fatalf("format3=%v", got)
+	}
+	for _, bad := range [][]byte{{2}, {0, 2}, {3, 0, 0}, {3, 0, 1, 0, 1, 0, 0, 2}} {
+		if _, err := parseCFFFDSelect(bad, 0, 2, 2); err == nil {
+			t.Errorf("accepted malformed FDSelect %v", bad)
+		}
+	}
+	// Selection must carry the per-FD local subroutine set and widths.
+	c := &cffFont{charStrings: [][]byte{{14}, {14}}, fdSelect: []uint16{0, 1}, fds: []cffPrivate{{nominalWidth: 10, localSubrs: [][]byte{{11}}}, {nominalWidth: 20, localSubrs: [][]byte{{11}, {11}}}}}
+	_, _, p, err := c.glyph(1)
+	if err != nil || p.nominalWidth != 20 || len(p.localSubrs) != 2 {
+		t.Fatalf("selected private=%#v err=%v", p, err)
+	}
+	for _, format := range []byte{0, 3} {
+		parsed, err := parseCFF1(syntheticCIDCFF(format))
+		if err != nil {
+			t.Fatalf("CID format %d: %v", format, err)
+		}
+		_, _, private, err := parsed.glyph(1)
+		if err != nil || private.nominalWidth != 20 || len(private.localSubrs) != 2 {
+			t.Fatalf("CID format %d selected %#v, %v", format, private, err)
+		}
+		if _, err := decodeType2(parsed.charStrings[1], private.localSubrs, parsed.globalSubrs, private.nominalWidth); err != nil {
+			t.Fatalf("CID format %d decode: %v", format, err)
+		}
+	}
+}
+
+func TestCFFCharsetEncodingAndPrivateBounds(t *testing.T) {
+	for name, data := range map[string][]byte{
+		"charset0": {0, 0, 1, 0, 2},
+		"charset1": {1, 0, 1, 1},
+		"charset2": {2, 0, 1, 0, 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := parseCFFCharset(data, 0, 3); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+	for name, data := range map[string][]byte{
+		"encoding0":  {0, 2, 65, 66},
+		"encoding1":  {1, 1, 65, 1},
+		"supplement": {0x80, 1, 65, 1, 66, 0, 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := parseCFFEncoding(data, 0); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+	for _, data := range [][]byte{{3}, {0, 0}, {1, 0, 1}, {2, 0, 1, 0}} {
+		if err := parseCFFCharset(data, 0, 3); err == nil {
+			t.Errorf("accepted malformed charset %v", data)
+		}
+	}
+	for _, data := range [][]byte{{2}, {0, 2, 65}, {1, 1, 65}, {0x80, 0}} {
+		if err := parseCFFEncoding(data, 0); err == nil {
+			t.Errorf("accepted malformed encoding %v", data)
+		}
+	}
+	if _, err := parseCFFPrivate([]byte{1, 2}, 3, 0); err == nil {
+		t.Fatal("accepted out-of-range Private DICT")
+	}
+}
+
+func syntheticCFFOTF() []byte {
+	tables := map[string][]byte{}
+	head := make([]byte, 54)
+	binary.BigEndian.PutUint16(head[18:20], 1000)
+	tables["head"] = head
+	maxp := make([]byte, 6)
+	binary.BigEndian.PutUint32(maxp[:4], 0x00005000)
+	binary.BigEndian.PutUint16(maxp[4:], 2)
+	tables["maxp"] = maxp
+	hhea := make([]byte, 36)
+	binary.BigEndian.PutUint16(hhea[34:], 2)
+	tables["hhea"] = hhea
+	hmtx := make([]byte, 8)
+	binary.BigEndian.PutUint16(hmtx[0:2], 500)
+	binary.BigEndian.PutUint16(hmtx[4:6], 700)
+	binary.BigEndian.PutUint16(hmtx[6:8], int16bits(50))
+	tables["hmtx"] = hmtx
+	cmap := make([]byte, 12+28)
+	binary.BigEndian.PutUint16(cmap[2:4], 1)
+	binary.BigEndian.PutUint16(cmap[4:6], 3)
+	binary.BigEndian.PutUint16(cmap[6:8], 10)
+	binary.BigEndian.PutUint32(cmap[8:12], 12)
+	binary.BigEndian.PutUint16(cmap[12:14], 12)
+	binary.BigEndian.PutUint32(cmap[16:20], 28)
+	binary.BigEndian.PutUint32(cmap[24:28], 1)
+	binary.BigEndian.PutUint32(cmap[28:32], 65)
+	binary.BigEndian.PutUint32(cmap[32:36], 65)
+	binary.BigEndian.PutUint32(cmap[36:40], 1)
+	tables["cmap"] = cmap
+	tables["CFF "] = syntheticCFF1()
+	tags := []string{"CFF ", "cmap", "head", "hhea", "hmtx", "maxp"}
+	header := 12 + 16*len(tags)
+	total := header
+	for _, tag := range tags {
+		total = (total + 3) &^ 3
+		total += len(tables[tag])
+	}
+	out := make([]byte, total)
+	copy(out[:4], "OTTO")
+	binary.BigEndian.PutUint16(out[4:6], uint16(len(tags)))
+	off := header
+	for i, tag := range tags {
+		off = (off + 3) &^ 3
+		rec := 12 + i*16
+		copy(out[rec:rec+4], tag)
+		binary.BigEndian.PutUint32(out[rec+8:rec+12], uint32(off))
+		binary.BigEndian.PutUint32(out[rec+12:rec+16], uint32(len(tables[tag])))
+		copy(out[off:], tables[tag])
+		off += len(tables[tag])
+	}
+	return out
+}
+func int16bits(v int16) uint16 { return uint16(v) }
+
+func TestOutlineExtractionCFF(t *testing.T) {
+	parsed, err := getParser(defaultParserName).Parse(syntheticCFFOTF())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gid := parsed.GlyphIndex('A'); gid != 1 {
+		t.Fatalf("gid=%d", gid)
+	}
+	e := NewOutlineExtractor()
+	for _, size := range []float64{10, 20} {
+		o, err := e.ExtractOutline(parsed, 1, size)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(o.Segments) != 4 || o.Advance != float32(700*size/1000) || o.LSB != float32(50*size/1000) {
+			t.Fatalf("size %v outline=%#v", size, o)
+		}
+		wantBounds := Rect{MinX: 0.1 * size, MinY: -0.6 * size, MaxX: 0.4 * size, MaxY: -0.2 * size}
+		if math.Abs(o.Bounds.MinX-wantBounds.MinX) > 1e-5 || math.Abs(o.Bounds.MinY-wantBounds.MinY) > 1e-5 || math.Abs(o.Bounds.MaxX-wantBounds.MaxX) > 1e-5 || math.Abs(o.Bounds.MaxY-wantBounds.MaxY) > 1e-5 {
+			t.Errorf("size %v bounds=%+.12v want=%+.12v", size, o.Bounds, wantBounds)
+		}
+		if got := parsed.GlyphBounds(1, size); got != o.Bounds {
+			t.Errorf("GlyphBounds=%v outline=%v", got, o.Bounds)
+		}
+		if _, err = e.ExtractOutlineHinted(parsed, 1, size, HintingVertical); err != nil {
+			t.Fatal(err)
+		}
+		if _, err = e.ExtractOutlineHintedVar(parsed, 1, size, HintingNone, []FontVariation{{Tag: [4]byte{'w', 'g', 'h', 't'}, Value: 700}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rasterized := RasterizeGlyph(parsed, 1, 32)
+	if rasterized == nil || rasterized.Mask == nil {
+		t.Fatal("public RasterizeGlyph returned no CFF mask")
+	}
+	nonEmpty := false
+	for _, alpha := range rasterized.Mask.Pix {
+		if alpha != 0 {
+			nonEmpty = true
+			break
+		}
+	}
+	if !nonEmpty {
+		t.Fatal("public RasterizeGlyph returned an empty CFF mask")
+	}
+	const goroutines = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			o, e := NewOutlineExtractor().ExtractOutline(parsed, 1, 18)
+			if e != nil {
+				errs <- e
+			} else if len(o.Segments) != 4 {
+				errs <- fmt.Errorf("got %d segments", len(o.Segments))
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func TestOutlineCFF2UnsupportedAndNoOutline(t *testing.T) {
+	base := syntheticCFFOTF()
+	tables, err := parseFontTables(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &ownParsedFont{tables: map[string][]byte{"CFF2": {2, 0, 5, 0, 0}}, rawData: base, upem: 1000, numGlyphs: 2}
+	if _, err := NewOutlineExtractor().ExtractOutline(f, 1, 12); err == nil {
+		t.Fatal("expected contextual CFF2 unsupported error")
+	}
+	f = &ownParsedFont{tables: tables, rawData: base, upem: 1000, numGlyphs: 2}
+	delete(f.tables, "CFF ")
+	o, err := NewOutlineExtractor().ExtractOutline(f, 1, 12)
+	if err != nil || o != nil {
+		t.Fatalf("missing outline got %#v, %v", o, err)
+	}
+}
+
+func TestCFFOutlineErrorBoundaries(t *testing.T) {
+	valid := syntheticCFF1()
+	for name, font := range map[string]*ownParsedFont{
+		"zero upem":     {upem: 0, numGlyphs: 2, tables: map[string][]byte{"CFF ": valid}},
+		"missing table": {upem: 1000, numGlyphs: 2, tables: map[string][]byte{}},
+		"malformed CFF": {upem: 1000, numGlyphs: 2, tables: map[string][]byte{"CFF ": {1}}},
+		"glyph range":   {upem: 1000, numGlyphs: 2, tables: map[string][]byte{"CFF ": valid}},
+		"empty glyph":   {upem: 1000, numGlyphs: 2, tables: map[string][]byte{"CFF ": valid}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gid := uint16(1)
+			if name == "glyph range" {
+				gid = 9
+			}
+			if name == "empty glyph" {
+				gid = 0
+			}
+			if bounds := font.cffGlyphBounds(gid, 16); bounds != (Rect{}) {
+				t.Fatalf("bounds=%v, want empty", bounds)
+			}
+		})
+	}
+
+	mismatch := &ownParsedFont{
+		numGlyphs: 3,
+		tables:    map[string][]byte{"CFF ": valid},
+	}
+	if _, err := mismatch.loadCFF(); err == nil {
+		t.Fatal("CharStrings/maxp glyph-count mismatch accepted")
+	}
+
+	extractor := NewOutlineExtractor()
+	for name, font := range map[string]*ownParsedFont{
+		"missing CFF": {upem: 1000, numGlyphs: 2, tables: map[string][]byte{}},
+		"invalid CFF": {upem: 1000, numGlyphs: 2, tables: map[string][]byte{"CFF ": {1}}},
+	} {
+		t.Run("extract "+name, func(t *testing.T) {
+			outline, err := extractor.extractCFF(font, 1, 16, 10)
+			if name == "missing CFF" {
+				if err != nil || outline != nil {
+					t.Fatalf("outline=%#v err=%v, want nil nil", outline, err)
+				}
+				return
+			}
+			if err == nil || outline != nil {
+				t.Fatalf("outline=%#v err=%v, want contextual error", outline, err)
+			}
+		})
+	}
+
+	if bounds := outlineSegmentBounds(nil); bounds != (Rect{}) {
+		t.Fatalf("empty outline bounds=%v", bounds)
+	}
+}
+
+func BenchmarkCFFOutlineCold(b *testing.B) {
+	data := syntheticCFFOTF()
+	b.ReportAllocs()
+	for b.Loop() {
+		p, err := getParser(defaultParserName).Parse(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err = NewOutlineExtractor().ExtractOutline(p, 1, 16); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+func BenchmarkCFFOutlineParsed(b *testing.B) {
+	p, err := getParser(defaultParserName).Parse(syntheticCFFOTF())
+	if err != nil {
+		b.Fatal(err)
+	}
+	e := NewOutlineExtractor()
+	if _, err = e.ExtractOutline(p, 1, 16); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err = e.ExtractOutline(p, 1, 16); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/text/font_parser_own.go
+++ b/text/font_parser_own.go
@@ -116,6 +116,13 @@ type ownParsedFont struct {
 	gvar     *gvarTable // nil if gvar not present or failed to parse
 	avarOnce sync.Once
 	avar     *avarTable // nil if avar not present
+
+	// CFF1 outlines — parsed on first outline or bounds request. cffErr is
+	// retained with the result so malformed-font failures are deterministic
+	// across callers and safe under concurrent extraction.
+	cffOnce sync.Once
+	cff     *cffFont
+	cffErr  error
 }
 
 // --- ParsedFont interface ---
@@ -162,11 +169,14 @@ func (f *ownParsedFont) GlyphAdvance(glyphIndex uint16, ppem float64) float64 {
 // GlyphBounds implements ParsedFont.GlyphBounds.
 // Returns the glyph bounding box scaled from font units to pixels.
 //
-// Uses the glyf table for TrueType outlines. CFF fonts are not yet
-// supported by the own parser (returns zero rect).
+// Uses the glyf table for TrueType outlines and lazily executes CFF1 Type 2
+// charstrings when glyf is absent.
 func (f *ownParsedFont) GlyphBounds(glyphIndex uint16, ppem float64) Rect {
 	glyfData, ok := f.tables["glyf"]
-	if !ok || f.upem == 0 {
+	if !ok {
+		return f.cffGlyphBounds(glyphIndex, ppem)
+	}
+	if f.upem == 0 {
 		return Rect{}
 	}
 
@@ -216,6 +226,42 @@ func (f *ownParsedFont) GlyphBounds(glyphIndex uint16, ppem float64) Rect {
 		MaxX: float64(xMax) * scale,
 		MaxY: float64(-yMin) * scale, // Y-UP → Y-DOWN: negate and swap
 	}
+}
+
+func (f *ownParsedFont) cffGlyphBounds(glyphIndex uint16, ppem float64) Rect {
+	if f.upem == 0 || f.tables["CFF "] == nil {
+		return Rect{}
+	}
+	cff, err := f.loadCFF()
+	if err != nil || cff == nil {
+		return Rect{}
+	}
+	charstring, global, private, err := cff.glyph(glyphIndex)
+	if err != nil {
+		return Rect{}
+	}
+	decoded, err := decodeType2(charstring, private.localSubrs, global, private.nominalWidth)
+	if err != nil || len(decoded.segments) == 0 {
+		return Rect{}
+	}
+	segments := scaleCFFSegments(decoded.segments, ppem/float64(f.upem))
+	return outlineSegmentBounds(segments)
+}
+
+func (f *ownParsedFont) loadCFF() (*cffFont, error) {
+	f.cffOnce.Do(func() {
+		data, ok := f.tables["CFF "]
+		if !ok {
+			return
+		}
+		f.cff, f.cffErr = parseCFF1(data)
+		if f.cffErr == nil && len(f.cff.charStrings) != f.numGlyphs {
+			charStringCount := len(f.cff.charStrings)
+			f.cff = nil
+			f.cffErr = fmt.Errorf("text: CFF1: CharStrings count %d does not match maxp glyph count %d", charStringCount, f.numGlyphs)
+		}
+	})
+	return f.cff, f.cffErr
 }
 
 // Metrics implements ParsedFont.Metrics.

--- a/text/glyph_outline.go
+++ b/text/glyph_outline.go
@@ -3,6 +3,7 @@ package text
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 	"sort"
 )
@@ -386,6 +387,12 @@ func (e *OutlineExtractor) ExtractOutlineHintedVar(
 	if !ok {
 		return nil, ErrUnsupportedFontType
 	}
+	// CFF1 has no gvar outline variation data. Keep the static CFF path (and
+	// its normal hinting fallback) authoritative when variation coordinates
+	// are supplied to the unified API.
+	if _, hasGlyf := ownFont.tables["glyf"]; !hasGlyf {
+		return e.ExtractOutlineHinted(parsedFont, gid, size, hinting)
+	}
 
 	// Extract the gvar-varied outline AND the varied contour points.
 	// Both are needed: the outline for the final result, and the contours
@@ -637,6 +644,19 @@ func (e *OutlineExtractor) extractFromOwn(f *ownParsedFont, gid GlyphID, size fl
 	// Get advance width.
 	advance := f.GlyphAdvance(uint16(gid), size)
 
+	// TrueType glyf stays the first-choice path for fonts that contain it.
+	// Only dispatch to CFF when glyf is absent.
+	if _, hasGlyf := f.tables["glyf"]; !hasGlyf {
+		if _, hasCFF2 := f.tables["CFF2"]; hasCFF2 {
+			return nil, &FontError{Reason: "own parser: CFF2 outlines are unsupported"}
+		}
+		if _, hasCFF := f.tables["CFF "]; hasCFF {
+			return e.extractCFF(f, gid, size, advance)
+		}
+		// Fonts without either supported outline table have no outline.
+		return nil, nil //nolint:nilnil // A missing optional outline is the existing empty-glyph contract.
+	}
+
 	// Parse raw contour points from glyf table.
 	contours, err := ParseGlyfContours(rawData, gid)
 	if err != nil {
@@ -686,6 +706,62 @@ func (e *OutlineExtractor) extractFromOwn(f *ownParsedFont, gid GlyphID, size fl
 	outline.Bounds = Rect{MinX: minX, MinY: minY, MaxX: maxX, MaxY: maxY}
 
 	return outline, nil
+}
+
+func (e *OutlineExtractor) extractCFF(f *ownParsedFont, gid GlyphID, size, advance float64) (*GlyphOutline, error) {
+	cff, err := f.loadCFF()
+	if err != nil {
+		return nil, &FontError{Reason: fmt.Sprintf("own parser: CFF1 parse failed: %v", err)}
+	}
+	if cff == nil {
+		return nil, nil //nolint:nilnil // Lazy absence is represented as no drawable outline.
+	}
+	charstring, global, private, err := cff.glyph(uint16(gid))
+	if err != nil {
+		return nil, &FontError{Reason: fmt.Sprintf("own parser: CFF1 glyph %d: %v", gid, err)}
+	}
+	decoded, err := decodeType2(charstring, private.localSubrs, global, private.nominalWidth)
+	if err != nil {
+		return nil, &FontError{Reason: fmt.Sprintf("own parser: CFF1 glyph %d: %v", gid, err)}
+	}
+	scale := size / float64(f.upem)
+	segments := scaleCFFSegments(decoded.segments, scale)
+	out := &GlyphOutline{Segments: segments, GID: gid, Type: GlyphTypeOutline, Advance: float32(advance)}
+	f.ensureHmtx()
+	if f.hmtxParsed && int(gid) < len(f.hmtxLSB) {
+		out.LSB = float32(float64(f.hmtxLSB[gid]) * scale)
+	}
+	if len(segments) != 0 {
+		out.Bounds = outlineSegmentBounds(segments)
+	}
+	return out, nil
+}
+
+// scaleCFFSegments converts Type 2's Y-up font-unit coordinates to the
+// existing outline contract: ppem-scaled X and Y-down coordinates.
+func scaleCFFSegments(in []OutlineSegment, scale float64) []OutlineSegment {
+	out := make([]OutlineSegment, len(in))
+	for i, seg := range in {
+		out[i].Op = seg.Op
+		for j := range segPointCount(seg.Op) {
+			out[i].Points[j] = OutlinePoint{X: float32(float64(seg.Points[j].X) * scale), Y: float32(-float64(seg.Points[j].Y) * scale)}
+		}
+	}
+	return out
+}
+
+func outlineSegmentBounds(segments []OutlineSegment) Rect {
+	minX, minY := float64(1e10), float64(1e10)
+	maxX, maxY := float64(-1e10), float64(-1e10)
+	for _, seg := range segments {
+		for j := range segPointCount(seg.Op) {
+			updateBounds(seg.Points[j], &minX, &minY, &maxX, &maxY)
+		}
+	}
+	if len(segments) == 0 {
+		return Rect{}
+	}
+	return Rect{MinX: minX, MinY: minY, MaxX: maxX, MaxY: maxY}
 }
 
 // extractFromOwnVariableWithContours extracts a glyph outline with font

--- a/text/type2.go
+++ b/text/type2.go
@@ -1,0 +1,678 @@
+package text
+
+import (
+	"fmt"
+	"math"
+)
+
+// The limits below are deliberately modest. Type 2 programs are untrusted
+// input and none of these limits is approached by normal desktop fonts.
+const (
+	type2MaxStack      = 48
+	type2MaxCallDepth  = 16
+	type2MaxOperations = 100000
+	// Keep the geometry ceiling below the operation ceiling so every path
+	// producer, including one-segment moveto programs, is independently
+	// bounded by the segment budget.
+	type2MaxSegments = 65536
+)
+
+type type2Result struct {
+	segments []OutlineSegment
+	width    float64
+	hasWidth bool
+}
+
+type type2Frame struct {
+	code     []byte
+	pc       int
+	subr     int
+	isGlobal bool
+	isSubr   bool
+}
+
+// decodeType2 executes one CFF1 Type 2 charstring in font units. The caller
+// supplies the local subroutines selected by the glyph's FD and the font-wide
+// global subroutines.
+//
+//nolint:gocognit,gocyclo,cyclop,funlen,gocritic,maintidx,nestif,revive // One bounded interpreter keeps the shared Type 2 operand/call state explicit across operators.
+func decodeType2(charstring []byte, localSubrs, globalSubrs [][]byte, nominalWidth float64) (type2Result, error) {
+	var result type2Result
+	stack := make([]float64, 0, type2MaxStack)
+	transient := [32]float64{}
+	frames := []type2Frame{{code: charstring, subr: -1}}
+	activeLocal := make(map[int]bool)
+	activeGlobal := make(map[int]bool)
+	var x, y float64
+	stems := 0
+	widthSeen := false
+	operations := 0
+
+	fail := func(format string, args ...any) (type2Result, error) {
+		return type2Result{}, fmt.Errorf("text: Type 2 charstring: "+format, args...)
+	}
+	setWidth := func(n int) error {
+		if widthSeen {
+			return nil
+		}
+		widthSeen = true
+		if len(stack) > n {
+			if len(stack) != n+1 {
+				return fmt.Errorf("invalid operand count %d", len(stack))
+			}
+			result.width = nominalWidth + stack[0]
+			result.hasWidth = true
+			stack = stack[1:]
+		}
+		return nil
+	}
+	setStemWidth := func() {
+		if widthSeen {
+			return
+		}
+		widthSeen = true
+		if len(stack)%2 != 0 {
+			result.width = nominalWidth + stack[0]
+			result.hasWidth = true
+			stack = stack[1:]
+		}
+	}
+	clear := func() { stack = stack[:0] }
+	exactInt := func(v float64, label string) (int, error) {
+		if math.IsNaN(v) || math.IsInf(v, 0) || v != math.Trunc(v) || v > float64(math.MaxInt) || v < float64(math.MinInt) {
+			return 0, fmt.Errorf("%s %v is not an integer", label, v)
+		}
+		return int(v), nil
+	}
+	line := func(nx, ny float64) error {
+		if math.IsNaN(nx) || math.IsNaN(ny) || math.IsInf(nx, 0) || math.IsInf(ny, 0) || math.Abs(nx) > math.MaxFloat32 || math.Abs(ny) > math.MaxFloat32 {
+			return fmt.Errorf("non-finite line coordinate")
+		}
+		if len(result.segments) >= type2MaxSegments {
+			return fmt.Errorf("segment limit exceeded")
+		}
+		x, y = nx, ny
+		result.segments = append(result.segments, OutlineSegment{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{X: float32(x), Y: float32(y)}}})
+		return nil
+	}
+	move := func(nx, ny float64) error {
+		if math.IsNaN(nx) || math.IsNaN(ny) || math.IsInf(nx, 0) || math.IsInf(ny, 0) || math.Abs(nx) > math.MaxFloat32 || math.Abs(ny) > math.MaxFloat32 {
+			return fmt.Errorf("non-finite move coordinate")
+		}
+		if len(result.segments) >= type2MaxSegments {
+			return fmt.Errorf("segment limit exceeded")
+		}
+		x, y = nx, ny
+		result.segments = append(result.segments, OutlineSegment{Op: OutlineOpMoveTo, Points: [3]OutlinePoint{{X: float32(x), Y: float32(y)}}})
+		return nil
+	}
+	curve := func(dx1, dy1, dx2, dy2, dx3, dy3 float64) error {
+		if len(result.segments) >= type2MaxSegments {
+			return fmt.Errorf("segment limit exceeded")
+		}
+		p1x, p1y := x+dx1, y+dy1
+		p2x, p2y := p1x+dx2, p1y+dy2
+		nx, ny := p2x+dx3, p2y+dy3
+		for _, v := range []float64{p1x, p1y, p2x, p2y, nx, ny} {
+			if math.IsNaN(v) || math.IsInf(v, 0) || math.Abs(v) > math.MaxFloat32 {
+				return fmt.Errorf("non-finite curve coordinate")
+			}
+		}
+		p1 := OutlinePoint{X: float32(p1x), Y: float32(p1y)}
+		p2 := OutlinePoint{X: float32(p2x), Y: float32(p2y)}
+		x, y = nx, ny
+		result.segments = append(result.segments, OutlineSegment{Op: OutlineOpCubicTo, Points: [3]OutlinePoint{p1, p2, {X: float32(x), Y: float32(y)}}})
+		return nil
+	}
+
+	for len(frames) != 0 {
+		fr := &frames[len(frames)-1]
+		if fr.pc >= len(fr.code) {
+			if fr.isSubr {
+				return fail("subroutine %d ended without return", fr.subr)
+			}
+			return fail("charstring ended without endchar")
+		}
+		b := fr.code[fr.pc]
+		if b == 28 || b == 255 || b >= 32 {
+			v, next, err := readType2Number(fr.code, fr.pc)
+			if err != nil {
+				return fail("at byte %d: %v", fr.pc, err)
+			}
+			if len(stack) >= type2MaxStack {
+				return fail("operand stack overflow")
+			}
+			stack = append(stack, v)
+			fr.pc = next
+			continue
+		}
+		fr.pc++
+		operations++
+		if operations > type2MaxOperations {
+			return fail("operation limit exceeded")
+		}
+		op := int(b)
+		if b == 12 {
+			if fr.pc >= len(fr.code) {
+				return fail("truncated escaped operator")
+			}
+			op = 1200 + int(fr.code[fr.pc])
+			fr.pc++
+		}
+
+		need := func(n int) error {
+			if len(stack) < n {
+				return fmt.Errorf("operator %d: operand stack underflow", op)
+			}
+			return nil
+		}
+		binary := func(fn func(float64, float64) float64) error {
+			if err := need(2); err != nil {
+				return err
+			}
+			n := len(stack)
+			stack[n-2] = fn(stack[n-2], stack[n-1])
+			stack = stack[:n-1]
+			return nil
+		}
+		var err error
+		switch op {
+		case 1, 3, 18, 23: // stem operators
+			setStemWidth()
+			if len(stack)%2 != 0 {
+				err = fmt.Errorf("operator %d: odd stem operands", op)
+			} else {
+				stems += len(stack) / 2
+				clear()
+			}
+		case 19, 20: // hintmask/cntrmask
+			if !widthSeen {
+				setStemWidth()
+			}
+			if err == nil {
+				if len(stack)%2 != 0 {
+					err = fmt.Errorf("operator %d: odd stem operands", op)
+				} else {
+					stems += len(stack) / 2
+					clear()
+					n := (stems + 7) / 8
+					if fr.pc+n > len(fr.code) {
+						err = fmt.Errorf("operator %d: truncated mask", op)
+					} else {
+						fr.pc += n
+					}
+				}
+			}
+		case 4: // vmoveto
+			if err = setWidth(1); err == nil {
+				if len(stack) != 1 {
+					err = fmt.Errorf("vmoveto: want 1 operand")
+				} else {
+					err = move(x, y+stack[0])
+					clear()
+				}
+			}
+		case 21:
+			if err = setWidth(2); err == nil {
+				if len(stack) != 2 {
+					err = fmt.Errorf("rmoveto: want 2 operands")
+				} else {
+					err = move(x+stack[0], y+stack[1])
+					clear()
+				}
+			}
+		case 22:
+			if err = setWidth(1); err == nil {
+				if len(stack) != 1 {
+					err = fmt.Errorf("hmoveto: want 1 operand")
+				} else {
+					err = move(x+stack[0], y)
+					clear()
+				}
+			}
+		case 5:
+			if len(stack) < 2 || len(stack)%2 != 0 {
+				err = fmt.Errorf("rlineto: invalid operand count")
+			} else {
+				for i := 0; i < len(stack) && err == nil; i += 2 {
+					err = line(x+stack[i], y+stack[i+1])
+				}
+				clear()
+			}
+		case 6, 7:
+			if len(stack) < 1 {
+				err = fmt.Errorf("operator %d: operand stack underflow", op)
+			} else {
+				horizontal := op == 6
+				for _, d := range stack {
+					if horizontal {
+						err = line(x+d, y)
+					} else {
+						err = line(x, y+d)
+					}
+					if err != nil {
+						break
+					}
+					horizontal = !horizontal
+				}
+				clear()
+			}
+		case 8:
+			if len(stack) < 6 || len(stack)%6 != 0 {
+				err = fmt.Errorf("rrcurveto: invalid operand count")
+			} else {
+				for i := 0; i < len(stack) && err == nil; i += 6 {
+					err = curve(stack[i], stack[i+1], stack[i+2], stack[i+3], stack[i+4], stack[i+5])
+				}
+				clear()
+			}
+		case 24:
+			if len(stack) < 8 || (len(stack)-2)%6 != 0 {
+				err = fmt.Errorf("rcurveline: invalid operand count")
+			} else {
+				i := 0
+				for i < len(stack)-2 && err == nil {
+					err = curve(stack[i], stack[i+1], stack[i+2], stack[i+3], stack[i+4], stack[i+5])
+					i += 6
+				}
+				if err == nil {
+					err = line(x+stack[i], y+stack[i+1])
+				}
+				clear()
+			}
+		case 25:
+			if len(stack) < 8 || (len(stack)-6)%2 != 0 {
+				err = fmt.Errorf("rlinecurve: invalid operand count")
+			} else {
+				i := 0
+				for i < len(stack)-6 && err == nil {
+					err = line(x+stack[i], y+stack[i+1])
+					i += 2
+				}
+				if err == nil {
+					err = curve(stack[i], stack[i+1], stack[i+2], stack[i+3], stack[i+4], stack[i+5])
+				}
+				clear()
+			}
+		case 26, 27:
+			if len(stack) < 4 {
+				err = fmt.Errorf("operator %d: operand stack underflow", op)
+			} else {
+				i := 0
+				extra := 0.0
+				if len(stack)%4 == 1 {
+					extra = stack[0]
+					i = 1
+				}
+				if (len(stack)-i)%4 != 0 {
+					err = fmt.Errorf("operator %d: invalid operand count", op)
+				} else {
+					for i < len(stack) && err == nil {
+						if op == 26 {
+							err = curve(extra, stack[i], stack[i+1], stack[i+2], 0, stack[i+3])
+						} else {
+							err = curve(stack[i], extra, stack[i+1], stack[i+2], stack[i+3], 0)
+						}
+						extra = 0
+						i += 4
+					}
+				}
+				clear()
+			}
+		case 30, 31:
+			if len(stack) < 4 {
+				err = fmt.Errorf("operator %d: operand stack underflow", op)
+			} else {
+				i := 0
+				vertical := op == 30
+				for i < len(stack) && err == nil {
+					rem := len(stack) - i
+					if rem < 4 {
+						err = fmt.Errorf("operator %d: invalid operand count", op)
+						break
+					}
+					extra := 0.0
+					take := 4
+					if rem == 5 {
+						extra = stack[i+4]
+						take = 5
+					}
+					if vertical {
+						err = curve(0, stack[i], stack[i+1], stack[i+2], stack[i+3], extra)
+					} else {
+						err = curve(stack[i], 0, stack[i+1], stack[i+2], extra, stack[i+3])
+					}
+					i += take
+					vertical = !vertical
+				}
+				clear()
+			}
+		case 10, 29: // callsubr/callgsubr
+			if err = need(1); err == nil {
+				n := len(stack)
+				raw, intErr := exactInt(stack[n-1], "subroutine operand")
+				stack = stack[:n-1]
+				list := localSubrs
+				global := false
+				active := activeLocal
+				if op == 29 {
+					list = globalSubrs
+					global = true
+					active = activeGlobal
+				}
+				idx := raw + type2SubrBias(len(list))
+				if intErr != nil {
+					err = intErr
+				} else if idx < 0 || idx >= len(list) {
+					err = fmt.Errorf("operator %d: subroutine %d out of range", op, idx)
+				} else if len(frames) >= type2MaxCallDepth {
+					err = fmt.Errorf("subroutine recursion limit exceeded")
+				} else if active[idx] {
+					err = fmt.Errorf("subroutine cycle at %d", idx)
+				} else {
+					active[idx] = true
+					frames = append(frames, type2Frame{code: list[idx], subr: idx, isGlobal: global, isSubr: true})
+				}
+			}
+		case 11:
+			if !fr.isSubr {
+				err = fmt.Errorf("return outside subroutine")
+			} else {
+				if fr.isGlobal {
+					delete(activeGlobal, fr.subr)
+				} else {
+					delete(activeLocal, fr.subr)
+				}
+				frames = frames[:len(frames)-1]
+			}
+		case 14:
+			// Some valid CFF1 fonts tail-call a subroutine that owns endchar.
+			// endchar terminates the entire glyph program, not only the current
+			// call frame, so handle it identically at every call depth.
+			if !widthSeen {
+				if len(stack) == 1 || len(stack) == 5 {
+					result.width = nominalWidth + stack[0]
+					result.hasWidth = true
+					stack = stack[1:]
+				}
+				widthSeen = true
+			}
+			if len(stack) != 0 && len(stack) != 4 {
+				err = fmt.Errorf("endchar: invalid operand count %d", len(stack))
+			} else if len(stack) == 4 {
+				err = fmt.Errorf("endchar: deprecated seac operands unsupported")
+			} else {
+				frames = nil
+				clear()
+			}
+		case 1200:
+			clear() // dotsection, obsolete but harmless
+		case 1203:
+			err = binary(func(a, b float64) float64 {
+				if a != 0 && b != 0 {
+					return 1
+				}
+				return 0
+			})
+		case 1204:
+			err = binary(func(a, b float64) float64 {
+				if a != 0 || b != 0 {
+					return 1
+				}
+				return 0
+			})
+		case 1205:
+			if err = need(1); err == nil {
+				if stack[len(stack)-1] == 0 {
+					stack[len(stack)-1] = 1
+				} else {
+					stack[len(stack)-1] = 0
+				}
+			}
+		case 1209:
+			if err = need(1); err == nil {
+				stack[len(stack)-1] = math.Abs(stack[len(stack)-1])
+			}
+		case 1210:
+			err = binary(func(a, b float64) float64 { return a + b })
+		case 1211:
+			err = binary(func(a, b float64) float64 { return a - b })
+		case 1212:
+			if err = need(2); err == nil {
+				if stack[len(stack)-1] == 0 {
+					err = fmt.Errorf("division by zero")
+				} else {
+					err = binary(func(a, b float64) float64 { return a / b })
+				}
+			}
+		case 1214:
+			if err = need(1); err == nil {
+				stack[len(stack)-1] = -stack[len(stack)-1]
+			}
+		case 1215:
+			err = binary(func(a, b float64) float64 {
+				if a == b {
+					return 1
+				}
+				return 0
+			})
+		case 1218:
+			if err = need(1); err == nil {
+				stack = stack[:len(stack)-1]
+			}
+		case 1220:
+			if err = need(2); err == nil {
+				n := len(stack)
+				i, intErr := exactInt(stack[n-1], "put index")
+				v := stack[n-2]
+				stack = stack[:n-2]
+				if intErr != nil {
+					err = intErr
+				} else if i < 0 || i >= len(transient) {
+					err = fmt.Errorf("put index %d out of range", i)
+				} else {
+					transient[i] = v
+				}
+			}
+		case 1221:
+			if err = need(1); err == nil {
+				i, intErr := exactInt(stack[len(stack)-1], "get index")
+				if intErr != nil {
+					err = intErr
+				} else if i < 0 || i >= len(transient) {
+					err = fmt.Errorf("get index %d out of range", i)
+				} else {
+					stack[len(stack)-1] = transient[i]
+				}
+			}
+		case 1222:
+			if err = need(4); err == nil {
+				n := len(stack)
+				v1, v2, s1, s2 := stack[n-4], stack[n-3], stack[n-2], stack[n-1]
+				stack = stack[:n-4]
+				if s1 <= s2 {
+					stack = append(stack, v1)
+				} else {
+					stack = append(stack, v2)
+				}
+			}
+		case 1223:
+			if len(stack) >= type2MaxStack {
+				err = fmt.Errorf("operand stack overflow")
+			} else {
+				stack = append(stack, 0.5)
+			} // deterministic random
+		case 1224:
+			err = binary(func(a, b float64) float64 { return a * b })
+		case 1226:
+			if err = need(1); err == nil {
+				if stack[len(stack)-1] < 0 {
+					err = fmt.Errorf("sqrt of negative value")
+				} else {
+					stack[len(stack)-1] = math.Sqrt(stack[len(stack)-1])
+				}
+			}
+		case 1227:
+			if err = need(1); err == nil {
+				if len(stack) >= type2MaxStack {
+					err = fmt.Errorf("operand stack overflow")
+				} else {
+					stack = append(stack, stack[len(stack)-1])
+				}
+			}
+		case 1228:
+			if err = need(2); err == nil {
+				n := len(stack)
+				stack[n-1], stack[n-2] = stack[n-2], stack[n-1]
+			}
+		case 1229:
+			if err = need(1); err == nil {
+				n := len(stack)
+				i, intErr := exactInt(stack[n-1], "index operand")
+				stack = stack[:n-1]
+				if intErr != nil {
+					err = intErr
+				} else {
+					if i < 0 {
+						i = 0
+					}
+					if i >= len(stack) {
+						i = len(stack) - 1
+					}
+					if i < 0 {
+						err = fmt.Errorf("index on empty stack")
+						break
+					}
+					// index consumes its own operand before duplicating, so a valid
+					// input stack always has room for the result.
+					stack = append(stack, stack[len(stack)-1-i])
+				}
+			}
+		case 1230:
+			if err = need(2); err == nil {
+				n := len(stack)
+				count, countErr := exactInt(stack[n-2], "roll count")
+				j, jErr := exactInt(stack[n-1], "roll shift")
+				stack = stack[:n-2]
+				if countErr != nil {
+					err = countErr
+				} else if jErr != nil {
+					err = jErr
+				} else if count < 0 || count > len(stack) {
+					err = fmt.Errorf("roll count %d out of range", count)
+				} else if count > 0 {
+					j %= count
+					if j < 0 {
+						j += count
+					}
+					base := len(stack) - count
+					tmp := append([]float64(nil), stack[base:]...)
+					for k := 0; k < count; k++ {
+						stack[base+(k+j)%count] = tmp[k]
+					}
+				}
+			}
+		case 1234: // hflex
+			if len(stack) != 7 {
+				err = fmt.Errorf("hflex: want 7 operands")
+			} else {
+				err = curve(stack[0], 0, stack[1], stack[2], stack[3], 0)
+				if err == nil {
+					err = curve(stack[4], 0, stack[5], -stack[2], stack[6], 0)
+				}
+				clear()
+			}
+		case 1235:
+			if len(stack) != 13 {
+				err = fmt.Errorf("flex: want 13 operands")
+			} else {
+				err = curve(stack[0], stack[1], stack[2], stack[3], stack[4], stack[5])
+				if err == nil {
+					err = curve(stack[6], stack[7], stack[8], stack[9], stack[10], stack[11])
+				}
+				clear()
+			}
+		case 1236:
+			if len(stack) != 9 {
+				err = fmt.Errorf("hflex1: want 9 operands")
+			} else {
+				dy := stack[1] + stack[3] + stack[7]
+				err = curve(stack[0], stack[1], stack[2], stack[3], stack[4], 0)
+				if err == nil {
+					err = curve(stack[5], 0, stack[6], stack[7], stack[8], -dy)
+				}
+				clear()
+			}
+		case 1237:
+			if len(stack) != 11 {
+				err = fmt.Errorf("flex1: want 11 operands")
+			} else {
+				dx := stack[0] + stack[2] + stack[4] + stack[6] + stack[8]
+				dy := stack[1] + stack[3] + stack[5] + stack[7] + stack[9]
+				d6x, d6y := 0.0, 0.0
+				if math.Abs(dx) > math.Abs(dy) {
+					d6x = stack[10]
+					d6y = -dy
+				} else {
+					d6x = -dx
+					d6y = stack[10]
+				}
+				err = curve(stack[0], stack[1], stack[2], stack[3], stack[4], stack[5])
+				if err == nil {
+					err = curve(stack[6], stack[7], stack[8], stack[9], d6x, d6y)
+				}
+				clear()
+			}
+		default:
+			err = fmt.Errorf("reserved or unsupported operator %d", op)
+		}
+		if err != nil {
+			return fail("at operator byte %d: %v", fr.pc-1, err)
+		}
+	}
+	return result, nil
+}
+
+func type2SubrBias(n int) int {
+	if n < 1240 {
+		return 107
+	}
+	if n < 33900 {
+		return 1131
+	}
+	return 32768
+}
+
+func readType2Number(data []byte, pos int) (float64, int, error) {
+	if pos >= len(data) {
+		return 0, pos, fmt.Errorf("truncated number")
+	}
+	b := data[pos]
+	switch {
+	case b >= 32 && b <= 246:
+		return float64(int(b) - 139), pos + 1, nil
+	case b >= 247 && b <= 250:
+		if pos+1 >= len(data) {
+			return 0, pos, fmt.Errorf("truncated positive number")
+		}
+		return float64((int(b)-247)*256 + int(data[pos+1]) + 108), pos + 2, nil
+	case b >= 251 && b <= 254:
+		if pos+1 >= len(data) {
+			return 0, pos, fmt.Errorf("truncated negative number")
+		}
+		return float64(-(int(b)-251)*256 - int(data[pos+1]) - 108), pos + 2, nil
+	case b == 28:
+		if pos+3 > len(data) {
+			return 0, pos, fmt.Errorf("truncated short number")
+		}
+		return float64(int16(uint16(data[pos+1])<<8 | uint16(data[pos+2]))), pos + 3, nil
+	case b == 255:
+		if pos+5 > len(data) {
+			return 0, pos, fmt.Errorf("truncated fixed number")
+		}
+		u := uint32(data[pos+1])<<24 | uint32(data[pos+2])<<16 | uint32(data[pos+3])<<8 | uint32(data[pos+4])
+		return float64(int32(u)) / 65536, pos + 5, nil
+	default:
+		return 0, pos, fmt.Errorf("byte %d is not a number", b)
+	}
+}

--- a/text/type2_boundaries_test.go
+++ b/text/type2_boundaries_test.go
@@ -1,0 +1,111 @@
+package text
+
+import (
+	"strings"
+	"testing"
+)
+
+func requireType2Error(t *testing.T, program []byte, contains string) {
+	t.Helper()
+	result, err := decodeType2(program, nil, nil, 0)
+	if err == nil || !strings.Contains(err.Error(), contains) {
+		t.Fatalf("result=%#v err=%v, want error containing %q", result, err, contains)
+	}
+	if result.segments != nil {
+		t.Fatalf("decoder leaked partial geometry: %#v", result.segments)
+	}
+}
+
+func TestType2BooleanAndStackAlternativeBranches(t *testing.T) {
+	tests := map[string]struct {
+		program []byte
+		want    OutlinePoint
+	}{
+		"and false":      {t2prog(0, 3, byte(12), byte(3), 0, byte(21), byte(14)), OutlinePoint{0, 0}},
+		"or false":       {t2prog(0, 0, byte(12), byte(4), 0, byte(21), byte(14)), OutlinePoint{0, 0}},
+		"not true input": {t2prog(7, byte(12), byte(5), 0, byte(21), byte(14)), OutlinePoint{0, 0}},
+		"eq false":       {t2prog(7, 8, byte(12), byte(15), 0, byte(21), byte(14)), OutlinePoint{0, 0}},
+		"ifelse second":  {t2prog(11, 22, 3, 2, byte(12), byte(22), 0, byte(21), byte(14)), OutlinePoint{22, 0}},
+		"index negative": {t2prog(10, -1, byte(12), byte(29), byte(21), byte(14)), OutlinePoint{10, 10}},
+		"roll negative":  {t2prog(1, 2, 2, -1, byte(12), byte(30), byte(21), byte(14)), OutlinePoint{2, 1}},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := decodeType2(test.program, nil, nil, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.segments) != 1 || result.segments[0].Points[0] != test.want {
+				t.Fatalf("segments=%#v, want endpoint %v", result.segments, test.want)
+			}
+		})
+	}
+
+	requireType2Error(t, t2prog([]byte{255, 0, 1, 0x80, 0}, byte(12), byte(29), byte(14)), "not an integer")
+}
+
+func TestType2LateOperatorArityAndMaskErrors(t *testing.T) {
+	for name, program := range map[string][]byte{
+		"hintmask odd after width": t2prog(10, 20, byte(1), 30, byte(19), byte(0), byte(14)),
+		"vmoveto after width":      t2prog(0, 0, byte(21), 1, 2, byte(4), byte(14)),
+		"hmoveto after width":      t2prog(0, 0, byte(21), 1, 2, byte(22), byte(14)),
+	} {
+		t.Run(name, func(t *testing.T) { requireType2Error(t, program, "operator") })
+	}
+}
+
+func TestType2Flex1HorizontalDominantAxis(t *testing.T) {
+	program := t2prog(0, 0, byte(21), 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 5, byte(12), byte(37), byte(14))
+	result, err := decodeType2(program, nil, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.segments) != 3 {
+		t.Fatalf("segments=%#v", result.segments)
+	}
+	if endpoint := result.segments[2].Points[2]; endpoint != (OutlinePoint{X: 55, Y: 0}) {
+		t.Fatalf("endpoint=%v, want (55,0)", endpoint)
+	}
+}
+
+func TestType2IndependentSegmentLimits(t *testing.T) {
+	t.Run("move", func(t *testing.T) {
+		program := make([]byte, 0, (type2MaxSegments+1)*3)
+		for range type2MaxSegments + 1 {
+			program = append(program, 139, 139, 21)
+		}
+		requireType2Error(t, program, "segment limit")
+	})
+
+	t.Run("alternating line", func(t *testing.T) {
+		program := t2prog(0, 0, byte(21))
+		for emitted := 0; emitted <= type2MaxSegments; emitted += type2MaxStack {
+			for range type2MaxStack {
+				program = append(program, 140) // delta 1
+			}
+			program = append(program, 6)
+		}
+		requireType2Error(t, program, "segment limit")
+	})
+
+	t.Run("curve", func(t *testing.T) {
+		program := t2prog(0, 0, byte(21))
+		const curvesPerOp = type2MaxStack / 6
+		for emitted := 0; emitted <= type2MaxSegments; emitted += curvesPerOp {
+			for range type2MaxStack {
+				program = append(program, 139)
+			}
+			program = append(program, 8)
+		}
+		requireType2Error(t, program, "segment limit")
+	})
+}
+
+func TestType2NumberReaderDirectBounds(t *testing.T) {
+	if _, _, err := readType2Number(nil, 0); err == nil {
+		t.Fatal("out-of-range number read accepted")
+	}
+	if _, _, err := readType2Number([]byte{0}, 0); err == nil {
+		t.Fatal("operator byte accepted as number")
+	}
+}

--- a/text/type2_test.go
+++ b/text/type2_test.go
@@ -1,0 +1,398 @@
+package text
+
+import (
+	"strings"
+	"testing"
+)
+
+func t2num(v int) []byte {
+	if v >= -107 && v <= 107 {
+		return []byte{byte(v + 139)}
+	}
+	if v >= 108 && v <= 1131 {
+		n := v - 108
+		return []byte{byte(n/256 + 247), byte(n % 256)}
+	}
+	if v >= -1131 && v <= -108 {
+		n := -v - 108
+		return []byte{byte(n/256 + 251), byte(n % 256)}
+	}
+	return []byte{28, byte(uint16(v) >> 8), byte(v)}
+}
+func t2prog(parts ...any) []byte {
+	var p []byte
+	for _, part := range parts {
+		switch v := part.(type) {
+		case int:
+			p = append(p, t2num(v)...)
+		case byte:
+			p = append(p, v)
+		case []byte:
+			p = append(p, v...)
+		}
+	}
+	return p
+}
+
+func TestType2NumericEncodings(t *testing.T) {
+	tests := []struct {
+		data []byte
+		want float64
+	}{{[]byte{32}, -107}, {[]byte{246}, 107}, {[]byte{247, 0}, 108}, {[]byte{250, 255}, 1131}, {[]byte{251, 0}, -108}, {[]byte{254, 255}, -1131}, {[]byte{28, 0x80, 0}, -32768}, {[]byte{255, 0, 1, 0x80, 0}, 1.5}}
+	for _, tt := range tests {
+		got, next, err := readType2Number(tt.data, 0)
+		if err != nil || got != tt.want || next != len(tt.data) {
+			t.Fatalf("readType2Number(%v)=(%v,%d,%v), want %v", tt.data, got, next, err, tt.want)
+		}
+	}
+	for _, data := range [][]byte{{28}, {255, 0}, {247}, {254}} {
+		if _, _, err := readType2Number(data, 0); err == nil {
+			t.Errorf("expected truncation for %v", data)
+		}
+	}
+}
+
+func TestType2MoveLineCurveFamilies(t *testing.T) {
+	p := t2prog(10, 20, byte(21), 30, 0, 0, 40, -10, 0, byte(5), 5, 10, 10, 5, 5, -5, byte(8), byte(14))
+	r, err := decodeType2(p, nil, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []OutlineSegment{
+		{Op: OutlineOpMoveTo, Points: [3]OutlinePoint{{10, 20}}},
+		{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{40, 20}}},
+		{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{40, 60}}},
+		{Op: OutlineOpLineTo, Points: [3]OutlinePoint{{30, 60}}},
+		{Op: OutlineOpCubicTo, Points: [3]OutlinePoint{{35, 70}, {45, 75}, {50, 70}}},
+	}
+	if len(r.segments) != len(want) {
+		t.Fatalf("segments=%#v", r.segments)
+	}
+	for i := range want {
+		if r.segments[i] != want[i] {
+			t.Errorf("segment %d=%#v want %#v", i, r.segments[i], want[i])
+		}
+	}
+
+	for name, p := range map[string][]byte{
+		"h/v line":   t2prog(0, 0, byte(21), 10, 20, 30, byte(6), byte(14)),
+		"curve-line": t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, 6, 7, 8, byte(24), byte(14)),
+		"line-curve": t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, 6, 7, 8, byte(25), byte(14)),
+		"vv":         t2prog(0, 0, byte(21), 1, 2, 3, 4, byte(26), byte(14)),
+		"hh":         t2prog(0, 0, byte(21), 1, 2, 3, 4, byte(27), byte(14)),
+		"vh":         t2prog(0, 0, byte(21), 1, 2, 3, 4, byte(30), byte(14)),
+		"hv":         t2prog(0, 0, byte(21), 1, 2, 3, 4, byte(31), byte(14)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			r, e := decodeType2(p, nil, nil, 0)
+			if e != nil {
+				t.Fatal(e)
+			}
+			if len(r.segments) < 2 {
+				t.Fatalf("no drawn segment: %#v", r)
+			}
+		})
+	}
+}
+
+func TestType2WidthStemsMasksAndSubrBias(t *testing.T) {
+	// Width 50, one stem, one-byte hint mask, then a move.
+	p := t2prog(50, 10, 20, byte(1), byte(19), byte(0x80), 0, 0, byte(21), byte(14))
+	r, err := decodeType2(p, nil, nil, 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.hasWidth || r.width != 550 {
+		t.Fatalf("width=%v has=%v", r.width, r.hasWidth)
+	}
+
+	for _, n := range []int{0, 1239, 1240, 33899, 33900} {
+		want := 107
+		if n >= 1240 {
+			want = 1131
+		}
+		if n >= 33900 {
+			want = 32768
+		}
+		if got := type2SubrBias(n); got != want {
+			t.Errorf("bias(%d)=%d want %d", n, got, want)
+		}
+	}
+	local := make([][]byte, 1)
+	local[0] = t2prog(10, 0, byte(5), byte(11))
+	global := make([][]byte, 1)
+	global[0] = t2prog(0, 20, byte(5), byte(11))
+	p = t2prog(0, 0, byte(21), -107, byte(10), -107, byte(29), byte(14))
+	r, err = decodeType2(p, local, global, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.segments[len(r.segments)-1].Points[0]; got != (OutlinePoint{10, 20}) {
+		t.Fatalf("subr endpoint=%v", got)
+	}
+}
+
+func TestType2EndcharInSubroutineTerminatesGlyph(t *testing.T) {
+	local := [][]byte{t2prog(10, 0, byte(5), byte(14))}
+	// The unsupported operator after callsubr must remain unreachable: endchar
+	// in the subroutine terminates the complete glyph program.
+	program := t2prog(0, 0, byte(21), -107, byte(10), byte(2))
+	result, err := decodeType2(program, local, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := result.segments[len(result.segments)-1].Points[0]; got != (OutlinePoint{10, 0}) {
+		t.Fatalf("subroutine endchar endpoint=%v, want (10,0)", got)
+	}
+}
+
+func TestType2FlexOperators(t *testing.T) {
+	programs := map[string][]byte{
+		"hflex":  t2prog(0, 0, byte(21), 10, 20, 5, 30, 40, 5, 10, byte(12), byte(34), byte(14)),
+		"flex":   t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 50, byte(12), byte(35), byte(14)),
+		"hflex1": t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, 6, 7, 8, 9, byte(12), byte(36), byte(14)),
+		"flex1":  t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, byte(12), byte(37), byte(14)),
+	}
+	for name, p := range programs {
+		t.Run(name, func(t *testing.T) {
+			r, err := decodeType2(p, nil, nil, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(r.segments) != 3 || r.segments[1].Op != OutlineOpCubicTo || r.segments[2].Op != OutlineOpCubicTo {
+				t.Fatalf("segments=%#v", r.segments)
+			}
+		})
+	}
+}
+
+func TestType2EscapedStackAndArithmeticOperators(t *testing.T) {
+	tests := map[string]struct {
+		program []byte
+		want    OutlinePoint
+	}{
+		"and":     {t2prog(2, 3, byte(12), byte(3), 0, byte(21), byte(14)), OutlinePoint{1, 0}},
+		"or":      {t2prog(0, 3, byte(12), byte(4), 0, byte(21), byte(14)), OutlinePoint{1, 0}},
+		"not":     {t2prog(0, byte(12), byte(5), 0, byte(21), byte(14)), OutlinePoint{1, 0}},
+		"abs":     {t2prog(-7, byte(12), byte(9), 0, byte(21), byte(14)), OutlinePoint{7, 0}},
+		"add":     {t2prog(7, 5, byte(12), byte(10), 0, byte(21), byte(14)), OutlinePoint{12, 0}},
+		"sub":     {t2prog(7, 5, byte(12), byte(11), 0, byte(21), byte(14)), OutlinePoint{2, 0}},
+		"div":     {t2prog(12, 3, byte(12), byte(12), 0, byte(21), byte(14)), OutlinePoint{4, 0}},
+		"neg":     {t2prog(7, byte(12), byte(14), 0, byte(21), byte(14)), OutlinePoint{-7, 0}},
+		"eq":      {t2prog(7, 7, byte(12), byte(15), 0, byte(21), byte(14)), OutlinePoint{1, 0}},
+		"drop":    {t2prog(7, 99, byte(12), byte(18), 0, byte(21), byte(14)), OutlinePoint{7, 0}},
+		"put-get": {t2prog(42, 3, byte(12), byte(20), 3, byte(12), byte(21), 0, byte(21), byte(14)), OutlinePoint{42, 0}},
+		"ifelse":  {t2prog(11, 22, 1, 2, byte(12), byte(22), 0, byte(21), byte(14)), OutlinePoint{11, 0}},
+		"random":  {t2prog(byte(12), byte(23), 0, byte(21), byte(14)), OutlinePoint{0.5, 0}},
+		"mul":     {t2prog(6, 7, byte(12), byte(24), 0, byte(21), byte(14)), OutlinePoint{42, 0}},
+		"sqrt":    {t2prog(81, byte(12), byte(26), 0, byte(21), byte(14)), OutlinePoint{9, 0}},
+		"dup":     {t2prog(7, byte(12), byte(27), byte(21), byte(14)), OutlinePoint{7, 7}},
+		"exch":    {t2prog(1, 2, byte(12), byte(28), byte(21), byte(14)), OutlinePoint{2, 1}},
+		"index":   {t2prog(10, 0, byte(12), byte(29), byte(21), byte(14)), OutlinePoint{10, 10}},
+		"roll":    {t2prog(1, 2, 2, 1, byte(12), byte(30), byte(21), byte(14)), OutlinePoint{2, 1}},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := decodeType2(test.program, nil, nil, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.segments) != 1 || result.segments[0].Points[0] != test.want {
+				t.Fatalf("segments=%#v, want endpoint %v", result.segments, test.want)
+			}
+		})
+	}
+}
+
+func TestType2MoveStemAndCurveVariants(t *testing.T) {
+	for name, program := range map[string][]byte{
+		"vmoveto":     t2prog(10, byte(4), byte(14)),
+		"hmoveto":     t2prog(10, byte(22), byte(14)),
+		"vlineto":     t2prog(0, 0, byte(21), 10, 20, byte(7), byte(14)),
+		"vv-extra":    t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, byte(26), byte(14)),
+		"hh-extra":    t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, byte(27), byte(14)),
+		"vh-extra":    t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, byte(30), byte(14)),
+		"hv-extra":    t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, byte(31), byte(14)),
+		"multi-curve": t2prog(0, 0, byte(21), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, byte(8), byte(14)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := decodeType2(program, nil, nil, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.segments) == 0 {
+				t.Fatal("operator produced no geometry")
+			}
+		})
+	}
+
+	for _, stemOp := range []byte{1, 3, 18, 23} {
+		program := t2prog(10, 20, stemOp, 0, 0, byte(21), byte(14))
+		if _, err := decodeType2(program, nil, nil, 0); err != nil {
+			t.Errorf("stem operator %d: %v", stemOp, err)
+		}
+	}
+	// cntrmask consumes one byte for the single declared stem.
+	if _, err := decodeType2(t2prog(10, 20, byte(20), byte(0x80), 0, 0, byte(21), byte(14)), nil, nil, 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestType2RejectsInvalidEscapedOperators(t *testing.T) {
+	tests := map[string][]byte{
+		"truncated escape": {12},
+		"and underflow":    t2prog(1, byte(12), byte(3), byte(14)),
+		"not underflow":    t2prog(byte(12), byte(5), byte(14)),
+		"division by zero": t2prog(1, 0, byte(12), byte(12), byte(14)),
+		"negative sqrt":    t2prog(-1, byte(12), byte(26), byte(14)),
+		"put range":        t2prog(1, 32, byte(12), byte(20), byte(14)),
+		"put non-integer":  t2prog(1, []byte{255, 0, 1, 0x80, 0}, byte(12), byte(20), byte(14)),
+		"get range":        t2prog(32, byte(12), byte(21), byte(14)),
+		"get non-integer":  t2prog([]byte{255, 0, 1, 0x80, 0}, byte(12), byte(21), byte(14)),
+		"index empty":      t2prog(0, byte(12), byte(29), byte(14)),
+		"roll range":       t2prog(1, 2, 3, 1, byte(12), byte(30), byte(14)),
+		"roll count float": t2prog(1, []byte{255, 0, 1, 0x80, 0}, 1, byte(12), byte(30), byte(14)),
+		"roll shift float": t2prog(1, 1, []byte{255, 0, 1, 0x80, 0}, byte(12), byte(30), byte(14)),
+		"hflex arity":      t2prog(1, byte(12), byte(34), byte(14)),
+		"flex arity":       t2prog(1, byte(12), byte(35), byte(14)),
+		"hflex1 arity":     t2prog(1, byte(12), byte(36), byte(14)),
+		"flex1 arity":      t2prog(1, byte(12), byte(37), byte(14)),
+	}
+	for name, program := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := decodeType2(program, nil, nil, 0); err == nil {
+				t.Fatal("invalid program accepted")
+			}
+		})
+	}
+}
+
+func TestType2WidthAndOperatorErrorBoundaries(t *testing.T) {
+	for name, program := range map[string][]byte{
+		"vmoveto width": t2prog(50, 10, byte(4), byte(14)),
+		"hmoveto width": t2prog(50, 10, byte(22), byte(14)),
+		"endchar width": t2prog(50, byte(14)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := decodeType2(program, nil, nil, 500)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.hasWidth || result.width != 550 {
+				t.Fatalf("width=%g hasWidth=%v, want 550 true", result.width, result.hasWidth)
+			}
+		})
+	}
+
+	invalid := map[string][]byte{
+		"odd stem operands":     t2prog(0, 0, byte(21), 10, byte(1), byte(14)),
+		"truncated hint mask":   t2prog(10, 20, byte(19)),
+		"vmoveto arity":         t2prog(0, 0, 0, byte(4), byte(14)),
+		"rmoveto arity":         t2prog(0, byte(21), byte(14)),
+		"hmoveto arity":         t2prog(0, 0, 0, byte(22), byte(14)),
+		"hlineto underflow":     t2prog(byte(6), byte(14)),
+		"rrcurveto arity":       t2prog(1, 2, byte(8), byte(14)),
+		"rcurveline arity":      t2prog(1, 2, 3, 4, 5, 6, byte(24), byte(14)),
+		"rlinecurve arity":      t2prog(1, 2, 3, 4, 5, 6, byte(25), byte(14)),
+		"vvcurveto underflow":   t2prog(1, 2, 3, byte(26), byte(14)),
+		"vvcurveto arity":       t2prog(1, 2, 3, 4, 5, 6, byte(26), byte(14)),
+		"vhcurveto underflow":   t2prog(1, 2, 3, byte(30), byte(14)),
+		"vhcurveto arity":       t2prog(1, 2, 3, 4, 5, 6, byte(30), byte(14)),
+		"fractional subroutine": t2prog([]byte{255, 0, 1, 0x80, 0}, byte(10), byte(14)),
+		"endchar operand count": t2prog(1, 2, byte(14)),
+		"endchar seac":          t2prog(1, 2, 3, 4, byte(14)),
+	}
+	for name, program := range invalid {
+		t.Run(name, func(t *testing.T) {
+			if _, err := decodeType2(program, nil, nil, 0); err == nil {
+				t.Fatal("invalid program accepted")
+			}
+		})
+	}
+
+	if _, err := decodeType2(t2prog(-107, byte(10), byte(14)), [][]byte{{}}, nil, 0); err == nil {
+		t.Fatal("subroutine without return accepted")
+	}
+}
+
+func TestType2NonFiniteGeometryAndStackLimits(t *testing.T) {
+	// Repeated multiplication stays representable as float64 while exceeding
+	// float32, which exercises the decoder's output-coordinate boundary.
+	huge := t2prog(32767, 32767, byte(12), byte(24))
+	for range 7 {
+		huge = append(huge, t2prog(32767, byte(12), byte(24))...)
+	}
+	for name, program := range map[string][]byte{
+		"move":  t2prog(huge, 0, byte(21), byte(14)),
+		"line":  t2prog(0, 0, byte(21), huge, 0, byte(5), byte(14)),
+		"curve": t2prog(0, 0, byte(21), huge, 0, 0, 0, 0, 0, byte(8), byte(14)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := decodeType2(program, nil, nil, 0); err == nil {
+				t.Fatal("out-of-range geometry accepted")
+			}
+		})
+	}
+
+	full := make([]byte, type2MaxStack)
+	for i := range full {
+		full[i] = 139
+	}
+	for name, operator := range map[string][]byte{
+		"random": {12, 23},
+		"dup":    {12, 27},
+	} {
+		t.Run(name, func(t *testing.T) {
+			program := append(append([]byte(nil), full...), operator...)
+			program = append(program, 14)
+			if _, err := decodeType2(program, nil, nil, 0); err == nil {
+				t.Fatal("stack overflow accepted")
+			}
+		})
+	}
+}
+
+func TestType2RejectsMalformedPrograms(t *testing.T) {
+	deep := make([][]byte, 1)
+	deep[0] = t2prog(-107, byte(10), byte(11))
+	chain := make([][]byte, type2MaxCallDepth)
+	for i := range len(chain) - 1 {
+		chain[i] = t2prog(i+1-type2SubrBias(len(chain)), byte(10), byte(11))
+	}
+	chain[len(chain)-1] = []byte{11}
+	many := make([]byte, 0, 2*(type2MaxOperations+1))
+	for range type2MaxOperations + 1 {
+		many = append(many, 12, 0)
+	}
+	stackOverflow := make([]byte, 0, 50)
+	for range type2MaxStack + 1 {
+		stackOverflow = append(stackOverflow, 139)
+	}
+	tests := map[string]struct {
+		p        []byte
+		locals   [][]byte
+		contains string
+	}{
+		"truncated number":  {[]byte{28}, nil, "truncated"},
+		"reserved operator": {[]byte{2}, nil, "unsupported"},
+		"underflow":         {[]byte{5}, nil, "invalid operand"},
+		"overflow":          {stackOverflow, nil, "overflow"},
+		"invalid subr":      {t2prog(-107, byte(10), byte(14)), nil, "out of range"},
+		"cycle":             {t2prog(-107, byte(10), byte(14)), deep, "cycle"},
+		"recursion limit":   {t2prog(-107, byte(10), byte(14)), chain, "recursion limit"},
+		"operation limit":   {many, nil, "operation limit"},
+		"missing endchar":   {t2prog(0, 0, byte(21)), nil, "without endchar"},
+		"return top":        {[]byte{11}, nil, "outside"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			r, err := decodeType2(tt.p, tt.locals, nil, 0)
+			if err == nil || !strings.Contains(err.Error(), tt.contains) {
+				t.Fatalf("result=%#v err=%v want containing %q", r, err, tt.contains)
+			}
+			if r.segments != nil || r.hasWidth {
+				t.Fatalf("partial result returned: %#v", r)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Restore CFF-flavored OpenType rendering in the pure-Go font stack:

- parse bounded CFF1 headers, INDEXes, DICTs, CharStrings, Private DICTs, and local/global subroutines
- support both ordinary CFF fonts and CID-keyed fonts via ROS, FDArray, and FDSelect formats 0 and 3
- execute Type 2 charstrings into the existing `GlyphOutline` move/line/cubic representation
- route CFF outlines through `ExtractOutline`, hinted extraction, bounds, advance, LSB, and existing raster consumers
- lazily parse immutable per-font CFF state behind `sync.Once`

## Root cause

The own parser only dispatched `glyf` outlines after the go-text fallback was removed. CFF-based `.otf` files could shape and expose metrics, but outline extraction returned no drawable geometry.

## Safety and compatibility

The parser and interpreter validate every offset and length and enforce explicit operand-stack, call-depth, operation, and segment limits. Malformed input returns contextual errors rather than panicking or running unbounded work.

TrueType `glyf` remains the first-choice path and is unchanged. `cmap` and `hmtx` remain authoritative for character mapping and metrics. No dependency or licensed font fixture is added; integration tests build compact synthetic ordinary and CID CFF1 fonts in memory.

Intentional limits:

- CFF2 variations remain unsupported
- deprecated `endchar` seac composition returns an explicit unsupported error
- Type 2 hint operators are consumed structurally but are not executed

## Validation

- `go test ./text -run 'Test(Type2|CFF|Outline.*CFF|Glyf|Outline)' -count=1`
- `go test -race ./text -run 'Test(CFF|Outline.*CFF)' -count=1`
- public-API scan of installed CFF1 fonts through the own parser: zero outline failures, including eight families that exercise `endchar` from a subroutine
- `go vet ./...`
- `go build ./...`
- `go test -tags nogpu ./... -count=1`
- `BenchmarkCFFOutlineCold`: 2.022 µs/op, 2,104 B/op, 52 allocs/op
- `BenchmarkCFFOutlineParsed`: 462.2 ns/op, 496 B/op, 6 allocs/op

Coverage includes INDEX/DICT number encodings, Type 2 drawing families and flex operators, width/stem/mask handling, subroutine bias and nesting, malformed/truncated data, limit enforcement, ordinary/CID end-to-end extraction, public rasterization, deterministic lazy reuse, concurrent extraction, CFF2 rejection, and existing `glyf` behavior.

Closes #448.
