### PR TITLE
fix(text): variable font advance + shear aliased rendering (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.50.16] - 2026-08-10
+
+### Fixed
+
+- **Variable font rendering advance mismatch** ([#405](https://github.com/gogpu/gg/issues/405)) —
+  `drawGlyphsVariable` used TT-hinted phantom advances (integer-rounded) for glyph
+  positioning, while `Face.Advance()` / `MeasureString()` used HVAR advances (fractional).
+  Rendering now uses HVAR advances via `varOrRawAdvance()`, matching FreeType
+  `ttgload.c:964-977`: when HVAR present, discard TT-hinted phantom advances.
+  Also fixed `faceGlyphAdvance()` (used by MultiFace/FilteredFace) to use
+  `advanceResolver` for consistent advances across all text paths.
+
+- **Shear/rotation text garbling in aliased mode** ([#405](https://github.com/gogpu/gg/issues/405)) —
+  `drawStringCPUAliased` and `drawStringCPU` routed sheared text through
+  `drawStringAsOutlines` with `NoAAFiller`, which produces garbled output on
+  non-axis-aligned paths. Now forces anti-aliased coverage for non-axis-aligned
+  outlines, matching Skia's `computeAxisAlignmentForHText` pattern where binary
+  coverage is used only for axis-aligned text.
+
 ## [0.50.15] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 | **SVG** | Full SVG renderer (`gg/svg`): parse + render SVG XML with color override for theming, **retained scene lowering** (`RenderToScene` — resolution-independent vector icons via scene graph), **thin stroke hinting** (pixel-grid snapping for crisp small icons), SVG path data parser (`ParseSVGPath`), transform-aware `FillPath`/`StrokePath` |
 | **Vector Export** | Recording system with PDF and SVG backends |
 | **Rasterizer** | Smart per-path algorithm selection (scanline, 4×4 tiles, 16×16 tiles, SDF, compute), text-aware area-based routing |
-| **Performance** | Tile-based parallel rendering, LRU caching, four-level damage pipeline (ADR-021: object diff → tile dirty → GPU scissor → OS present), **text batch coalescing** (ADR-031: same-style DrawString calls merge into 1 GPU draw call, Skia TextBlob pattern), **zero-copy buffer reuse** (NewPixmapFromBuffer + ImageView for hot rendering loops), incremental Path.Bounds (Skia pattern), `GOGPU_DEBUG_DAMAGE=1` overlay |
+| **Performance** | Tile-based parallel rendering, LRU caching, four-level damage pipeline (ADR-021: object diff → tile dirty → GPU scissor → OS present), **text batch coalescing** (ADR-031: same-style DrawString calls merge into 1 GPU draw call, Skia TextBlob pattern), **zero-copy buffer reuse** (NewPixmapFromBuffer + ImageView for hot rendering loops), incremental Path.Bounds (Skia pattern), `GOGPU_DEBUG_DAMAGE=overlay` overlay |
 
 ---
 
@@ -589,7 +589,7 @@ dc := gg.NewContext(512, 512) // dc = drawing context
 Visualize which regions are repainted each frame:
 
 ```bash
-GOGPU_DEBUG_DAMAGE=1 go run ./examples/gogpu_integration
+GOGPU_DEBUG_DAMAGE=overlay go run ./examples/gogpu_integration
 ```
 
 Green flash-and-fade overlay shows damaged (repainted) regions. Useful for verifying that damage tracking works correctly and only dirty areas are repainted.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -171,7 +171,7 @@
 - [x] GPU scene clip: transform Push/Pop fix (BUG-GG-GPU-SCENE-CLIP-001)
 - [x] Rect clips → hardware scissor in GPUSceneRenderer
 - [x] SetDamageTracking API (ADR-021)
-- [x] Flash-and-fade damage debug overlay (GOGPU_DEBUG_DAMAGE=1)
+- [x] Flash-and-fade damage debug overlay (GOGPU_DEBUG_DAMAGE=overlay)
 - [x] Scene Append layer-aware encoding
 - [x] TagStroke LineCap/LineJoin/MiterLimit fix
 - [x] Software backend softwareMode flag (lazy GPU init)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.50.11
+## Current State: v0.50.16
 
 ✅ **Production-ready** with GPU-accelerated rendering:
 - **Forward-diff curve edges** (ADR-063) — Skia AAA forward-diff pipeline (updateQuadratic/updateCubic) with deviation-based subdivision. Value-type curve edges (zero per-edge heap allocs). 30% faster on small paths

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -825,7 +825,7 @@ Key components:
 - **`Context.FrameDamage()`** — `[]image.Rectangle` list of per-operation damage rects for immediate-mode
 - **Threshold merge** — >16 rects merged to bounding box (Swiss cheese prevention, Wayland compositor pattern)
 - **`DamageRectSetter`** — ggcanvas passes per-rect damage to `gogpu.SetDamageRects()` → `wgpu.PresentWithDamage()`
-- **`GOGPU_DEBUG_DAMAGE=1`** — green overlay on damage regions (Android SurfaceFlinger pattern, full recompose per debug frame)
+- **`GOGPU_DEBUG_DAMAGE=overlay`** — green overlay on damage regions (Android SurfaceFlinger pattern, full recompose per debug frame)
 
 ### Render Mode (ADR-020)
 

--- a/examples/damage_demo/main.go
+++ b/examples/damage_demo/main.go
@@ -3,14 +3,14 @@
 // Demonstrates real partial screen updates:
 //   - Static elements: colored rectangles + text (drawn once, never redrawn)
 //   - Animated element: single bouncing circle (only its area redrawn each frame)
-//   - GOGPU_DEBUG_DAMAGE=1: green overlay shows which regions update
+//   - GOGPU_DEBUG_DAMAGE=overlay: green overlay shows which regions update
 //
 // Expected result: with debug overlay, only the bouncing circle area flashes green.
 // Static rectangles stay clean after the first frame.
 //
 // Run:
 //
-//	GOGPU_GRAPHICS_API=software GOGPU_DEBUG_DAMAGE=1 go run ./examples/damage_demo
+//	GOGPU_GRAPHICS_API=software GOGPU_DEBUG_DAMAGE=overlay go run ./examples/damage_demo
 package main
 
 import (

--- a/examples/multi_damage_demo/main.go
+++ b/examples/multi_damage_demo/main.go
@@ -6,7 +6,7 @@
 //
 // Run with debug overlay to see damage rects:
 //
-//	GOGPU_DEBUG_DAMAGE=1 go run ./examples/multi_damage_demo
+//	GOGPU_DEBUG_DAMAGE=overlay go run ./examples/multi_damage_demo
 //
 // Expected: two green flash regions at opposite corners, NOT a diagonal stripe.
 package main
@@ -147,7 +147,7 @@ func drawBackground(cc *gg.Context, w, h int) {
 	cc.SetRGBA(1, 1, 1, 0.3)
 	cc.DrawStringAnchored("Multi-Rect Damage Demo (ADR-028)", float64(w)/2, float64(h)/2-20, 0.5, 0.5)
 	cc.DrawStringAnchored("Two animated regions at opposite corners", float64(w)/2, float64(h)/2+5, 0.5, 0.5)
-	cc.DrawStringAnchored("With GOGPU_DEBUG_DAMAGE=1: only two green squares, not diagonal", float64(w)/2, float64(h)/2+25, 0.5, 0.5)
+	cc.DrawStringAnchored("With GOGPU_DEBUG_DAMAGE=overlay: only two green squares, not diagonal", float64(w)/2, float64(h)/2+25, 0.5, 0.5)
 }
 
 func drawTopLeftSpinner(cc *gg.Context, t float64) {

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -61,14 +61,20 @@ type Canvas struct {
 	width                int
 	height               int
 	closed               bool
-	tracked              bool               // true if auto-registered with a ResourceTracker
-	damageFlashs         damageOverlayState // debug overlay fade state
-	lastFrameDamageRects []image.Rectangle  // damage rects from last Render (for diagnostics)
-	prevFrameDamageRects []image.Rectangle  // previous frame damage for 2-frame union (Wayland pattern)
+	tracked              bool              // true if auto-registered with a ResourceTracker
+	damageOverlay        *ggDamageOverlay  // debug overlay renderer (ADR-066)
+	lastFrameDamageRects []image.Rectangle // damage rects from last Render (for diagnostics)
+	prevFrameDamageRects []image.Rectangle // previous frame damage for 2-frame union (Wayland pattern)
+
+	// damageSource is the registered damage reporter for gg (ADR-065).
+	// Set on first Render() call via interface assertion on the RenderTarget.
+	// When set, forwardDamageRects reports damage through this reporter
+	// instead of the removed DamageRectSetter interface.
+	damageSource gpucontext.DamageReporter
 
 	// presentDamageRects holds damage rects for the next present call (ADR-021 Phase 4).
 	// Set by caller (e.g. ui retained tree) via SetPresentDamage().
-	// Consumed and cleared by Render() after forwarding to SetDamageRects().
+	// Consumed and cleared by Render() after forwarding via damageSource.
 	presentDamageRects []image.Rectangle
 }
 
@@ -310,14 +316,18 @@ func (c *Canvas) LastDamageRects() []image.Rectangle {
 // NeedsAnimationFrame reports whether the canvas needs another frame
 // for debug overlay fade animation. Caller should RequestRedraw if true.
 func (c *Canvas) NeedsAnimationFrame() bool {
-	return c.damageFlashs.needsAnimationFrame()
+	if c.damageOverlay == nil {
+		return false
+	}
+	return c.damageOverlay.needsAnimationFrame()
 }
 
 // SetPresentDamage sets damage rectangles for the next present call (ADR-021 Level 4).
 // Rects are in logical (user-space) coordinates with top-left origin. They are
-// automatically scaled to physical pixels and forwarded to gogpu SetDamageRects()
-// → wgpu PresentWithDamage() → OS compositor hint (VK_KHR_incremental_present,
-// DX12 Present1, eglSwapBuffersWithDamage).
+// automatically scaled to physical pixels and forwarded via the registered
+// DamageReporter (ADR-065) → gogpu compositor → wgpu PresentWithDamage() →
+// OS compositor hint (VK_KHR_incremental_present, DX12 Present1,
+// eglSwapBuffersWithDamage).
 //
 // Callers with retained-mode knowledge (e.g. ui widget tree) should provide
 // BOTH old and new bounds of moved/resized objects. Immediate-mode callers
@@ -343,26 +353,23 @@ func (c *Canvas) SetPresentDamage(rects []image.Rectangle) {
 	c.presentDamageRects = rects
 }
 
-// forwardDamageRects sends damage rects to the OS compositor via SetDamageRects
-// (ADR-021 Level 4). Unions explicit rects from SetPresentDamage with
+// forwardDamageRects reports damage rects to the compositor via the registered
+// DamageReporter (ADR-065). Unions explicit rects from SetPresentDamage with
 // immediate-mode FrameDamage — never lets caller understate actual damage.
 // Includes previous frame damage (2-frame ring, Wayland wlr_damage_ring pattern)
 // so moved objects don't leave trails on double-buffered surfaces.
 // Clears presentDamageRects after forwarding (one-shot per frame).
-func (c *Canvas) forwardDamageRects(dc RenderTarget, frameDamage []image.Rectangle) {
-	setter, ok := dc.(DamageRectSetter)
-	if !ok {
+func (c *Canvas) forwardDamageRects(frameDamage []image.Rectangle) {
+	if c.damageSource == nil {
 		c.presentDamageRects = nil
 		c.prevFrameDamageRects = frameDamage
 		return
 	}
 
-	// First frame or after Resize: full-window damage. The pixmap is complete
+	// First frame or after Resize: full-surface damage. The pixmap is complete
 	// but the window surface is uninitialized — must blit everything.
 	if c.prevFrameDamageRects == nil {
-		setter.SetDamageRects([]image.Rectangle{
-			image.Rect(0, 0, c.width, c.height),
-		})
+		c.damageSource.ReportDamage(image.Rect(0, 0, c.width, c.height))
 		c.presentDamageRects = nil
 		// Empty (not nil) marks "initialized" — nil means "first frame".
 		if frameDamage != nil {
@@ -386,7 +393,7 @@ func (c *Canvas) forwardDamageRects(dc RenderTarget, frameDamage []image.Rectang
 		rects = append(rects, c.prevFrameDamageRects...)
 	}
 	if len(rects) > 0 {
-		setter.SetDamageRects(rects)
+		c.damageSource.ReportDamage(rects...)
 	}
 	c.presentDamageRects = nil
 	c.prevFrameDamageRects = frameDamage
@@ -706,13 +713,6 @@ type CommandEncoderProvider interface {
 	CommandEncoder() gpucontext.CommandEncoder
 }
 
-// DamageRectSetter is an optional interface for RenderTargets that support
-// damage-aware presentation (ADR-021 Level 3-4). gogpu.ContextRenderTarget
-// implements this via Context.SetDamageRects().
-type DamageRectSetter interface {
-	SetDamageRects(rects []image.Rectangle)
-}
-
 // SurfacePixelWriter is an optional interface for RenderTargets that support
 // direct pixel upload to the surface framebuffer (software backend zero-copy).
 // Bypasses texture creation, render pass, and SPIR-V — single memcpy+swizzle.
@@ -738,6 +738,32 @@ func (c *Canvas) Render(dc RenderTarget) error {
 		return ErrCanvasClosed
 	}
 
+	// Register as "gg" damage source on first Render call (ADR-065).
+	// Uses interface assertion to discover RegisterDamageSource without
+	// importing gogpu — same duck-typing pattern as CommandEncoderProvider,
+	// SurfacePixelWriter, etc.
+	if c.damageSource == nil {
+		type damageSourceRegistrar interface {
+			RegisterDamageSource(name string) gpucontext.DamageReporter
+		}
+		if reg, ok := dc.(damageSourceRegistrar); ok {
+			c.damageSource = reg.RegisterDamageSource("gg")
+		}
+	}
+
+	// Register gg damage overlay renderer on first Render call (ADR-066).
+	// Provides text-enhanced overlay (source labels, reason, rect count)
+	// that replaces gogpu's built-in flat-color quads.
+	if c.damageOverlay == nil {
+		type overlayRendererSetter interface {
+			SetDamageOverlayRenderer(gpucontext.DamageOverlayRenderer)
+		}
+		if setter, ok := dc.(overlayRendererSetter); ok {
+			c.damageOverlay = &ggDamageOverlay{ctx: c.ctx}
+			setter.SetDamageOverlayRenderer(c.damageOverlay)
+		}
+	}
+
 	// Auto-detect DPI scale change (ADR-059). Zero overhead when unchanged.
 	if wp, ok := c.provider.(gpucontext.WindowProvider); ok {
 		if newScale := wp.ScaleFactor(); newScale > 0 && newScale != c.ctx.DeviceScale() {
@@ -755,18 +781,6 @@ func (c *Canvas) Render(dc RenderTarget) error {
 	c.lastFrameDamageRects = damageRects
 	c.ctx.ResetFrameDamage()
 
-	// Debug damage overlay (ADR-021 Phase 6a).
-	// Draw overlay BEFORE present so it's visible on ALL backends.
-	// Android SurfaceFlinger pattern: flash-and-fade on dirty regions.
-	if isDebugDamageEnabled() {
-		c.damageFlashs.update(damageRects)
-		if len(c.damageFlashs.flashes) > 0 {
-			c.ctx.SetDamageTracking(false)
-			c.damageFlashs.drawAll(c.ctx)
-			c.ctx.SetDamageTracking(true)
-		}
-	}
-
 	// Try GPU-direct path (zero-copy surface rendering).
 	// Only attempt if the accelerator is actually capable — on CPU-only
 	// adapters (llvmpipe, SwiftShader) the accelerator stays uninitialized
@@ -775,7 +789,7 @@ func (c *Canvas) Render(dc RenderTarget) error {
 	if !sv.IsNil() && gg.AcceleratorCanRenderDirect() {
 		sw, sh := dc.SurfaceSize()
 		if err := c.renderDirectToTarget(dc, sv, sw, sh); err == nil {
-			c.forwardDamageRects(dc, damageRects)
+			c.forwardDamageRects(damageRects)
 			return nil
 		}
 	}
@@ -790,7 +804,7 @@ func (c *Canvas) Render(dc RenderTarget) error {
 		if err := c.ctx.FlushGPU(); err != nil {
 			gg.Logger().Debug("ggcanvas: FlushGPU before PresentPixels failed", "err", err)
 		}
-		c.forwardDamageRects(dc, damageRects)
+		c.forwardDamageRects(damageRects)
 		pixmap := c.ctx.ResizeTarget()
 		if err := pw.WriteSurfacePixels(pixmap.Data(), uint32(c.ctx.PixelWidth()), uint32(c.ctx.PixelHeight())); err == nil {
 			c.dirty = false
@@ -811,7 +825,7 @@ func (c *Canvas) Render(dc RenderTarget) error {
 		return err
 	}
 
-	c.forwardDamageRects(dc, damageRects)
+	c.forwardDamageRects(damageRects)
 
 	return dc.PresentTexture(tex)
 }

--- a/integration/ggcanvas/canvas_render_test.go
+++ b/integration/ggcanvas/canvas_render_test.go
@@ -25,8 +25,7 @@ type renderMockPixelWriter struct {
 	writtenH       uint32
 	writeCallCount int
 	writeErr       error
-	damageRects    []image.Rectangle
-	damageSetCount int
+	reporter       *mockDamageReporter
 }
 
 func (m *renderMockPixelWriter) SurfaceView() gpucontext.TextureView { return gpucontext.TextureView{} }
@@ -44,9 +43,11 @@ func (m *renderMockPixelWriter) WriteSurfacePixels(data []byte, width, height ui
 	m.writeCallCount++
 	return m.writeErr
 }
-func (m *renderMockPixelWriter) SetDamageRects(rects []image.Rectangle) {
-	m.damageRects = rects
-	m.damageSetCount++
+
+// RegisterDamageSource satisfies the damageSourceRegistrar interface.
+func (m *renderMockPixelWriter) RegisterDamageSource(_ string) gpucontext.DamageReporter {
+	m.reporter = &mockDamageReporter{}
+	return m.reporter
 }
 
 // TextureCreator returns a mock renderer so promoteIfPending can create a real texture.
@@ -377,7 +378,7 @@ func TestRender_UniversalPath(t *testing.T) {
 }
 
 // TestRender_DamageRectsForwardedOnPixelUpload verifies that damage rects ARE
-// forwarded to the render target before WriteSurfacePixels for partial blit
+// forwarded to the damage reporter before WriteSurfacePixels for partial blit
 // optimization. WritePixels writes full pixmap to DIB, blitDamageRectsToWindow
 // BitBlts only changed areas.
 func TestRender_DamageRectsForwardedOnPixelUpload(t *testing.T) {
@@ -400,8 +401,11 @@ func TestRender_DamageRectsForwardedOnPixelUpload(t *testing.T) {
 		t.Fatalf("Render: %v", err)
 	}
 
-	// Damage rects forwarded for partial blit optimization.
-	if dc.damageSetCount == 0 {
-		t.Error("SetDamageRects not called — damage rects should be forwarded for partial blit")
+	// Render registers damage source on first call, then reports damage.
+	if dc.reporter == nil {
+		t.Fatal("RegisterDamageSource should have been called")
+	}
+	if dc.reporter.reportCount == 0 {
+		t.Error("ReportDamage not called — damage rects should be forwarded for partial blit")
 	}
 }

--- a/integration/ggcanvas/canvas_test.go
+++ b/integration/ggcanvas/canvas_test.go
@@ -1066,14 +1066,39 @@ func TestPixmapTextureView_PromotedTexture(t *testing.T) {
 	}
 }
 
-// mockRenderTarget implements RenderTarget + DamageRectSetter for testing damage forwarding.
+// mockDamageReporter implements gpucontext.DamageReporter for testing damage forwarding.
+type mockDamageReporter struct {
+	rects       []image.Rectangle
+	reportCount int
+	fullDamage  bool
+}
+
+func (m *mockDamageReporter) ReportDamage(rects ...image.Rectangle) {
+	m.reportCount++
+	if len(rects) == 0 {
+		m.fullDamage = true
+	} else {
+		m.rects = append(m.rects, rects...)
+	}
+}
+
+func (m *mockDamageReporter) ReportDamageWithReason(_ gpucontext.DamageReason, rects ...image.Rectangle) {
+	m.ReportDamage(rects...)
+}
+
+func (m *mockDamageReporter) reset() {
+	m.rects = m.rects[:0]
+	m.reportCount = 0
+	m.fullDamage = false
+}
+
+// mockRenderTarget implements RenderTarget + damage source registration for testing.
 type mockRenderTarget struct {
-	surfaceView    gpucontext.TextureView
-	surfaceW       uint32
-	surfaceH       uint32
-	presentedTex   any
-	damageRects    []image.Rectangle
-	damageSetCount int
+	surfaceView  gpucontext.TextureView
+	surfaceW     uint32
+	surfaceH     uint32
+	presentedTex any
+	reporter     *mockDamageReporter // last registered reporter
 }
 
 func (m *mockRenderTarget) SurfaceView() gpucontext.TextureView { return m.surfaceView }
@@ -1082,12 +1107,14 @@ func (m *mockRenderTarget) PresentTexture(tex any) error {
 	m.presentedTex = tex
 	return nil
 }
-func (m *mockRenderTarget) SetDamageRects(rects []image.Rectangle) {
-	m.damageRects = rects
-	m.damageSetCount++
+
+// RegisterDamageSource satisfies the damageSourceRegistrar interface for ggcanvas.
+func (m *mockRenderTarget) RegisterDamageSource(_ string) gpucontext.DamageReporter {
+	m.reporter = &mockDamageReporter{}
+	return m.reporter
 }
 
-// mockRenderTargetNoDamage implements RenderTarget WITHOUT DamageRectSetter.
+// mockRenderTargetNoDamage implements RenderTarget WITHOUT damage source registration.
 type mockRenderTargetNoDamage struct {
 	surfaceView  gpucontext.TextureView
 	surfaceW     uint32
@@ -1110,9 +1137,12 @@ func TestSetPresentDamage_ForwardedOnRender(t *testing.T) {
 	}
 	defer c.Close()
 
-	// Warm up past first-frame full-window damage.
-	dc0 := &mockRenderTarget{}
-	c.forwardDamageRects(dc0, nil)
+	reporter := &mockDamageReporter{}
+	c.damageSource = reporter
+
+	// Warm up past first-frame full-surface damage.
+	c.forwardDamageRects(nil)
+	reporter.reset()
 
 	rects := []image.Rectangle{
 		image.Rect(10, 10, 30, 30),
@@ -1120,17 +1150,16 @@ func TestSetPresentDamage_ForwardedOnRender(t *testing.T) {
 	}
 	c.SetPresentDamage(rects)
 
-	dc := &mockRenderTarget{}
-	c.forwardDamageRects(dc, nil)
+	c.forwardDamageRects(nil)
 
-	if dc.damageSetCount != 1 {
-		t.Errorf("SetDamageRects called %d times, want 1", dc.damageSetCount)
+	if reporter.reportCount != 1 {
+		t.Errorf("ReportDamage called %d times, want 1", reporter.reportCount)
 	}
-	if len(dc.damageRects) != 2 {
-		t.Fatalf("damageRects len = %d, want 2", len(dc.damageRects))
+	if len(reporter.rects) != 2 {
+		t.Fatalf("damageRects len = %d, want 2", len(reporter.rects))
 	}
-	if dc.damageRects[0] != rects[0] || dc.damageRects[1] != rects[1] {
-		t.Errorf("damageRects = %v, want %v", dc.damageRects, rects)
+	if reporter.rects[0] != rects[0] || reporter.rects[1] != rects[1] {
+		t.Errorf("damageRects = %v, want %v", reporter.rects, rects)
 	}
 
 	// After forward, presentDamageRects must be cleared.
@@ -1147,19 +1176,21 @@ func TestSetPresentDamage_FallbackToFrameDamage(t *testing.T) {
 	}
 	defer c.Close()
 
-	// Warm up past first-frame full-window damage.
-	dc := &mockRenderTarget{}
-	c.forwardDamageRects(dc, nil)
+	reporter := &mockDamageReporter{}
+	c.damageSource = reporter
+
+	// Warm up past first-frame full-surface damage.
+	c.forwardDamageRects(nil)
+	reporter.reset()
 
 	frameDamage := []image.Rectangle{image.Rect(5, 5, 15, 15)}
-	dc2 := &mockRenderTarget{}
-	c.forwardDamageRects(dc2, frameDamage)
+	c.forwardDamageRects(frameDamage)
 
-	if dc2.damageSetCount != 1 {
-		t.Errorf("SetDamageRects called %d times, want 1", dc2.damageSetCount)
+	if reporter.reportCount != 1 {
+		t.Errorf("ReportDamage called %d times, want 1", reporter.reportCount)
 	}
-	if len(dc2.damageRects) != 1 || dc2.damageRects[0] != frameDamage[0] {
-		t.Errorf("damageRects = %v, want %v", dc2.damageRects, frameDamage)
+	if len(reporter.rects) != 1 || reporter.rects[0] != frameDamage[0] {
+		t.Errorf("damageRects = %v, want %v", reporter.rects, frameDamage)
 	}
 }
 
@@ -1171,25 +1202,27 @@ func TestSetPresentDamage_UnionsWithFrameDamage(t *testing.T) {
 	}
 	defer c.Close()
 
-	// Warm up past first-frame full-window damage.
-	dc0 := &mockRenderTarget{}
-	c.forwardDamageRects(dc0, nil)
+	reporter := &mockDamageReporter{}
+	c.damageSource = reporter
+
+	// Warm up past first-frame full-surface damage.
+	c.forwardDamageRects(nil)
+	reporter.reset()
 
 	explicit := []image.Rectangle{image.Rect(20, 20, 40, 40)}
 	frameDamage := []image.Rectangle{image.Rect(5, 5, 15, 15)}
 
 	c.SetPresentDamage(explicit)
-	dc := &mockRenderTarget{}
-	c.forwardDamageRects(dc, frameDamage)
+	c.forwardDamageRects(frameDamage)
 
-	if len(dc.damageRects) != 2 {
-		t.Fatalf("damageRects count = %d, want 2 (union of explicit + frame)", len(dc.damageRects))
+	if len(reporter.rects) != 2 {
+		t.Fatalf("damageRects count = %d, want 2 (union of explicit + frame)", len(reporter.rects))
 	}
-	if dc.damageRects[0] != explicit[0] {
-		t.Errorf("damageRects[0] = %v, want explicit %v", dc.damageRects[0], explicit[0])
+	if reporter.rects[0] != explicit[0] {
+		t.Errorf("damageRects[0] = %v, want explicit %v", reporter.rects[0], explicit[0])
 	}
-	if dc.damageRects[1] != frameDamage[0] {
-		t.Errorf("damageRects[1] = %v, want frameDamage %v", dc.damageRects[1], frameDamage[0])
+	if reporter.rects[1] != frameDamage[0] {
+		t.Errorf("damageRects[1] = %v, want frameDamage %v", reporter.rects[1], frameDamage[0])
 	}
 }
 
@@ -1201,22 +1234,26 @@ func TestSetPresentDamage_FirstFrameFullWindow(t *testing.T) {
 	}
 	defer c.Close()
 
-	dc := &mockRenderTarget{}
-	c.forwardDamageRects(dc, nil)
+	reporter := &mockDamageReporter{}
+	c.damageSource = reporter
 
-	// First frame: full-window damage regardless of frameDamage content.
-	if dc.damageSetCount != 1 {
-		t.Errorf("first frame: SetDamageRects called %d times, want 1 (full-window)", dc.damageSetCount)
+	c.forwardDamageRects(nil)
+
+	// First frame: full-surface damage regardless of frameDamage content.
+	if reporter.reportCount != 1 {
+		t.Errorf("first frame: ReportDamage called %d times, want 1 (full-surface)", reporter.reportCount)
 	}
 
-	// Second frame with nil frameDamage: no damage → no call.
-	c.forwardDamageRects(dc, nil)
-	if dc.damageSetCount != 1 {
-		t.Errorf("second frame nil: SetDamageRects called %d times, want still 1", dc.damageSetCount)
+	reporter.reset()
+
+	// Second frame with nil frameDamage: no damage -> no call.
+	c.forwardDamageRects(nil)
+	if reporter.reportCount != 0 {
+		t.Errorf("second frame nil: ReportDamage called %d times, want 0", reporter.reportCount)
 	}
 }
 
-func TestSetPresentDamage_NoDamageSetterInterface(t *testing.T) {
+func TestSetPresentDamage_NoDamageSource(t *testing.T) {
 	provider := newMockProvider()
 	c, err := New(provider, 50, 50)
 	if err != nil {
@@ -1224,15 +1261,15 @@ func TestSetPresentDamage_NoDamageSetterInterface(t *testing.T) {
 	}
 	defer c.Close()
 
+	// damageSource is nil (no registration).
 	explicit := []image.Rectangle{image.Rect(10, 10, 30, 30)}
 	c.SetPresentDamage(explicit)
 
-	dc := &mockRenderTargetNoDamage{}
-	c.forwardDamageRects(dc, nil)
+	c.forwardDamageRects(nil)
 
-	// No panic, presentDamageRects cleared even without setter.
+	// No panic, presentDamageRects cleared even without damageSource.
 	if c.presentDamageRects != nil {
-		t.Error("presentDamageRects not cleared when setter unavailable")
+		t.Error("presentDamageRects not cleared when damageSource unavailable")
 	}
 }
 
@@ -1244,19 +1281,98 @@ func TestSetPresentDamage_ClearedAfterForward(t *testing.T) {
 	}
 	defer c.Close()
 
+	reporter := &mockDamageReporter{}
+	c.damageSource = reporter
+
 	c.SetPresentDamage([]image.Rectangle{image.Rect(0, 0, 50, 50)})
-	dc := &mockRenderTarget{}
 
-	c.forwardDamageRects(dc, nil)
-	if dc.damageSetCount != 1 {
-		t.Fatalf("first forward: want 1 call, got %d", dc.damageSetCount)
+	c.forwardDamageRects(nil)
+	if reporter.reportCount != 1 {
+		t.Fatalf("first forward: want 1 call, got %d", reporter.reportCount)
 	}
 
-	// Second forward: no rects → no SetDamageRects call.
-	c.forwardDamageRects(dc, nil)
-	if dc.damageSetCount != 1 {
-		t.Errorf("second forward: want still 1 call, got %d", dc.damageSetCount)
+	reporter.reset()
+
+	// Second forward: no rects -> no ReportDamage call.
+	c.forwardDamageRects(nil)
+	if reporter.reportCount != 0 {
+		t.Errorf("second forward: want 0 calls, got %d", reporter.reportCount)
 	}
+}
+
+// mockRenderTargetWithCreator adds TextureCreator to mockRenderTarget so the
+// universal path (Flush -> promoteIfPending -> PresentTexture) works.
+type mockRenderTargetWithCreator struct {
+	mockRenderTarget
+	renderer *mockRenderer
+}
+
+func (m *mockRenderTargetWithCreator) TextureCreator() gpucontext.TextureCreator {
+	return m.renderer
+}
+
+// TestRender_RegistersDamageSource verifies that Render() auto-registers "gg"
+// as a damage source when the RenderTarget supports RegisterDamageSource.
+func TestRender_RegistersDamageSource(t *testing.T) {
+	provider := newMockProvider()
+	c, err := New(provider, 50, 50)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer c.Close()
+
+	dc := &mockRenderTargetWithCreator{renderer: &mockRenderer{}}
+	if c.damageSource != nil {
+		t.Fatal("damageSource should be nil before first Render")
+	}
+
+	// Render triggers registration.
+	c.dirty = true
+	if err := c.Render(dc); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	if c.damageSource == nil {
+		t.Error("damageSource should be set after first Render with registrar target")
+	}
+	if dc.reporter == nil {
+		t.Error("RegisterDamageSource should have been called on the target")
+	}
+}
+
+// TestRender_NoDamageRegistration verifies that Render() works correctly when
+// the RenderTarget does not support damage source registration.
+func TestRender_NoDamageRegistration(t *testing.T) {
+	provider := newMockProvider()
+	c, err := New(provider, 50, 50)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer c.Close()
+
+	// mockRenderTargetNoDamage does not implement RegisterDamageSource.
+	// Use a wrapper with TextureCreator so Render can complete.
+	dc := &renderMockNoDamageWithCreator{renderer: &mockRenderer{}}
+	c.dirty = true
+
+	// Should not panic; damageSource stays nil.
+	if err := c.Render(dc); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	if c.damageSource != nil {
+		t.Error("damageSource should remain nil when target doesn't support registration")
+	}
+}
+
+// renderMockNoDamageWithCreator wraps mockRenderTargetNoDamage with TextureCreator.
+type renderMockNoDamageWithCreator struct {
+	mockRenderTargetNoDamage
+	renderer *mockRenderer
+}
+
+func (m *renderMockNoDamageWithCreator) TextureCreator() gpucontext.TextureCreator {
+	return m.renderer
 }
 
 // TestPixmapTextureView_ClosedCanvas returns nil on closed canvas.

--- a/integration/ggcanvas/damage_debug.go
+++ b/integration/ggcanvas/damage_debug.go
@@ -1,122 +1,238 @@
 package ggcanvas
 
 import (
+	"fmt"
 	"image"
-	"os"
-	"sync"
+	"image/color"
 	"time"
 
 	"github.com/gogpu/gg"
+	"github.com/gogpu/gpucontext"
 )
 
-// Debug damage visualization (ADR-021 Phase 6a).
-// Enabled via GOGPU_DEBUG_DAMAGE=1 environment variable.
-// Draws colored overlay on damage regions — like Android "Show surface updates"
-// and Chrome "Paint flashing" developer tools.
+// ggDamageOverlay implements gpucontext.DamageOverlayRenderer with text labels.
 //
-// Flash-and-fade effect (400ms): Android SurfaceFlinger doDebugFlashRegions pattern.
-// Draws via gg.Context (Fill/Stroke) — works on ALL backends (Vulkan/DX12/Metal/GLES/Software).
-// Damage tracking suppressed during overlay draw to avoid self-inflating damage.
+// Renders per-source damage rects as colored flash-and-fade overlays via
+// gg.Context (Fill/Stroke/DrawString). Works on ALL backends because gg
+// renders through the CPU rasterizer before present.
 //
-// Zero overhead when disabled — env var checked once at init.
+// Text labels show source name, damage reason, rect count, and pixel area.
+// Uses the context's current font if set; labels are silently skipped when
+// no font is available. The overlay suppresses damage tracking during draw
+// to prevent feedback loops (overlay drawing would dirty the overlay area).
+//
+// ADR-066: pluggable overlay — gogpu provides flat-color quads (no text),
+// gg registers this richer renderer via SetDamageOverlayRenderer.
 
-var (
-	debugDamageOnce    sync.Once
-	debugDamageEnabled bool
-)
+// Compile-time interface check.
+var _ gpucontext.DamageOverlayRenderer = (*ggDamageOverlay)(nil)
 
-func isDebugDamageEnabled() bool {
-	debugDamageOnce.Do(func() {
-		debugDamageEnabled = os.Getenv("GOGPU_DEBUG_DAMAGE") == "1"
-	})
-	return debugDamageEnabled
+const ggDamageFlashDuration = 400 * time.Millisecond
+
+// labelFontSize is the font size used for overlay labels (physical pixels).
+const labelFontSize = 11.0
+
+// labelPadH is horizontal padding inside the label background box.
+const labelPadH = 4.0
+
+// labelPadV is vertical padding inside the label background box.
+const labelPadV = 2.0
+
+// ggDamageFlash tracks one active damage flash with per-source metadata.
+type ggDamageFlash struct {
+	name   string
+	color  color.RGBA
+	rect   image.Rectangle
+	full   bool
+	reason gpucontext.DamageReason
+	time   time.Time
 }
 
-const damageFlashDuration = 400 * time.Millisecond
-
-type damageFlash struct {
-	rect image.Rectangle
-	time time.Time
+// ggDamageOverlay renders the damage debug overlay using gg.Context.
+// Registered with gogpu via SetDamageOverlayRenderer on first Render.
+type ggDamageOverlay struct {
+	ctx     *gg.Context
+	flashes []ggDamageFlash
 }
 
-// damageOverlayState tracks damage flashes with fade effect.
-type damageOverlayState struct {
-	flashes []damageFlash
-}
+// RenderDamageOverlay draws per-source damage overlays with text labels.
+// Called by the gogpu compositor after all content renderers have finished.
+func (o *ggDamageOverlay) RenderDamageOverlay(info gpucontext.DamageOverlayInfo) {
+	o.updateFlashes(info.Sources)
 
-func (s *damageOverlayState) update(rects []image.Rectangle) {
-	now := time.Now()
-	alive := s.flashes[:0]
-	for _, f := range s.flashes {
-		if now.Sub(f.time) < damageFlashDuration {
-			alive = append(alive, f)
-		}
+	if len(o.flashes) == 0 {
+		return
 	}
-	s.flashes = alive
 
-	for _, r := range rects {
-		if r.Empty() {
-			continue
-		}
-		// Refresh-or-create: if an active flash already covers the same rect,
-		// refresh its timestamp instead of creating a new one. This prevents
-		// feedback loops (TrackDamageRect same rect every frame) while keeping
-		// continuously animated regions green until they stop updating.
-		// Android SurfaceFlinger pattern: region stays highlighted while dirty,
-		// fade begins only when updates stop.
-		refreshed := false
-		for i := range s.flashes {
-			if s.flashes[i].rect == r {
-				s.flashes[i].time = now
-				refreshed = true
-				break
-			}
-		}
-		if !refreshed {
-			s.flashes = append(s.flashes, damageFlash{rect: r, time: now})
-		}
-	}
-}
+	// Suppress damage tracking to avoid feedback (overlay paint triggers damage).
+	o.ctx.SetDamageTracking(false)
+	defer o.ctx.SetDamageTracking(true)
 
-// drawAll renders green flash-and-fade overlay via gg.Context.
-// Works on all backends. Caller must SetDamageTracking(false) before calling.
-func (s *damageOverlayState) drawAll(cc *gg.Context) {
 	now := time.Now()
-	for _, f := range s.flashes {
+	for i := range o.flashes {
+		f := &o.flashes[i]
 		age := now.Sub(f.time)
-		if age >= damageFlashDuration {
+		if age >= ggDamageFlashDuration {
 			continue
 		}
-		fade := 1.0 - float64(age)/float64(damageFlashDuration)
+		fade := 1.0 - float64(age)/float64(ggDamageFlashDuration)
 
-		x := float64(f.rect.Min.X)
-		y := float64(f.rect.Min.Y)
-		w := float64(f.rect.Dx())
-		h := float64(f.rect.Dy())
+		rect := f.rect
+		if f.full {
+			rect = image.Rect(0, 0, int(info.SurfaceWidth), int(info.SurfaceHeight))
+		}
+
+		x := float64(rect.Min.X)
+		y := float64(rect.Min.Y)
+		w := float64(rect.Dx())
+		h := float64(rect.Dy())
 		if w <= 0 || h <= 0 {
 			continue
 		}
 
-		// Green fill with fade.
-		cc.SetRGBA(0, 0.8, 0, 0.15*fade)
-		cc.DrawRectangle(x, y, w, h)
-		_ = cc.Fill()
+		// Fill with source color at low alpha.
+		o.ctx.SetRGBA(
+			float64(f.color.R)/255.0,
+			float64(f.color.G)/255.0,
+			float64(f.color.B)/255.0,
+			0.15*fade,
+		)
+		o.ctx.DrawRectangle(x, y, w, h)
+		_ = o.ctx.Fill()
 
-		// Green border with fade.
-		cc.SetRGBA(0, 0.9, 0, 0.7*fade)
-		cc.SetLineWidth(2)
-		cc.DrawRectangle(x+1, y+1, w-2, h-2)
-		_ = cc.Stroke()
+		// Anti-aliased border at higher alpha (gg AA via CPU rasterizer).
+		o.ctx.SetRGBA(
+			float64(f.color.R)/255.0,
+			float64(f.color.G)/255.0,
+			float64(f.color.B)/255.0,
+			0.7*fade,
+		)
+		o.ctx.SetLineWidth(2)
+		o.ctx.DrawRectangle(x+1, y+1, w-2, h-2)
+		_ = o.ctx.Stroke()
+
+		// Text label (only if font is set on the context).
+		o.drawLabel(f, x, y, fade)
 	}
 }
 
-func (s *damageOverlayState) needsAnimationFrame() bool {
-	if len(s.flashes) == 0 {
+// drawLabel renders a text label at the top-left of the damage rect.
+// Skips silently if no font is set on the gg.Context.
+func (o *ggDamageOverlay) drawLabel(f *ggDamageFlash, x, y, fade float64) {
+	if o.ctx.Font() == nil {
+		return
+	}
+
+	label := formatLabel(f)
+	if label == "" {
+		return
+	}
+
+	tw, th := o.ctx.MeasureString(label)
+	if tw <= 0 || th <= 0 {
+		return
+	}
+
+	// Dark semi-transparent background box.
+	bgX := x + 2
+	bgY := y + 2
+	bgW := tw + labelPadH*2
+	bgH := th + labelPadV*2
+
+	o.ctx.SetRGBA(0, 0, 0, 0.6*fade)
+	o.ctx.DrawRectangle(bgX, bgY, bgW, bgH)
+	_ = o.ctx.Fill()
+
+	// White text.
+	o.ctx.SetRGBA(1, 1, 1, 0.9*fade)
+	o.ctx.DrawString(label, bgX+labelPadH, bgY+labelPadV+th*0.85)
+}
+
+// formatLabel builds a human-readable label for a damage flash.
+//
+// Format examples:
+//
+//	"g3d: camera rotation (1 rects, 360000px)"
+//	"g3d (full surface)"
+//	"gg (3 rects, 12000px)"
+func formatLabel(f *ggDamageFlash) string {
+	if f.full {
+		if f.reason.Detail != "" {
+			return fmt.Sprintf("%s: %s (full surface)", f.name, f.reason.Detail)
+		}
+		return fmt.Sprintf("%s (full surface)", f.name)
+	}
+
+	area := f.rect.Dx() * f.rect.Dy()
+	if f.reason.Detail != "" {
+		return fmt.Sprintf("%s: %s (1 rect, %dpx)", f.name, f.reason.Detail, area)
+	}
+	return fmt.Sprintf("%s (1 rect, %dpx)", f.name, area)
+}
+
+// updateFlashes prunes expired flashes, refreshes timestamps for still-active
+// rects, and adds new flashes from the current frame's source snapshots.
+// "Refresh-or-create" prevents duplicate overlapping flashes for the same
+// rect appearing across consecutive frames (Android SurfaceFlinger pattern).
+func (o *ggDamageOverlay) updateFlashes(sources []gpucontext.DamageSourceSnapshot) {
+	now := time.Now()
+
+	// Prune expired flashes.
+	alive := o.flashes[:0]
+	for _, f := range o.flashes {
+		if now.Sub(f.time) < ggDamageFlashDuration {
+			alive = append(alive, f)
+		}
+	}
+	o.flashes = alive
+
+	// Add or refresh flashes from current snapshots.
+	for _, snap := range sources {
+		if snap.Full {
+			o.refreshOrAdd(snap.Name, snap.Color, image.Rectangle{}, true, snap.Reason, now)
+			continue
+		}
+		for _, r := range snap.Rects {
+			if r.Empty() {
+				continue
+			}
+			o.refreshOrAdd(snap.Name, snap.Color, r, false, snap.Reason, now)
+		}
+	}
+}
+
+// refreshOrAdd refreshes an existing flash with matching name+rect, or
+// creates a new one. Prevents duplicate flashes for the same damage area
+// across consecutive frames.
+func (o *ggDamageOverlay) refreshOrAdd(name string, c color.RGBA, rect image.Rectangle, full bool, reason gpucontext.DamageReason, now time.Time) {
+	for i := range o.flashes {
+		f := &o.flashes[i]
+		if f.name == name && f.rect == rect && f.full == full {
+			f.time = now
+			f.reason = reason
+			return
+		}
+	}
+	o.flashes = append(o.flashes, ggDamageFlash{
+		name:   name,
+		color:  c,
+		rect:   rect,
+		full:   full,
+		reason: reason,
+		time:   now,
+	})
+}
+
+// needsAnimationFrame reports whether the overlay has active flashes that
+// require additional frames for the fade-out animation. Used by ggcanvas
+// to call RequestRedraw for the self-sustaining render loop (Chromium pattern).
+func (o *ggDamageOverlay) needsAnimationFrame() bool {
+	if len(o.flashes) == 0 {
 		return false
 	}
 	now := time.Now()
-	for _, f := range s.flashes {
-		if now.Sub(f.time) < damageFlashDuration {
+	for _, f := range o.flashes {
+		if now.Sub(f.time) < ggDamageFlashDuration {
 			return true
 		}
 	}

--- a/integration/ggcanvas/damage_debug_test.go
+++ b/integration/ggcanvas/damage_debug_test.go
@@ -1,135 +1,301 @@
 package ggcanvas
 
 import (
+	"fmt"
 	"image"
+	"image/color"
 	"testing"
 	"time"
+
+	"github.com/gogpu/gpucontext"
 )
 
-func TestDamageOverlay_RefreshSameRect(t *testing.T) {
-	var s damageOverlayState
+func TestGGDamageOverlay_RefreshSameRect(t *testing.T) {
+	o := &ggDamageOverlay{}
 
 	r := image.Rect(170, 410, 218, 458)
-	s.update([]image.Rectangle{r})
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{R: 0, G: 204, B: 0, A: 102}, Rects: []image.Rectangle{r}},
+	})
 
-	if len(s.flashes) != 1 {
-		t.Fatalf("first update: want 1 flash, got %d", len(s.flashes))
+	if len(o.flashes) != 1 {
+		t.Fatalf("first update: want 1 flash, got %d", len(o.flashes))
 	}
-	firstTime := s.flashes[0].time
+	firstTime := o.flashes[0].time
 
 	// Same rect again — should refresh time, NOT create new flash.
 	time.Sleep(time.Millisecond)
-	s.update([]image.Rectangle{r})
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{R: 0, G: 204, B: 0, A: 102}, Rects: []image.Rectangle{r}},
+	})
 
-	if len(s.flashes) != 1 {
-		t.Errorf("second update same rect: want 1 flash (refreshed), got %d", len(s.flashes))
+	if len(o.flashes) != 1 {
+		t.Errorf("second update same rect: want 1 flash (refreshed), got %d", len(o.flashes))
 	}
-	if !s.flashes[0].time.After(firstTime) {
+	if !o.flashes[0].time.After(firstTime) {
 		t.Error("flash time should be refreshed (newer than first)")
 	}
 }
 
-func TestDamageOverlay_DifferentRectsNotDeduped(t *testing.T) {
-	var s damageOverlayState
+func TestGGDamageOverlay_DifferentRectsNotDeduped(t *testing.T) {
+	o := &ggDamageOverlay{}
 
 	r1 := image.Rect(10, 10, 50, 50)
 	r2 := image.Rect(100, 100, 200, 200)
 
-	s.update([]image.Rectangle{r1})
-	s.update([]image.Rectangle{r2})
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{G: 204, A: 102}, Rects: []image.Rectangle{r1}},
+	})
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{G: 204, A: 102}, Rects: []image.Rectangle{r2}},
+	})
 
-	if len(s.flashes) != 2 {
-		t.Errorf("different rects: want 2 flashes, got %d", len(s.flashes))
+	if len(o.flashes) != 2 {
+		t.Errorf("different rects: want 2 flashes, got %d", len(o.flashes))
 	}
 }
 
-func TestDamageOverlay_ExpiredFlashAllowsNewForSameRect(t *testing.T) {
-	var s damageOverlayState
+func TestGGDamageOverlay_ExpiredFlashAllowsNewForSameRect(t *testing.T) {
+	o := &ggDamageOverlay{}
 
 	r := image.Rect(10, 10, 50, 50)
-	s.update([]image.Rectangle{r})
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{G: 204, A: 102}, Rects: []image.Rectangle{r}},
+	})
 
 	// Simulate flash expiry by backdating.
-	s.flashes[0].time = time.Now().Add(-damageFlashDuration - time.Millisecond)
+	o.flashes[0].time = time.Now().Add(-ggDamageFlashDuration - time.Millisecond)
 
 	// Update again — expired flash pruned, same rect should create new flash.
-	s.update([]image.Rectangle{r})
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{G: 204, A: 102}, Rects: []image.Rectangle{r}},
+	})
 
-	if len(s.flashes) != 1 {
-		t.Errorf("after expiry: want 1 new flash, got %d", len(s.flashes))
+	if len(o.flashes) != 1 {
+		t.Errorf("after expiry: want 1 new flash, got %d", len(o.flashes))
 	}
 
 	// New flash should have recent time.
-	if time.Since(s.flashes[0].time) > time.Second {
+	if time.Since(o.flashes[0].time) > time.Second {
 		t.Error("new flash time should be recent")
 	}
 }
 
-func TestDamageOverlay_NeedsAnimationFrameFalseAfterExpiry(t *testing.T) {
-	var s damageOverlayState
+func TestGGDamageOverlay_NeedsAnimationFrameFalseAfterExpiry(t *testing.T) {
+	o := &ggDamageOverlay{}
 
-	s.update([]image.Rectangle{image.Rect(10, 10, 50, 50)})
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{G: 204, A: 102}, Rects: []image.Rectangle{image.Rect(10, 10, 50, 50)}},
+	})
 
-	if !s.needsAnimationFrame() {
+	if !o.needsAnimationFrame() {
 		t.Error("should need frame during active flash")
 	}
 
 	// Expire all flashes.
-	s.flashes[0].time = time.Now().Add(-damageFlashDuration - time.Millisecond)
+	o.flashes[0].time = time.Now().Add(-ggDamageFlashDuration - time.Millisecond)
 
-	if s.needsAnimationFrame() {
+	if o.needsAnimationFrame() {
 		t.Error("should NOT need frame after all flashes expired")
 	}
 }
 
-func TestDamageOverlay_FeedbackLoopBroken(t *testing.T) {
+func TestGGDamageOverlay_FeedbackLoopBroken(t *testing.T) {
 	// Simulates the feedback loop scenario:
-	// Frame 1: TrackDamageRect(spinner) → update → flash
-	// Frames 2-10: TrackDamageRect(spinner) again → refresh time → 1 flash (not 10)
-	// Spinner stops → no more updates → flash expires → NeedsAnimationFrame=false
+	// Frame 1: source reports spinner rect → flash
+	// Frames 2-10: source reports same rect → refresh time → 1 flash (not 10)
+	// Spinner stops → no more updates → flash expires → needsAnimationFrame=false
 
-	var s damageOverlayState
+	o := &ggDamageOverlay{}
 	spinner := image.Rect(170, 410, 218, 458)
-
-	// Frame 1
-	s.update([]image.Rectangle{spinner})
-	if len(s.flashes) != 1 {
-		t.Fatalf("frame 1: want 1 flash, got %d", len(s.flashes))
+	snap := []gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{G: 204, A: 102}, Rects: []image.Rectangle{spinner}},
 	}
 
-	// Frames 2-10: same spinner rect every frame (TrackDamageRect from compositor)
+	// Frame 1
+	o.updateFlashes(snap)
+	if len(o.flashes) != 1 {
+		t.Fatalf("frame 1: want 1 flash, got %d", len(o.flashes))
+	}
+
+	// Frames 2-10: same spinner rect every frame
 	for i := 2; i <= 10; i++ {
-		s.update([]image.Rectangle{spinner})
+		o.updateFlashes(snap)
 	}
 
 	// Still only 1 flash (refreshed, not duplicated)
-	if len(s.flashes) != 1 {
-		t.Errorf("after 10 frames: want 1 flash (refreshed), got %d", len(s.flashes))
+	if len(o.flashes) != 1 {
+		t.Errorf("after 10 frames: want 1 flash (refreshed), got %d", len(o.flashes))
 	}
 
 	// While spinner animates, flash stays alive (time refreshed each frame).
-	// NeedsAnimationFrame=true — but this is correct, loop doesn't grow.
-	if !s.needsAnimationFrame() {
+	if !o.needsAnimationFrame() {
 		t.Error("during animation: should need frame (flash still active)")
 	}
 
 	// Spinner stops — no more updates. Flash expires after 400ms.
-	s.flashes[0].time = time.Now().Add(-damageFlashDuration - time.Millisecond)
+	o.flashes[0].time = time.Now().Add(-ggDamageFlashDuration - time.Millisecond)
 
-	if s.needsAnimationFrame() {
+	if o.needsAnimationFrame() {
 		t.Error("after spinner stopped + flash expired: loop should be broken")
 	}
 }
 
-func TestDamageOverlay_EmptyRectsIgnored(t *testing.T) {
-	var s damageOverlayState
+func TestGGDamageOverlay_EmptyRectsIgnored(t *testing.T) {
+	o := &ggDamageOverlay{}
 
-	s.update([]image.Rectangle{
-		{},
-		image.Rect(5, 5, 5, 5),
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{G: 204, A: 102}, Rects: []image.Rectangle{
+			{},
+			image.Rect(5, 5, 5, 5),
+		}},
 	})
 
-	if len(s.flashes) != 0 {
-		t.Errorf("empty rects should be ignored, got %d flashes", len(s.flashes))
+	if len(o.flashes) != 0 {
+		t.Errorf("empty rects should be ignored, got %d flashes", len(o.flashes))
 	}
+}
+
+func TestGGDamageOverlay_FullSurface(t *testing.T) {
+	o := &ggDamageOverlay{}
+
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "g3d", Color: color.RGBA{B: 204, A: 102}, Full: true},
+	})
+
+	if len(o.flashes) != 1 {
+		t.Fatalf("full surface: want 1 flash, got %d", len(o.flashes))
+	}
+	if !o.flashes[0].full {
+		t.Error("flash should be marked as full surface")
+	}
+	if o.flashes[0].rect != (image.Rectangle{}) {
+		t.Error("full surface flash rect should be zero")
+	}
+}
+
+func TestGGDamageOverlay_MultipleSourcesSameFrame(t *testing.T) {
+	o := &ggDamageOverlay{}
+
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{G: 204, A: 102}, Rects: []image.Rectangle{image.Rect(0, 0, 100, 100)}},
+		{Name: "g3d", Color: color.RGBA{B: 204, A: 102}, Full: true},
+	})
+
+	if len(o.flashes) != 2 {
+		t.Fatalf("two sources: want 2 flashes, got %d", len(o.flashes))
+	}
+	if o.flashes[0].name != "gg" {
+		t.Errorf("first flash: want name gg, got %s", o.flashes[0].name)
+	}
+	if o.flashes[1].name != "g3d" {
+		t.Errorf("second flash: want name g3d, got %s", o.flashes[1].name)
+	}
+}
+
+func TestFormatLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		flash ggDamageFlash
+		want  string
+	}{
+		{
+			name:  "full surface without reason",
+			flash: ggDamageFlash{name: "g3d", full: true},
+			want:  "g3d (full surface)",
+		},
+		{
+			name: "full surface with reason",
+			flash: ggDamageFlash{
+				name:   "g3d",
+				full:   true,
+				reason: gpucontext.DamageReason{Category: gpucontext.DamageCategoryAnimation, Detail: "camera rotation"},
+			},
+			want: "g3d: camera rotation (full surface)",
+		},
+		{
+			name: "partial without reason",
+			flash: ggDamageFlash{
+				name: "gg",
+				rect: image.Rect(0, 0, 100, 120),
+			},
+			want: "gg (1 rect, 12000px)",
+		},
+		{
+			name: "partial with reason",
+			flash: ggDamageFlash{
+				name:   "g3d",
+				rect:   image.Rect(0, 0, 600, 600),
+				reason: gpucontext.DamageReason{Category: gpucontext.DamageCategoryAnimation, Detail: "camera rotation"},
+			},
+			want: "g3d: camera rotation (1 rect, 360000px)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatLabel(&tt.flash)
+			if got != tt.want {
+				t.Errorf("formatLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGGDamageOverlay_ReasonPreserved(t *testing.T) {
+	o := &ggDamageOverlay{}
+	reason := gpucontext.DamageReason{
+		Category: gpucontext.DamageCategoryAnimation,
+		Detail:   "spinner tick",
+	}
+
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{
+			Name:   "ui",
+			Color:  color.RGBA{R: 255, G: 165, A: 102},
+			Rects:  []image.Rectangle{image.Rect(10, 10, 50, 50)},
+			Reason: reason,
+		},
+	})
+
+	if len(o.flashes) != 1 {
+		t.Fatalf("want 1 flash, got %d", len(o.flashes))
+	}
+	if o.flashes[0].reason != reason {
+		t.Errorf("reason not preserved: got %+v, want %+v", o.flashes[0].reason, reason)
+	}
+}
+
+func TestGGDamageOverlay_DifferentSourcesSameRect(t *testing.T) {
+	o := &ggDamageOverlay{}
+	r := image.Rect(0, 0, 100, 100)
+
+	o.updateFlashes([]gpucontext.DamageSourceSnapshot{
+		{Name: "gg", Color: color.RGBA{G: 204, A: 102}, Rects: []image.Rectangle{r}},
+		{Name: "g3d", Color: color.RGBA{B: 204, A: 102}, Rects: []image.Rectangle{r}},
+	})
+
+	// Different sources with same rect = 2 separate flashes.
+	if len(o.flashes) != 2 {
+		t.Errorf("different sources same rect: want 2 flashes, got %d", len(o.flashes))
+	}
+}
+
+func TestFormatLabel_ZeroRect(t *testing.T) {
+	f := &ggDamageFlash{name: "test", rect: image.Rectangle{}}
+	got := formatLabel(f)
+	want := "test (1 rect, 0px)"
+	if got != want {
+		t.Errorf("formatLabel zero rect = %q, want %q", got, want)
+	}
+}
+
+func TestGGDamageOverlay_InterfaceCompliance(t *testing.T) {
+	// Verify compile-time interface check works at test time too.
+	var r gpucontext.DamageOverlayRenderer = &ggDamageOverlay{}
+	if r == nil {
+		t.Error("should not be nil")
+	}
+	// Verify the method exists with correct signature.
+	_ = fmt.Sprintf("%T", r)
 }

--- a/text.go
+++ b/text.go
@@ -584,6 +584,15 @@ func (c *Context) drawStringCPU(s string, x, y float64) {
 	}
 
 	// Tier 2: Everything else → glyph outlines as paths (Strategy B, Vello pattern).
+	// Force AA for non-axis-aligned transforms — NoAAFiller produces garbled
+	// output on sheared/rotated paths (binary coverage assumes axis-aligned edges).
+	// Skia: computeAxisAlignmentForHText returns kNone for non-axis-aligned baseline.
+	if !c.antiAlias && (m.B != 0 || m.D != 0) {
+		c.antiAlias = true
+		c.drawStringAsOutlines(s, x, y)
+		c.antiAlias = false
+		return
+	}
 	c.drawStringAsOutlines(s, x, y)
 }
 
@@ -621,19 +630,22 @@ func (c *Context) drawStringScaled(s string, x, y float64, deviceSize float64) {
 // Uses GlyphMaskRasterizer.RasterizeAliased (NoAAFiller) to produce per-glyph R8
 // masks with only 0 or 255 values, then composites via draw.DrawMask.
 //
-// For rotation/skew, routes through drawStringAsOutlines with AA disabled so the
-// normal fill pipeline uses NoAAFiller for vector outlines.
+// For rotation/skew, routes through drawStringAsOutlines with AA forced ON.
+// Binary coverage (NoAAFiller) is incompatible with non-axis-aligned geometry —
+// sheared outlines produce garbled output. Skia's computeAxisAlignmentForHText
+// disables binary mode when the baseline is not axis-aligned (returns kNone).
 func (c *Context) drawStringCPUAliased(s string, x, y float64) {
 	m := c.matrix
 
-	// Non-trivial transforms: route through vector outlines with AA disabled.
-	// IsTranslationOnly = identity + translation.
-	// Uniform positive scale: B=0, D=0, A=E, A>0.
+	// Non-axis-aligned transforms: force AA for outline rendering.
+	// NoAAFiller produces garbled output on sheared/rotated paths because
+	// binary coverage assumes axis-aligned edges. All enterprise engines
+	// (Skia, Cairo) use AA for non-axis-aligned text outlines.
 	if !m.IsTranslationOnly() && !(m.B == 0 && m.D == 0 && m.A == m.E && m.A > 0) {
-		saved := c.paint.Antialias
-		c.paint.Antialias = false
+		savedAA := c.antiAlias
+		c.antiAlias = true
 		c.drawStringAsOutlines(s, x, y)
-		c.paint.Antialias = saved
+		c.antiAlias = savedAA
 		return
 	}
 

--- a/text/draw.go
+++ b/text/draw.go
@@ -167,6 +167,15 @@ func hintedOrRawAdvance(ttCache *ttHintCache, glyph Glyph, ppem float64) float64
 //  2. Auto-hinter on the gvar-varied outline
 //  3. Grid-fit fallback
 //
+// Advance priority (FreeType ttgload.c:964-977):
+//
+//	HVAR present → use HVAR advance (fractional, matches Face.Advance)
+//	HVAR absent  → use outline.Advance (TT-hinted phantom points)
+//
+// TT bytecode hinting grid-fits phantom points to integer pixels, but HVAR
+// provides the authoritative variable-font advance. Using TT-hinted phantom
+// advances causes measurement/rendering mismatch (#405).
+//
 // The mode parameter selects coverage computation (Skia pattern: outline source
 // and rasterization mode are orthogonal — variable fonts don't affect AA choice).
 func drawGlyphsVariable(
@@ -190,6 +199,11 @@ func drawGlyphsVariable(
 	src := image.NewUniform(col)
 	extractor := &OutlineExtractor{}
 
+	// HVAR takes priority over TT-hinted phantom advances for positioning.
+	// FreeType ttgload.c:964-977: when HVAR present and hinting active,
+	// discard TT-hinted phantoms and use HVAR-adjusted advance instead.
+	varProv, _ := parsed.(VariableAdvanceProvider)
+
 	advanceX := 0.0
 	for _, r := range text {
 		if r < 0x20 && r != '\t' {
@@ -198,12 +212,7 @@ func drawGlyphsVariable(
 
 		gid := GlyphID(parsed.GlyphIndex(r))
 		if gid == 0 {
-			// Use variable-aware advance for skipped glyphs.
-			if vap, vapOK := parsed.(VariableAdvanceProvider); vapOK {
-				advanceX += vap.GlyphAdvanceVar(uint16(gid), ppem, variations)
-			} else {
-				advanceX += parsed.GlyphAdvance(uint16(gid), ppem)
-			}
+			advanceX += varOrRawAdvance(varProv, parsed, uint16(gid), ppem, variations)
 			continue
 		}
 
@@ -219,9 +228,7 @@ func drawGlyphsVariable(
 		// ExtractOutlineHintedVar applies gvar deltas THEN hinting in one pass.
 		outline, _ := extractor.ExtractOutlineHintedVar(parsed, gid, ppem, hinting, variations)
 		if outline == nil || outline.IsEmpty() {
-			if outline != nil {
-				advanceX += float64(outline.Advance)
-			}
+			advanceX += varOrRawAdvance(varProv, parsed, uint16(gid), ppem, variations)
 			continue
 		}
 
@@ -234,7 +241,7 @@ func drawGlyphsVariable(
 			result, rErr = rast.RasterizeOutline(outline, subpixelX, subpixelY)
 		}
 		if rErr != nil || result == nil {
-			advanceX += float64(outline.Advance)
+			advanceX += varOrRawAdvance(varProv, parsed, uint16(gid), ppem, variations)
 			continue
 		}
 
@@ -250,8 +257,16 @@ func drawGlyphsVariable(
 		destRect := image.Rect(dstX, dstY, dstX+result.Width, dstY+result.Height)
 		draw.DrawMask(dst, destRect, src, image.Point{}, maskImg, image.Point{}, draw.Over)
 
-		advanceX += float64(outline.Advance)
+		advanceX += varOrRawAdvance(varProv, parsed, uint16(gid), ppem, variations)
 	}
+}
+
+// varOrRawAdvance returns the HVAR advance when available, raw hmtx otherwise.
+func varOrRawAdvance(varProv VariableAdvanceProvider, parsed ParsedFont, gid uint16, ppem float64, variations []FontVariation) float64 {
+	if varProv != nil {
+		return varProv.GlyphAdvanceVar(gid, ppem, variations)
+	}
+	return parsed.GlyphAdvance(gid, ppem)
 }
 
 // rasterizeHintedGlyph rasterizes a glyph with 256-level analytic AA coverage.
@@ -363,42 +378,21 @@ func drawFilteredFace(dst draw.Image, text string, ff *FilteredFace, x, y float6
 	}
 }
 
-// faceGlyphAdvance returns the advance width for a single-rune string,
-// using TT hinted advances when available. This is used by drawMultiFace
-// and drawFilteredFace which render one rune at a time and need consistent
-// cursor advancement matching the hinted glyph outlines.
+// faceGlyphAdvance returns the advance width for a single-rune string.
+// Uses advanceResolver (HVAR for variable, TT-hinted for static, raw otherwise).
+// This is used by drawMultiFace and drawFilteredFace which render one rune
+// at a time and need consistent cursor advancement matching Face.Advance().
 func faceGlyphAdvance(face Face, runeStr string) float64 {
 	sf, ok := face.(*sourceFace)
 	if !ok {
 		return unhintedGlyphAdvance(face, runeStr)
 	}
 
-	cache := loadFaceTTCache(sf)
-	if cache == nil {
-		return unhintedGlyphAdvance(face, runeStr)
-	}
-
-	ppem := sf.size
+	ar := newAdvanceResolver(sf)
 	for glyph := range sf.Glyphs(runeStr) {
-		if adv, hintOK := cache.hintedAdvanceWidth(uint16(glyph.GID), int32(ppem)); hintOK {
-			return adv
-		}
-		return glyph.Advance
+		return ar.advance(uint16(glyph.GID))
 	}
 	return 0
-}
-
-// loadFaceTTCache returns the TT hint cache for a sourceFace, or nil if
-// TT bytecode hinting is unavailable or disabled.
-func loadFaceTTCache(sf *sourceFace) *ttHintCache {
-	if sf.config.hinting == HintingNone {
-		return nil
-	}
-	ownFont, ok := sf.source.Parsed().(*ownParsedFont)
-	if !ok {
-		return nil
-	}
-	return ownFont.loadTTHintCache()
 }
 
 // unhintedGlyphAdvance returns the advance from the Glyphs iterator (unhinted).

--- a/text/draw_test.go
+++ b/text/draw_test.go
@@ -412,6 +412,353 @@ func TestMeasureFilteredFace(t *testing.T) {
 	}
 }
 
+// findNotoSansSCVar returns the path to NotoSansSC variable font for testing.
+func findNotoSansSCVar() string {
+	paths := []string{
+		"../tmp/tsl0922_fonts/NotoSansSC-VariableFont_wght.ttf",
+		"tmp/tsl0922_fonts/NotoSansSC-VariableFont_wght.ttf",
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// TestVarOrRawAdvance verifies the helper uses HVAR when available,
+// raw hmtx otherwise.
+func TestVarOrRawAdvance(t *testing.T) {
+	fontPath := findNotoSansSCVar()
+	if fontPath == "" {
+		fontPath = findVariableFontForTest(t)
+	}
+	if fontPath == "" {
+		t.Skip("No variable font with HVAR available")
+	}
+
+	source, err := NewFontSourceFromFile(fontPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = source.Close() }()
+
+	parsed := source.Parsed()
+	varProv, ok := parsed.(VariableAdvanceProvider)
+	if !ok {
+		t.Skip("font does not implement VariableAdvanceProvider")
+	}
+
+	axes := source.VariationAxes()
+	var wghtMax float32
+	for _, ax := range axes {
+		if ax.Tag == [4]byte{'w', 'g', 'h', 't'} {
+			wghtMax = ax.Maximum
+			break
+		}
+	}
+	if wghtMax == 0 {
+		t.Skip("font has no wght axis")
+	}
+
+	variations := []FontVariation{NewFontVariation("wght", wghtMax)}
+	gid := parsed.GlyphIndex('H')
+	if gid == 0 {
+		gid = parsed.GlyphIndex('A')
+	}
+	ppem := 14.0
+
+	// With HVAR provider: should return HVAR advance.
+	hvarAdv := varOrRawAdvance(varProv, parsed, gid, ppem, variations)
+	expectedHVAR := varProv.GlyphAdvanceVar(gid, ppem, variations)
+	if hvarAdv != expectedHVAR {
+		t.Errorf("with varProv: got %.4f, want %.4f", hvarAdv, expectedHVAR)
+	}
+
+	// Without HVAR provider: should return raw hmtx advance.
+	rawAdv := varOrRawAdvance(nil, parsed, gid, ppem, variations)
+	expectedRaw := parsed.GlyphAdvance(gid, ppem)
+	if rawAdv != expectedRaw {
+		t.Errorf("without varProv: got %.4f, want %.4f", rawAdv, expectedRaw)
+	}
+
+	t.Logf("gid=%d: HVAR=%.4f, raw=%.4f", gid, hvarAdv, rawAdv)
+}
+
+// TestDrawGlyphsVariable_UsesHVARAdvance_405 verifies that drawGlyphsVariable
+// uses HVAR advances for positioning, matching Face.Advance(). This is the fix
+// for #405: TT-hinted phantom advances (integer-rounded) diverged from HVAR
+// advances (fractional) causing measurement/rendering mismatch.
+//
+// FreeType ttgload.c:964-977: when HVAR present, discard TT-hinted phantom
+// advances and use HVAR-scaled advance instead.
+func TestDrawGlyphsVariable_UsesHVARAdvance_405(t *testing.T) {
+	fontPath := findNotoSansSCVar()
+	if fontPath == "" {
+		fontPath = findVariableFontForTest(t)
+	}
+	if fontPath == "" {
+		t.Skip("No variable font available")
+	}
+
+	source, err := NewFontSourceFromFile(fontPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = source.Close() }()
+
+	axes := source.VariationAxes()
+	var wghtMax float32
+	for _, ax := range axes {
+		if ax.Tag == [4]byte{'w', 'g', 'h', 't'} {
+			wghtMax = ax.Maximum
+			break
+		}
+	}
+	if wghtMax == 0 {
+		t.Skip("font has no wght axis")
+	}
+
+	variations := []FontVariation{NewFontVariation("wght", wghtMax)}
+
+	tests := []struct {
+		name string
+		text string
+		size float64
+	}{
+		{"Hello_14px", "Hello", 14},
+		{"Hello_22px", "Hello", 22},
+		{"Abcdef_14px", "abcdef", 14},
+		{"Test_36px", "Test", 36},
+	}
+
+	// Add CJK tests only when using NotoSansSC.
+	if findNotoSansSCVar() != "" {
+		tests = append(tests,
+			struct {
+				name, text string
+				size       float64
+			}{"Chinese_14px", "你好世界", 14},
+			struct {
+				name, text string
+				size       float64
+			}{"Chinese_22px", "你好世界", 22},
+		)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			face := source.Face(tc.size, WithVariations(variations...))
+
+			faceAdv := face.Advance(tc.text)
+			if faceAdv <= 0 {
+				t.Fatalf("Face.Advance(%q) = %.4f — should be positive", tc.text, faceAdv)
+			}
+
+			// Render to an image and measure actual ink extent.
+			// If rendering uses a different advance than Face.Advance, the last
+			// glyph will be positioned at the wrong X.
+			dst := image.NewRGBA(image.Rect(0, 0, 500, 100))
+			startX := 50.0
+			Draw(dst, tc.text, face, startX, 60, color.Black)
+
+			// Find rightmost ink pixel.
+			rightmostInk := 0
+			for x := 499; x >= 0; x-- {
+				for y := 0; y < 100; y++ {
+					_, _, _, a := dst.At(x, y).RGBA()
+					if a > 0 {
+						rightmostInk = x
+						goto found
+					}
+				}
+			}
+		found:
+
+			// The rightmost ink should be near startX + faceAdv.
+			// Allow tolerance for glyph overshoot (typically ≤3px at these sizes).
+			renderedWidth := float64(rightmostInk) - startX
+			diff := renderedWidth - faceAdv
+			if diff < 0 {
+				diff = -diff
+			}
+
+			t.Logf("%s: Face.Advance=%.2f, rendered ink width=%.1f, diff=%.1f",
+				tc.name, faceAdv, renderedWidth, diff)
+
+			// Before fix: diff was 1-4px due to integer phantom advance.
+			// After fix: diff should be <3px (glyph overshoot only).
+			if diff > 5 {
+				t.Errorf("measurement/rendering mismatch: Face.Advance=%.2f, rendered=%.1f (diff=%.1f > 5px)",
+					faceAdv, renderedWidth, diff)
+			}
+		})
+	}
+}
+
+// TestFaceGlyphAdvance_UsesAdvanceResolver verifies that faceGlyphAdvance
+// (used by drawMultiFace) returns the same advance as Face.Advance for
+// both static and variable fonts.
+func TestFaceGlyphAdvance_UsesAdvanceResolver(t *testing.T) {
+	fontPath := testFontPath(t)
+
+	source, err := NewFontSourceFromFile(fontPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(14.0)
+	sf := face.(*sourceFace)
+
+	for _, r := range "Hello" {
+		runeStr := string(r)
+		fga := faceGlyphAdvance(sf, runeStr)
+		faceAdv := sf.Advance(runeStr)
+
+		if fga != faceAdv {
+			t.Errorf("faceGlyphAdvance(%q)=%.4f != Face.Advance(%q)=%.4f",
+				runeStr, fga, runeStr, faceAdv)
+		}
+	}
+}
+
+// TestFaceGlyphAdvance_VariableFont_UsesHVAR verifies that faceGlyphAdvance
+// returns HVAR advance for variable fonts, not TT-hinted phantom advance.
+func TestFaceGlyphAdvance_VariableFont_UsesHVAR(t *testing.T) {
+	fontPath := findNotoSansSCVar()
+	if fontPath == "" {
+		fontPath = findVariableFontForTest(t)
+	}
+	if fontPath == "" {
+		t.Skip("No variable font available")
+	}
+
+	source, err := NewFontSourceFromFile(fontPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = source.Close() }()
+
+	axes := source.VariationAxes()
+	var wghtMax float32
+	for _, ax := range axes {
+		if ax.Tag == [4]byte{'w', 'g', 'h', 't'} {
+			wghtMax = ax.Maximum
+			break
+		}
+	}
+	if wghtMax == 0 {
+		t.Skip("font has no wght axis")
+	}
+
+	variations := []FontVariation{NewFontVariation("wght", wghtMax)}
+	face := source.Face(14.0, WithVariations(variations...))
+	sf := face.(*sourceFace)
+
+	parsed := source.Parsed()
+	varProv, ok := parsed.(VariableAdvanceProvider)
+	if !ok {
+		t.Skip("font does not implement VariableAdvanceProvider")
+	}
+
+	for _, r := range "Helo" {
+		gid := parsed.GlyphIndex(r)
+		if gid == 0 {
+			continue
+		}
+		runeStr := string(r)
+		fga := faceGlyphAdvance(sf, runeStr)
+		faceAdv := sf.Advance(runeStr)
+
+		if fga != faceAdv {
+			t.Errorf("faceGlyphAdvance(%q)=%.4f != Face.Advance(%q)=%.4f — advance source mismatch",
+				runeStr, fga, runeStr, faceAdv)
+		}
+
+		hvarAdv := varProv.GlyphAdvanceVar(gid, 14.0, variations)
+		if fga != hvarAdv {
+			t.Errorf("faceGlyphAdvance(%q)=%.4f != HVAR=%.4f — not using HVAR for variable font",
+				runeStr, fga, hvarAdv)
+		}
+	}
+}
+
+// TestDrawVariable_MeasureRenderConsistency_405 is the definitive regression
+// test for #405. It verifies the invariant that the total advance used during
+// rendering matches Face.Advance() — so MeasureString-based positioning works.
+func TestDrawVariable_MeasureRenderConsistency_405(t *testing.T) {
+	fontPath := findNotoSansSCVar()
+	if fontPath == "" {
+		fontPath = findVariableFontForTest(t)
+	}
+	if fontPath == "" {
+		t.Skip("No variable font available")
+	}
+
+	source, err := NewFontSourceFromFile(fontPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = source.Close() }()
+
+	parsed := source.Parsed()
+	varProv, ok := parsed.(VariableAdvanceProvider)
+	if !ok {
+		t.Skip("font does not implement VariableAdvanceProvider")
+	}
+
+	axes := source.VariationAxes()
+	var wghtMax float32
+	for _, ax := range axes {
+		if ax.Tag == [4]byte{'w', 'g', 'h', 't'} {
+			wghtMax = ax.Maximum
+			break
+		}
+	}
+	if wghtMax == 0 {
+		t.Skip("font has no wght axis")
+	}
+
+	variations := []FontVariation{NewFontVariation("wght", wghtMax)}
+
+	testCases := []struct {
+		size float64
+		text string
+	}{
+		{14, "Hello"},
+		{14, "rl"},
+		{22, "Hello"},
+		{36, "Test"},
+	}
+	if findNotoSansSCVar() != "" {
+		testCases = append(testCases, struct {
+			size float64
+			text string
+		}{22, "你好世界"})
+	}
+
+	for _, tc := range testCases {
+		face := source.Face(tc.size, WithVariations(variations...))
+		faceAdv := face.Advance(tc.text)
+
+		// Compute the advance that drawGlyphsVariable would use per-glyph.
+		renderAdv := 0.0
+		for _, r := range tc.text {
+			if r < 0x20 && r != '\t' {
+				continue
+			}
+			gid := parsed.GlyphIndex(r)
+			renderAdv += varOrRawAdvance(varProv, parsed, gid, tc.size, variations)
+		}
+
+		if faceAdv != renderAdv {
+			t.Errorf("size=%.0f %q: Face.Advance=%.4f != render advance=%.4f (diff=%.4f)",
+				tc.size, tc.text, faceAdv, renderAdv, faceAdv-renderAdv)
+		}
+	}
+}
+
 func BenchmarkDraw(b *testing.B) {
 	// Try to get a font, skip if not available
 	candidates := []string{

--- a/text_transform_test.go
+++ b/text_transform_test.go
@@ -852,3 +852,147 @@ func TestTextTransformGolden(t *testing.T) {
 		// They use a 300x200 canvas, so we just check non-zero (already done in sub-tests).
 	})
 }
+
+// --------------------------------------------------------------------------
+// Shear + Aliased: force-AA for non-axis-aligned outlines (Skia pattern)
+// --------------------------------------------------------------------------
+
+// TestShearAliased_ForceAA_ProducesReadableText verifies that aliased text
+// with shear is readable (not garbled). NoAAFiller produces broken output on
+// sheared outlines — the fix forces AA for non-axis-aligned text paths.
+//
+// Skia: computeAxisAlignmentForHText returns kNone when baseline is not
+// axis-aligned, disabling binary coverage mode.
+func TestShearAliased_ForceAA_ProducesReadableText(t *testing.T) {
+	dc, source := setupTextContext(t, 400, 100, 24)
+	defer func() { _ = source.Close() }()
+
+	dc.SetAntiAlias(false)
+	dc.SetTextMode(TextModeAliased)
+
+	dc.Push()
+	dc.Shear(-0.3, 0)
+	dc.DrawString("Hello World", 30, 60)
+	dc.Pop()
+
+	pixels := countNonWhitePixels(dc, 0, 0, 400, 100)
+	if pixels == 0 {
+		t.Fatal("Shear+aliased text produced no pixels")
+	}
+
+	// Verify text is readable: count distinct ink runs at mid-height.
+	// "Hello World" = 10 visible chars → expect ≥5 ink runs.
+	// Garbled text collapses into 1-3 blobs.
+	midY := 45
+	inkRuns := countInkRuns(dc, midY, 0, 400)
+	t.Logf("ink runs at y=%d: %d, total pixels: %d", midY, inkRuns, pixels)
+	if inkRuns < 4 {
+		t.Errorf("only %d ink runs at y=%d — text is garbled (expected ≥4 for 'Hello World')", inkRuns, midY)
+	}
+}
+
+// TestShearAliased_MatchesShearAA verifies that aliased+shear and AA+shear
+// produce similar pixel count (both route through drawStringAsOutlines with AA).
+func TestShearAliased_MatchesShearAA(t *testing.T) {
+	fontPath := findSystemFont(t)
+	if fontPath == "" {
+		t.Skip("No system font available")
+	}
+
+	source, err := text.NewFontSourceFromFile(fontPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = source.Close() }()
+
+	render := func(aliased bool) int {
+		dc := NewContext(400, 100)
+		dc.SetFont(source.Face(24))
+		dc.SetRGB(0, 0, 0)
+		dc.ClearWithColor(White)
+		if aliased {
+			dc.SetAntiAlias(false)
+			dc.SetTextMode(TextModeAliased)
+		}
+		dc.Push()
+		dc.Shear(-0.3, 0)
+		dc.DrawString("Test123", 30, 60)
+		dc.Pop()
+		return countNonWhitePixels(dc, 0, 0, 400, 100)
+	}
+
+	aaPixels := render(false)
+	aliasedPixels := render(true)
+
+	if aaPixels == 0 || aliasedPixels == 0 {
+		t.Fatalf("no pixels: AA=%d, aliased=%d", aaPixels, aliasedPixels)
+	}
+
+	// Both should produce similar pixel counts since both force AA for shear.
+	// Allow 50% tolerance for AA edge differences.
+	ratio := float64(aliasedPixels) / float64(aaPixels)
+	t.Logf("AA pixels=%d, aliased pixels=%d, ratio=%.2f", aaPixels, aliasedPixels, ratio)
+	if ratio < 0.5 || ratio > 2.0 {
+		t.Errorf("aliased/AA pixel ratio %.2f outside [0.5, 2.0] — force-AA not working", ratio)
+	}
+}
+
+// TestShearAliased_NoShear_StillBinary verifies that aliased text WITHOUT
+// shear still uses binary (NoAAFiller) rendering — the force-AA only applies
+// to non-axis-aligned transforms.
+func TestShearAliased_NoShear_StillBinary(t *testing.T) {
+	fontPath := findSystemFont(t)
+	if fontPath == "" {
+		t.Skip("No system font available")
+	}
+
+	source, err := text.NewFontSourceFromFile(fontPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = source.Close() }()
+
+	dc := NewContext(200, 60)
+	dc.SetFont(source.Face(20))
+	dc.SetRGB(0, 0, 0)
+	dc.ClearWithColor(White)
+	dc.SetAntiAlias(false)
+	dc.SetTextMode(TextModeAliased)
+	dc.DrawString("Hi", 10, 40)
+
+	// Aliased text should have only 0 or 255 alpha values (binary coverage).
+	// Scan for intermediate values — there should be none.
+	hasGray := false
+	for y := 0; y < 60; y++ {
+		for x := 0; x < 200; x++ {
+			p := dc.pixmap.GetPixel(x, y)
+			r := pixelByte(p.R)
+			if r > 5 && r < 250 {
+				hasGray = true
+				break
+			}
+		}
+		if hasGray {
+			break
+		}
+	}
+	if hasGray {
+		t.Error("aliased text without shear has gray pixels — should be binary coverage only")
+	}
+}
+
+// countInkRuns counts the number of distinct ink runs (non-white segments)
+// along a horizontal scanline.
+func countInkRuns(dc *Context, y, xStart, xEnd int) int {
+	runs := 0
+	inInk := false
+	for x := xStart; x < xEnd && x < dc.width; x++ {
+		p := dc.pixmap.GetPixel(x, y)
+		isInk := pixelByte(p.R) < 200
+		if isInk && !inInk {
+			runs++
+		}
+		inInk = isInk
+	}
+	return runs
+}


### PR DESCRIPTION
## Summary

Two fixes for the variable font regression reported by @tsl0922 in #405.

**1. Variable font advance mismatch** — `drawGlyphsVariable` used TT-hinted phantom advances (integer-rounded, e.g. 36.0) for glyph positioning, while `Face.Advance()` / `MeasureString()` used HVAR advances (fractional, e.g. 36.18). This caused text positioned via MeasureString to overlap. Now uses HVAR advances via `varOrRawAdvance()`, matching FreeType `ttgload.c:964-977`: when HVAR is present, discard TT-hinted phantom advances. Also fixed `faceGlyphAdvance()` (used by MultiFace/FilteredFace paths) to use `advanceResolver` for consistent advances.

**2. Shear/rotation aliased text garbling** — `drawStringCPUAliased` and `drawStringCPU` routed sheared text through `drawStringAsOutlines` with NoAAFiller (binary coverage). NoAAFiller produces garbled output on non-axis-aligned paths because binary coverage assumes axis-aligned edges. Now forces anti-aliased coverage for non-axis-aligned outlines, matching Skia's `computeAxisAlignmentForHText` pattern where binary coverage is only used for axis-aligned text.

## Test plan

- [x] `TestVarOrRawAdvance` — HVAR vs raw advance helper
- [x] `TestDrawGlyphsVariable_UsesHVARAdvance_405` — rendered ink matches Face.Advance
- [x] `TestFaceGlyphAdvance_UsesAdvanceResolver` — static font consistency
- [x] `TestFaceGlyphAdvance_VariableFont_UsesHVAR` — variable font uses HVAR, not TT phantom
- [x] `TestDrawVariable_MeasureRenderConsistency_405` — per-glyph HVAR sum == Face.Advance total
- [x] `TestShearAliased_ForceAA_ProducesReadableText` — ink run count validates readable text
- [x] `TestShearAliased_MatchesShearAA` — aliased+shear pixel count matches AA+shear (ratio=1.00)
- [x] `TestShearAliased_NoShear_StillBinary` — aliased without shear stays binary coverage (no regression)
