### PR TITLE
fix: synchronize global text cache replacement

### DIFF
--- a/text/glyph_cache.go
+++ b/text/glyph_cache.go
@@ -483,20 +483,24 @@ func (p *GlyphCachePool) Put(c *GlyphCache) {
 }
 
 // globalGlyphCache is the default shared glyph cache.
-var globalGlyphCache = NewGlyphCache()
+var globalGlyphCache atomic.Pointer[GlyphCache]
+
+func init() {
+	globalGlyphCache.Store(NewGlyphCache())
+}
 
 // GetGlobalGlyphCache returns the global shared glyph cache.
+// It is safe to call concurrently with SetGlobalGlyphCache.
 func GetGlobalGlyphCache() *GlyphCache {
-	return globalGlyphCache
+	return globalGlyphCache.Load()
 }
 
 // SetGlobalGlyphCache replaces the global glyph cache.
 // The old cache is returned for cleanup if needed.
+// It is safe for concurrent use.
 func SetGlobalGlyphCache(cache *GlyphCache) *GlyphCache {
 	if cache == nil {
 		cache = NewGlyphCache()
 	}
-	old := globalGlyphCache
-	globalGlyphCache = cache
-	return old
+	return globalGlyphCache.Swap(cache)
 }

--- a/text/glyph_cache_test.go
+++ b/text/glyph_cache_test.go
@@ -544,6 +544,44 @@ func TestSetGlobalGlyphCache_Nil(t *testing.T) {
 	}
 }
 
+func TestGlobalGlyphCacheConcurrentAccess(t *testing.T) {
+	original := GetGlobalGlyphCache()
+	t.Cleanup(func() {
+		_ = SetGlobalGlyphCache(original)
+	})
+
+	caches := []*GlyphCache{NewGlyphCache(), NewGlyphCache()}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 1000; j++ {
+				_ = SetGlobalGlyphCache(caches[(offset+j)%len(caches)])
+			}
+		}(i)
+	}
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 1000; j++ {
+				if GetGlobalGlyphCache() == nil {
+					t.Error("GetGlobalGlyphCache returned nil")
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}
+
 func TestOutlineCacheKey_Uniqueness(t *testing.T) {
 	cache := NewGlyphCache()
 

--- a/text/subpixel.go
+++ b/text/subpixel.go
@@ -3,6 +3,7 @@ package text
 
 import (
 	"sync"
+	"sync/atomic"
 )
 
 // SubpixelMode controls subpixel text positioning.
@@ -415,20 +416,24 @@ func MakeSubpixelKey(baseKey OutlineCacheKey, x, y float64, config SubpixelConfi
 }
 
 // globalSubpixelCache is the default shared subpixel cache.
-var globalSubpixelCache = NewSubpixelCache(DefaultSubpixelConfig())
+var globalSubpixelCache atomic.Pointer[SubpixelCache]
+
+func init() {
+	globalSubpixelCache.Store(NewSubpixelCache(DefaultSubpixelConfig()))
+}
 
 // GetGlobalSubpixelCache returns the global shared subpixel cache.
+// It is safe to call concurrently with SetGlobalSubpixelCache.
 func GetGlobalSubpixelCache() *SubpixelCache {
-	return globalSubpixelCache
+	return globalSubpixelCache.Load()
 }
 
 // SetGlobalSubpixelCache replaces the global subpixel cache.
 // The old cache is returned for cleanup if needed.
+// It is safe for concurrent use.
 func SetGlobalSubpixelCache(cache *SubpixelCache) *SubpixelCache {
 	if cache == nil {
 		cache = NewSubpixelCache(DefaultSubpixelConfig())
 	}
-	old := globalSubpixelCache
-	globalSubpixelCache = cache
-	return old
+	return globalSubpixelCache.Swap(cache)
 }

--- a/text/subpixel_test.go
+++ b/text/subpixel_test.go
@@ -696,6 +696,47 @@ func TestSetGlobalSubpixelCache_Nil(t *testing.T) {
 	}
 }
 
+func TestGlobalSubpixelCacheConcurrentAccess(t *testing.T) {
+	original := GetGlobalSubpixelCache()
+	t.Cleanup(func() {
+		_ = SetGlobalSubpixelCache(original)
+	})
+
+	caches := []*SubpixelCache{
+		NewSubpixelCache(DefaultSubpixelConfig()),
+		NewSubpixelCache(HighQualitySubpixelConfig()),
+	}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 1000; j++ {
+				_ = SetGlobalSubpixelCache(caches[(offset+j)%len(caches)])
+			}
+		}(i)
+	}
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 1000; j++ {
+				if GetGlobalSubpixelCache() == nil {
+					t.Error("GetGlobalSubpixelCache returned nil")
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}
+
 func TestSubpixelCache_Concurrent(t *testing.T) {
 	cache := NewSubpixelCache(DefaultSubpixelConfig())
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Summary

- publish the global glyph and subpixel cache pointers atomically
- preserve the existing nil-replacement and old-cache return behavior
- add concurrent getter/setter regression coverage for both caches

## Root cause

`GetGlobalGlyphCache` / `SetGlobalGlyphCache` and their subpixel equivalents read and wrote package-level pointers without synchronization. Concurrent cache replacement therefore triggered data races even though each cache's internal operations are concurrency-safe.

This addresses **BUG-RACE-001** in #365 without closing the broader audit issue.

## Validation

- `go test -race ./text -count=1`
- focused concurrent cache stress tests with `-count=100`
- `go vet ./text`
- `go test -race ./... -run '^$'` (compile-only)
- `gofmt` and `git diff --check`
- GitHub Actions CI: all build, race-test, GPU golden, lint, formatting, and dependency jobs pass
- Codecov patch coverage: 100.00% (target 78.40%)
