### PR TITLE
fix(ggcanvas): reuse canvases and track window size

### DIFF
--- a/integration/ggcanvas/cache.go
+++ b/integration/ggcanvas/cache.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package ggcanvas
+
+import (
+	"math"
+	"reflect"
+	"sync"
+
+	"github.com/gogpu/gpucontext"
+)
+
+// canvasCacheKey identifies the resources and logical geometry owned by a
+// Canvas.  DeviceProvider values returned by gogpu.App are short-lived
+// adapters, so the provider interface itself cannot be used as the identity.
+// The opaque GPU handles, on the other hand, refer to the long-lived device,
+// queue, and adapter and are comparable value types.
+type canvasCacheKey struct {
+	device  gpucontext.Device
+	queue   gpucontext.Queue
+	adapter gpucontext.Adapter
+
+	// providerType/providerPtr are used only when all GPU handles are zero.
+	// This keeps independent zero-device test providers from aliasing one
+	// another while still allowing repeated calls with the same pointer mock to
+	// reuse a Canvas.
+	providerType reflect.Type
+	providerPtr  uintptr
+
+	width  int
+	height int
+	scale  float64
+}
+
+var canvasCache = struct {
+	sync.Mutex
+	entries map[canvasCacheKey]*Canvas
+}{
+	entries: make(map[canvasCacheKey]*Canvas),
+}
+
+// normalizeScale is shared by the cache and Canvas construction.  NaN is not
+// a useful device scale and cannot be matched as a map key, so treat it like
+// the existing non-positive fallback.  Infinite values are likewise rejected
+// here before they can produce an invalid physical allocation.
+func normalizeScale(scale float64) float64 {
+	if scale <= 0 || math.IsNaN(scale) || math.IsInf(scale, 0) {
+		return 1.0
+	}
+	return scale
+}
+
+func cacheKeyFor(provider gpucontext.DeviceProvider, width, height int, scale float64) (canvasCacheKey, bool) {
+	key := canvasCacheKey{
+		width:  width,
+		height: height,
+		scale:  normalizeScale(scale),
+	}
+	if provider == nil {
+		return key, false
+	}
+
+	key.device = provider.Device()
+	key.queue = provider.Queue()
+	key.adapter = provider.Adapter()
+	if !key.device.IsNil() || !key.queue.IsNil() || !key.adapter.IsNil() {
+		return key, true
+	}
+
+	// A zero-handle provider is common in CPU-only and unit-test setups.  Do
+	// not collapse every such provider into one global Canvas.  Pointer-backed
+	// providers have stable identity for the lifetime of the Canvas; value
+	// providers have no portable identity, so conservatively disable caching.
+	v := reflect.ValueOf(provider)
+	if v.Kind() != reflect.Pointer || v.IsNil() {
+		return key, false
+	}
+	key.providerType = v.Type()
+	key.providerPtr = v.Pointer()
+	return key, key.providerPtr != 0
+}
+
+func (c *Canvas) cacheKeyFor(width, height int, scale float64) (canvasCacheKey, bool) {
+	return cacheKeyFor(c.provider, width, height, scale)
+}
+
+// lookupCachedCanvas returns a live Canvas for key, updating its window
+// provider to the latest adapter wrapper. Cache and lifecycle locks are never
+// held together: Close takes lifecycle then cache, while this helper releases
+// cache before taking lifecycle. A candidate that closes in that interval is
+// discarded and looked up again.
+func lookupCachedCanvas(provider gpucontext.DeviceProvider, key canvasCacheKey) (*Canvas, bool) {
+	for {
+		canvasCache.Lock()
+		cached := canvasCache.entries[key]
+		if cached == nil {
+			canvasCache.Unlock()
+			return nil, false
+		}
+		canvasCache.Unlock()
+
+		cached.lifecycleMu.Lock()
+		if cached.closed {
+			cached.lifecycleMu.Unlock()
+			canvasCache.Lock()
+			if canvasCache.entries[key] == cached {
+				delete(canvasCache.entries, key)
+				cached.cached = false
+			}
+			canvasCache.Unlock()
+			continue
+		}
+		cached.windowProvider = nil
+		if wp, ok := provider.(gpucontext.WindowProvider); ok {
+			cached.windowProvider = wp
+		}
+		cached.lifecycleMu.Unlock()
+		return cached, true
+	}
+}
+
+// removeFromCanvasCache removes c only if it is still the owner of its key.
+// The owner check is important when a resized Canvas lost a key to another
+// Canvas or when a concurrent constructor won the same key.
+func (c *Canvas) removeFromCanvasCacheLocked() {
+	if !c.cached {
+		return
+	}
+	if current := canvasCache.entries[c.cacheKey]; current == c {
+		delete(canvasCache.entries, c.cacheKey)
+	}
+	c.cached = false
+}

--- a/integration/ggcanvas/cache_test.go
+++ b/integration/ggcanvas/cache_test.go
@@ -78,6 +78,29 @@ func (p *barrierProvider) TrackResource(c io.Closer) {
 
 func (p *barrierProvider) UntrackResource(io.Closer) {}
 
+func resetCanvasCache(t *testing.T) {
+	t.Helper()
+
+	reset := func() {
+		canvasCache.Lock()
+		canvases := make(map[*Canvas]struct{}, len(canvasCache.entries))
+		for _, canvas := range canvasCache.entries {
+			if canvas != nil {
+				canvases[canvas] = struct{}{}
+			}
+		}
+		canvasCache.entries = make(map[canvasCacheKey]*Canvas)
+		canvasCache.Unlock()
+
+		for canvas := range canvases {
+			_ = canvas.Close()
+		}
+	}
+
+	reset()
+	t.Cleanup(reset)
+}
+
 func newStableProvider(device, queue, adapter unsafe.Pointer) *stableProvider {
 	return &stableProvider{
 		mockProvider: newMockProvider(),
@@ -100,6 +123,7 @@ func (p *stableProvider) ScaleFactor() float64        { return p.NullWindowProvi
 func (p *stableProvider) RequestRedraw()              {}
 
 func TestNew_ReusesStableGPUHandlesAcrossProviderWrappers(t *testing.T) {
+	resetCanvasCache(t)
 	device, queue, adapter := new(int), new(int), new(int)
 	p1 := newStableProvider(unsafe.Pointer(device), unsafe.Pointer(queue), unsafe.Pointer(adapter)) //nolint:gosec // opaque test handles
 	p2 := newStableProvider(unsafe.Pointer(device), unsafe.Pointer(queue), unsafe.Pointer(adapter)) //nolint:gosec // opaque test handles
@@ -130,6 +154,7 @@ func TestNew_ReusesStableGPUHandlesAcrossProviderWrappers(t *testing.T) {
 }
 
 func TestNew_ZeroHandleProvidersUsePointerFallback(t *testing.T) {
+	resetCanvasCache(t)
 	p1 := newMockProvider()
 	p2 := newMockProvider()
 	c1, err := New(p1, 40, 30)
@@ -156,6 +181,7 @@ func TestNew_ZeroHandleProvidersUsePointerFallback(t *testing.T) {
 }
 
 func TestCacheKeyFor_NilProviderIsUncacheable(t *testing.T) {
+	resetCanvasCache(t)
 	key, cacheable := cacheKeyFor(nil, 40, 30, 2)
 	if cacheable {
 		t.Fatal("nil provider must not produce a cacheable key")
@@ -166,6 +192,7 @@ func TestCacheKeyFor_NilProviderIsUncacheable(t *testing.T) {
 }
 
 func TestNew_PreservesDistinctGeometryAndScale(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c1, err := New(p, 80, 60)
 	if err != nil {
@@ -188,6 +215,7 @@ func TestNew_PreservesDistinctGeometryAndScale(t *testing.T) {
 }
 
 func TestNew_CloseEvictsBeforeRecreate(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c1, err := New(p, 80, 60)
 	if err != nil {
@@ -210,6 +238,7 @@ func TestNew_CloseEvictsBeforeRecreate(t *testing.T) {
 }
 
 func TestResize_RekeysCacheWithoutEvictingOtherGeometry(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c1, err := New(p, 80, 60)
 	if err != nil {
@@ -250,6 +279,7 @@ func TestResize_RekeysCacheWithoutEvictingOtherGeometry(t *testing.T) {
 }
 
 func TestDraw_AutoResizeFailureRestoresCache(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c, err := New(p, 80, 60)
 	if err != nil {
@@ -277,6 +307,7 @@ func TestDraw_AutoResizeFailureRestoresCache(t *testing.T) {
 }
 
 func TestDraw_AutoResizesFromWindowProvider(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c, err := New(p, 80, 60)
 	if err != nil {
@@ -306,6 +337,7 @@ func TestDraw_AutoResizesFromWindowProvider(t *testing.T) {
 }
 
 func TestDraw_ZeroWindowSizeDoesNotResize(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c, err := New(p, 80, 60)
 	if err != nil {
@@ -322,6 +354,7 @@ func TestDraw_ZeroWindowSizeDoesNotResize(t *testing.T) {
 }
 
 func TestNew_ConcurrentDuplicateConstruction(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	const workers = 32
 	results := make(chan *Canvas, workers)
@@ -362,6 +395,7 @@ func TestNew_ConcurrentDuplicateConstruction(t *testing.T) {
 }
 
 func TestNew_StaleClosedCacheEntryRetries(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	original, err := New(p, 64, 48)
 	if err != nil {
@@ -397,6 +431,7 @@ func TestNew_StaleClosedCacheEntryRetries(t *testing.T) {
 }
 
 func TestPublishCanvas_RetriesWhenWinnerCloses(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	winner, err := New(p, 64, 48)
 	if err != nil {
@@ -441,6 +476,7 @@ func TestPublishCanvas_RetriesWhenWinnerCloses(t *testing.T) {
 }
 
 func TestNew_TrackerCloseDoesNotPublishClosedCanvas(t *testing.T) {
+	resetCanvasCache(t)
 	p := &closeOnTrackProvider{stableProvider: newStableProvider(
 		unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), //nolint:gosec // opaque test handles
 	)}
@@ -460,6 +496,7 @@ func TestNew_TrackerCloseDoesNotPublishClosedCanvas(t *testing.T) {
 }
 
 func TestNew_ValueProviderSkipsCache(t *testing.T) {
+	resetCanvasCache(t)
 	p := newValueProvider()
 	c1, err := NewWithScale(p, 64, 48, 1)
 	if err != nil {
@@ -478,6 +515,7 @@ func TestNew_ValueProviderSkipsCache(t *testing.T) {
 }
 
 func TestNew_ValueProviderTrackerCloseIsRejected(t *testing.T) {
+	resetCanvasCache(t)
 	p := closeValueProvider{valueProvider: newValueProvider()}
 	c, err := NewWithScale(p, 64, 48, 1)
 	if c != nil {
@@ -489,6 +527,7 @@ func TestNew_ValueProviderTrackerCloseIsRejected(t *testing.T) {
 }
 
 func TestNewWithScale_NormalizesNonFiniteScale(t *testing.T) {
+	resetCanvasCache(t)
 	for _, scale := range []float64{0, -1, math.NaN(), math.Inf(1), math.Inf(-1)} {
 		t.Run(fmt.Sprintf("scale_%v", scale), func(t *testing.T) {
 			p := newStableProvider(
@@ -514,6 +553,7 @@ func TestNewWithScale_NormalizesNonFiniteScale(t *testing.T) {
 }
 
 func TestSetDeviceScale_RekeysAndPreservesDestinationOwner(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c, err := NewWithScale(p, 64, 48, 1)
 	if err != nil {
@@ -573,6 +613,7 @@ func TestSetDeviceScale_RekeysAndPreservesDestinationOwner(t *testing.T) {
 }
 
 func TestDraw_ClosedReturnsErrCanvasClosed(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c, err := New(p, 32, 24)
 	if err != nil {
@@ -587,6 +628,7 @@ func TestDraw_ClosedReturnsErrCanvasClosed(t *testing.T) {
 }
 
 func TestRender_TracksWindowScaleChange(t *testing.T) {
+	resetCanvasCache(t)
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c, err := New(p, 32, 24)
 	if err != nil {
@@ -607,6 +649,7 @@ func TestRender_TracksWindowScaleChange(t *testing.T) {
 }
 
 func TestNew_ConcurrentDuplicateConstructionPublishesOneWinner(t *testing.T) {
+	resetCanvasCache(t)
 	const workers = 8
 	release := make(chan struct{})
 	p := &barrierProvider{

--- a/integration/ggcanvas/cache_test.go
+++ b/integration/ggcanvas/cache_test.go
@@ -155,6 +155,16 @@ func TestNew_ZeroHandleProvidersUsePointerFallback(t *testing.T) {
 	}
 }
 
+func TestCacheKeyFor_NilProviderIsUncacheable(t *testing.T) {
+	key, cacheable := cacheKeyFor(nil, 40, 30, 2)
+	if cacheable {
+		t.Fatal("nil provider must not produce a cacheable key")
+	}
+	if key.width != 40 || key.height != 30 || key.scale != 2 {
+		t.Fatalf("nil-provider key = %+v, want geometry 40x30 at scale 2", key)
+	}
+}
+
 func TestNew_PreservesDistinctGeometryAndScale(t *testing.T) {
 	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
 	c1, err := New(p, 80, 60)
@@ -236,6 +246,33 @@ func TestResize_RekeysCacheWithoutEvictingOtherGeometry(t *testing.T) {
 	}
 	if other != c2 {
 		t.Fatal("resize evicted an unrelated geometry key")
+	}
+}
+
+func TestDraw_AutoResizeFailureRestoresCache(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	c, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	resizeErr := errors.New("injected context resize failure")
+	c.resizeFn = func(int, int) error { return resizeErr }
+	p.W, p.H = 120, 90
+	called := false
+	if err := c.Draw(func(*gg.Context) { called = true }); !errors.Is(err, resizeErr) {
+		t.Fatalf("Draw resize error = %v, want injected failure", err)
+	}
+	if called {
+		t.Fatal("Draw callback ran after the window resize failed")
+	}
+	reused, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused != c {
+		t.Fatal("failed resize did not restore the original cache entry")
 	}
 }
 
@@ -356,6 +393,50 @@ func TestNew_StaleClosedCacheEntryRetries(t *testing.T) {
 	original.closed = false
 	original.lifecycleMu.Unlock()
 	_ = original.Close()
+	_ = recreated.Close()
+}
+
+func TestPublishCanvas_RetriesWhenWinnerCloses(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	winner, err := New(p, 64, 48)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := winner.cacheKey
+	candidate := &Canvas{
+		ctx:      gg.NewContext(64, 48),
+		provider: p,
+		width:    64,
+		height:   48,
+		dirty:    true,
+	}
+
+	// Model a winner closing immediately after the candidate observed it in
+	// the publication map. Leaving the closed winner cached makes the retry
+	// branch deterministic without scheduler timing.
+	winner.lifecycleMu.Lock()
+	winner.closed = true
+	winner.lifecycleMu.Unlock()
+	canvasCache.Lock()
+	winner.cached = true
+	canvasCache.entries[key] = winner
+	canvasCache.Unlock()
+
+	recreated, err := publishCanvas(candidate, p, key, 64, 48, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recreated == winner || recreated == candidate {
+		t.Fatal("publication retry did not create a fresh live Canvas")
+	}
+	if !candidate.closed {
+		t.Fatal("losing candidate was not closed before retry")
+	}
+
+	winner.lifecycleMu.Lock()
+	winner.closed = false
+	winner.lifecycleMu.Unlock()
+	_ = winner.Close()
 	_ = recreated.Close()
 }
 

--- a/integration/ggcanvas/cache_test.go
+++ b/integration/ggcanvas/cache_test.go
@@ -1,0 +1,333 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package ggcanvas
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gpucontext"
+)
+
+// stableProvider is intentionally a fresh wrapper around the same opaque
+// handles.  This models App.GPUContextProvider(), which returns a new adapter
+// on every call while its device resources remain stable.
+type stableProvider struct {
+	*mockProvider
+	device  gpucontext.Device
+	queue   gpucontext.Queue
+	adapter gpucontext.Adapter
+	gpucontext.NullWindowProvider
+}
+
+type closeOnTrackProvider struct {
+	*stableProvider
+}
+
+func (p *closeOnTrackProvider) TrackResource(c io.Closer) { _ = c.Close() }
+func (p *closeOnTrackProvider) UntrackResource(io.Closer) {}
+
+func newStableProvider(device, queue, adapter unsafe.Pointer) *stableProvider {
+	return &stableProvider{
+		mockProvider: newMockProvider(),
+		device:       gpucontext.NewDevice(device),
+		queue:        gpucontext.NewQueue(queue),
+		adapter:      gpucontext.NewAdapter(adapter),
+		NullWindowProvider: gpucontext.NullWindowProvider{
+			W:  100,
+			H:  100,
+			SF: 1,
+		},
+	}
+}
+
+func (p *stableProvider) Device() gpucontext.Device   { return p.device }
+func (p *stableProvider) Queue() gpucontext.Queue     { return p.queue }
+func (p *stableProvider) Adapter() gpucontext.Adapter { return p.adapter }
+func (p *stableProvider) Size() (int, int)            { return p.NullWindowProvider.Size() }
+func (p *stableProvider) ScaleFactor() float64        { return p.NullWindowProvider.ScaleFactor() }
+func (p *stableProvider) RequestRedraw()              {}
+
+func TestNew_ReusesStableGPUHandlesAcrossProviderWrappers(t *testing.T) {
+	device, queue, adapter := new(int), new(int), new(int)
+	p1 := newStableProvider(unsafe.Pointer(device), unsafe.Pointer(queue), unsafe.Pointer(adapter)) //nolint:gosec // opaque test handles
+	p2 := newStableProvider(unsafe.Pointer(device), unsafe.Pointer(queue), unsafe.Pointer(adapter)) //nolint:gosec // opaque test handles
+	p1.W, p1.H = 80, 60
+	p2.W, p2.H = 120, 90
+
+	c1, err := NewWithScale(p1, 80, 60, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := NewWithScale(p2, 80, 60, 2.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c1 != c2 {
+		t.Fatal("provider wrappers with the same GPU handles should reuse the Canvas")
+	}
+	if err := c2.Draw(func(dc *gg.Context) {
+		if dc.Width() != 120 || dc.Height() != 90 {
+			t.Errorf("latest provider wrapper size = %dx%d, want 120x90", dc.Width(), dc.Height())
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := c1.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNew_ZeroHandleProvidersUsePointerFallback(t *testing.T) {
+	p1 := newMockProvider()
+	p2 := newMockProvider()
+	c1, err := New(p1, 40, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := New(p2, 40, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c1 == c2 {
+		t.Fatal("independent zero-handle providers must not alias")
+	}
+	defer c1.Close()
+	defer c2.Close()
+
+	c3, err := New(p1, 40, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c3 != c1 {
+		t.Fatal("same zero-handle provider pointer should reuse the Canvas")
+	}
+}
+
+func TestNew_PreservesDistinctGeometryAndScale(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	c1, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := New(p, 100, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c3, err := NewWithScale(p, 80, 60, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c1.Close()
+	defer c2.Close()
+	defer c3.Close()
+	if c1 == c2 || c1 == c3 || c2 == c3 {
+		t.Fatal("different dimensions or scale must retain independent canvases")
+	}
+}
+
+func TestNew_CloseEvictsBeforeRecreate(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	c1, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	c2, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if c1 == c2 {
+		t.Fatal("a closed Canvas must not be returned from the cache")
+	}
+	if c2.Context() == nil {
+		t.Fatal("recreated Canvas has no drawing context")
+	}
+}
+
+func TestResize_RekeysCacheWithoutEvictingOtherGeometry(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	c1, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := New(p, 120, 90)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c1.Close()
+	defer c2.Close()
+
+	if err := c1.Resize(160, 120); err != nil {
+		t.Fatal(err)
+	}
+	old, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Close()
+	if old == c1 || old == c2 {
+		t.Fatal("old geometry key still references a resized Canvas")
+	}
+	current, err := New(p, 160, 120)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current != c1 {
+		t.Fatal("resized Canvas was not published under its new geometry key")
+	}
+	other, err := New(p, 120, 90)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other != c2 {
+		t.Fatal("resize evicted an unrelated geometry key")
+	}
+}
+
+func TestDraw_AutoResizesFromWindowProvider(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	c, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	p.W, p.H = 120, 90
+	if err := c.Draw(func(dc *gg.Context) {
+		if dc.Width() != 120 || dc.Height() != 90 {
+			t.Errorf("Draw callback context size = %dx%d, want 120x90", dc.Width(), dc.Height())
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if gotW, gotH := c.Size(); gotW != 120 || gotH != 90 {
+		t.Fatalf("Size after Draw = %dx%d, want 120x90", gotW, gotH)
+	}
+	// The resized Canvas is rekeyed, while the old geometry can be recreated.
+	old, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Close()
+	if old == c {
+		t.Fatal("Draw resize left the old cache key pointing at the resized Canvas")
+	}
+}
+
+func TestDraw_ZeroWindowSizeDoesNotResize(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	c, err := New(p, 80, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	p.W, p.H = 0, 0
+	if err := c.Draw(func(_ *gg.Context) {}); err != nil {
+		t.Fatal(err)
+	}
+	if gotW, gotH := c.Size(); gotW != 80 || gotH != 60 {
+		t.Fatalf("Size after zero-window Draw = %dx%d, want 80x60", gotW, gotH)
+	}
+}
+
+func TestNew_ConcurrentDuplicateConstruction(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	const workers = 32
+	results := make(chan *Canvas, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := NewWithScale(p, 100, 100, 1)
+			results <- c
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	var first *Canvas
+	for c := range results {
+		if c == nil {
+			t.Fatal("concurrent constructor returned nil Canvas")
+		}
+		if first == nil {
+			first = c
+		} else if c != first {
+			t.Fatal("concurrent constructors returned duplicate live canvases")
+		}
+	}
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent constructor error: %v", err)
+		}
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNew_StaleClosedCacheEntryRetries(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	original, err := New(p, 64, 48)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Model the small interleave where a cache lookup observes the entry just
+	// before Close marks it closed. The production Close path evicts normally;
+	// retaining the entry here makes the retry branch deterministic.
+	original.lifecycleMu.Lock()
+	original.closed = true
+	original.lifecycleMu.Unlock()
+	canvasCache.Lock()
+	original.cached = true
+	canvasCache.entries[original.cacheKey] = original
+	canvasCache.Unlock()
+
+	recreated, err := New(p, 64, 48)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recreated == original {
+		t.Fatal("stale closed cache entry was returned instead of recreated")
+	}
+
+	// Restore the synthetic state so the original context is torn down by its
+	// normal idempotent Close path as well.
+	original.lifecycleMu.Lock()
+	original.closed = false
+	original.lifecycleMu.Unlock()
+	_ = original.Close()
+	_ = recreated.Close()
+}
+
+func TestNew_TrackerCloseDoesNotPublishClosedCanvas(t *testing.T) {
+	p := &closeOnTrackProvider{stableProvider: newStableProvider(
+		unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), //nolint:gosec // opaque test handles
+	)}
+	canvas, err := NewWithScale(p, 64, 48, 1)
+	if canvas != nil {
+		t.Fatal("tracker-closed construction returned a Canvas")
+	}
+	if err == nil || !errors.Is(err, ErrCanvasClosed) {
+		t.Fatalf("tracker-closed construction error = %v, want ErrCanvasClosed", err)
+	}
+	key, cacheable := cacheKeyFor(p, 64, 48, 1)
+	if cacheable {
+		if cached, ok := lookupCachedCanvas(p, key); ok || cached != nil {
+			t.Fatal("tracker-closed construction left a stale cache entry")
+		}
+	}
+}

--- a/integration/ggcanvas/cache_test.go
+++ b/integration/ggcanvas/cache_test.go
@@ -5,13 +5,17 @@ package ggcanvas
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"math"
 	"sync"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/gogpu/gg"
 	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/gputypes"
 )
 
 // stableProvider is intentionally a fresh wrapper around the same opaque
@@ -31,6 +35,48 @@ type closeOnTrackProvider struct {
 
 func (p *closeOnTrackProvider) TrackResource(c io.Closer) { _ = c.Close() }
 func (p *closeOnTrackProvider) UntrackResource(io.Closer) {}
+
+// valueProvider deliberately has no stable identity. A value provider is a
+// valid CPU-only DeviceProvider, but cacheKeyFor conservatively leaves it
+// uncacheable because two equal values need not represent the same resources.
+type valueProvider struct {
+	format gputypes.TextureFormat
+}
+
+func newValueProvider() valueProvider {
+	return valueProvider{format: gputypes.TextureFormatBGRA8Unorm}
+}
+
+func (p valueProvider) Device() gpucontext.Device             { return gpucontext.Device{} }
+func (p valueProvider) Queue() gpucontext.Queue               { return gpucontext.Queue{} }
+func (p valueProvider) Adapter() gpucontext.Adapter           { return gpucontext.Adapter{} }
+func (p valueProvider) SurfaceFormat() gputypes.TextureFormat { return p.format }
+func (valueProvider) AdapterInfo() gpucontext.AdapterInfo {
+	return gpucontext.AdapterInfo{Type: gpucontext.AdapterTypeUnknown}
+}
+
+type closeValueProvider struct {
+	valueProvider
+}
+
+func (closeValueProvider) TrackResource(c io.Closer) { _ = c.Close() }
+func (closeValueProvider) UntrackResource(io.Closer) {}
+
+// barrierProvider keeps constructors together after resource tracking and
+// before cache publication. This makes the loser-cleanup path deterministic
+// instead of relying on scheduler timing.
+type barrierProvider struct {
+	*stableProvider
+	arrived chan struct{}
+	release <-chan struct{}
+}
+
+func (p *barrierProvider) TrackResource(c io.Closer) {
+	p.arrived <- struct{}{}
+	<-p.release
+}
+
+func (p *barrierProvider) UntrackResource(io.Closer) {}
 
 func newStableProvider(device, queue, adapter unsafe.Pointer) *stableProvider {
 	return &stableProvider{
@@ -329,5 +375,208 @@ func TestNew_TrackerCloseDoesNotPublishClosedCanvas(t *testing.T) {
 		if cached, ok := lookupCachedCanvas(p, key); ok || cached != nil {
 			t.Fatal("tracker-closed construction left a stale cache entry")
 		}
+	}
+}
+
+func TestNew_ValueProviderSkipsCache(t *testing.T) {
+	p := newValueProvider()
+	c1, err := NewWithScale(p, 64, 48, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := NewWithScale(p, 64, 48, 1)
+	if err != nil {
+		c1.Close()
+		t.Fatal(err)
+	}
+	defer c1.Close()
+	defer c2.Close()
+	if c1 == c2 {
+		t.Fatal("value providers must not alias through the Canvas cache")
+	}
+}
+
+func TestNew_ValueProviderTrackerCloseIsRejected(t *testing.T) {
+	p := closeValueProvider{valueProvider: newValueProvider()}
+	c, err := NewWithScale(p, 64, 48, 1)
+	if c != nil {
+		t.Fatal("tracker-closed value-provider construction returned a Canvas")
+	}
+	if !errors.Is(err, ErrCanvasClosed) {
+		t.Fatalf("tracker-closed value-provider construction error = %v, want ErrCanvasClosed", err)
+	}
+}
+
+func TestNewWithScale_NormalizesNonFiniteScale(t *testing.T) {
+	for _, scale := range []float64{0, -1, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		t.Run(fmt.Sprintf("scale_%v", scale), func(t *testing.T) {
+			p := newStableProvider(
+				unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), //nolint:gosec // opaque test handles
+			)
+			c, err := NewWithScale(p, 64, 48, scale)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			if got := c.DeviceScale(); got != 1 {
+				t.Fatalf("DeviceScale for %v = %v, want 1", scale, got)
+			}
+			reused, err := NewWithScale(p, 64, 48, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if reused != c {
+				t.Fatalf("normalized scale %v did not reuse the scale-1 Canvas", scale)
+			}
+		})
+	}
+}
+
+func TestSetDeviceScale_RekeysAndPreservesDestinationOwner(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	c, err := NewWithScale(p, 64, 48, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.DeviceScale() != 1 {
+		t.Fatalf("initial DeviceScale = %v, want 1", c.DeviceScale())
+	}
+	c.SetDeviceScale(1) // unchanged scale is a no-op
+	for _, invalid := range []float64{0, -1, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		c.SetDeviceScale(invalid)
+	}
+	if c.DeviceScale() != 1 {
+		t.Fatalf("invalid scale changed DeviceScale to %v", c.DeviceScale())
+	}
+	c.SetDeviceScale(2)
+	if got := c.DeviceScale(); got != 2 {
+		t.Fatalf("DeviceScale after change = %v, want 2", got)
+	}
+	if !c.IsDirty() {
+		t.Fatal("changing device scale must mark the Canvas dirty")
+	}
+	reused, err := NewWithScale(p, 64, 48, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reused != c {
+		t.Fatal("scale change did not publish the Canvas under its new key")
+	}
+	oldScale, err := NewWithScale(p, 64, 48, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldScale == c {
+		t.Fatal("old scale key still points at the rescaled Canvas")
+	}
+	oldScale.Close()
+	c.Close()
+	c.SetDeviceScale(3) // closed canvases ignore scale changes
+
+	p2 := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	first, err := NewWithScale(p2, 64, 48, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination, err := NewWithScale(p2, 64, 48, 2)
+	if err != nil {
+		first.Close()
+		t.Fatal(err)
+	}
+	first.SetDeviceScale(2)
+	if got, err := NewWithScale(p2, 64, 48, 2); err != nil || got != destination {
+		t.Fatalf("rescale collision replaced destination Canvas: got=%p want=%p err=%v", got, destination, err)
+	}
+	first.Close()
+	destination.Close()
+}
+
+func TestDraw_ClosedReturnsErrCanvasClosed(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	c, err := New(p, 32, 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Draw(nil); !errors.Is(err, ErrCanvasClosed) {
+		t.Fatalf("Draw on closed Canvas error = %v, want ErrCanvasClosed", err)
+	}
+}
+
+func TestRender_TracksWindowScaleChange(t *testing.T) {
+	p := newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))) //nolint:gosec // opaque test handles
+	c, err := New(p, 32, 24)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	p.SF = 2
+	target := &renderMockPixelWriter{}
+	if err := c.Render(target); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.DeviceScale(); got != 2 {
+		t.Fatalf("Render did not apply window scale: got %v want 2", got)
+	}
+	if target.writtenW != 64 || target.writtenH != 48 {
+		t.Fatalf("rendered physical size = %dx%d, want 64x48", target.writtenW, target.writtenH)
+	}
+}
+
+func TestNew_ConcurrentDuplicateConstructionPublishesOneWinner(t *testing.T) {
+	const workers = 8
+	release := make(chan struct{})
+	p := &barrierProvider{
+		stableProvider: newStableProvider(unsafe.Pointer(new(int)), unsafe.Pointer(new(int)), unsafe.Pointer(new(int))), //nolint:gosec // opaque test handles
+		arrived:        make(chan struct{}, workers),
+		release:        release,
+	}
+	results := make(chan *Canvas, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := NewWithScale(p, 96, 72, 1)
+			results <- c
+			errs <- err
+		}()
+	}
+	for i := 0; i < workers; i++ {
+		select {
+		case <-p.arrived:
+		case <-time.After(2 * time.Second):
+			t.Fatal("constructors did not all reach resource tracking")
+		}
+	}
+	close(release)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	var winner *Canvas
+	for c := range results {
+		if c == nil {
+			t.Fatal("concurrent constructor returned nil Canvas")
+		}
+		if winner == nil {
+			winner = c
+		} else if c != winner {
+			t.Fatalf("concurrent constructors returned %p and %p", winner, c)
+		}
+	}
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent constructor error: %v", err)
+		}
+	}
+	if winner == nil {
+		t.Fatal("no winning Canvas")
+	}
+	if err := winner.Close(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -52,6 +52,7 @@ type resourceTracker interface {
 // or use external synchronization.
 type Canvas struct {
 	ctx                  *gg.Context
+	resizeFn             func(width, height int) error // context resize dependency; lifecycleMu protects replacement
 	provider             gpucontext.DeviceProvider
 	windowProvider       gpucontext.WindowProvider // latest wrapper for dynamic size/scale
 	texture              any                       // Lazy-created texture (*gogpu.Texture)
@@ -182,8 +183,10 @@ func NewWithScale(provider gpucontext.DeviceProvider, width, height int, scale f
 		opts = append(opts, gg.WithDeviceScale(scale))
 	}
 
+	ctx := gg.NewContext(width, height, opts...)
 	c := &Canvas{
-		ctx:      gg.NewContext(width, height, opts...),
+		ctx:      ctx,
+		resizeFn: ctx.Resize,
 		provider: provider,
 		width:    width,
 		height:   height,
@@ -602,8 +605,8 @@ func (c *Canvas) resizeLocked(width, height int) error {
 	c.removeFromCanvasCacheLocked()
 	canvasCache.Unlock()
 
-	// Resize gg context
-	if err := c.ctx.Resize(width, height); err != nil {
+	// Resize gg context.
+	if err := c.resizeFn(width, height); err != nil {
 		// Restore the old cache key when the context rejects the resize.
 		key, cacheable := c.cacheKeyFor(oldWidth, oldHeight, c.ctx.DeviceScale())
 		if cacheable {

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -48,8 +48,10 @@ type resourceTracker interface {
 // Canvas wraps gg.Context with gogpu integration.
 // It manages the CPU-to-GPU pipeline automatically.
 //
-// Canvas is NOT safe for concurrent use. Create one Canvas per goroutine,
-// or use external synchronization.
+// Cache-visible lifecycle operations (construction, resize, scale changes, and
+// close) are internally serialized. Drawing and general Canvas use are NOT
+// safe concurrently; callers must use one Canvas per goroutine or provide
+// external synchronization.
 type Canvas struct {
 	ctx                  *gg.Context
 	resizeFn             func(width, height int) error // context resize dependency; lifecycleMu protects replacement

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -219,49 +219,55 @@ func NewWithScale(provider gpucontext.DeviceProvider, width, height int, scale f
 	// Do not hold canvasCache across context creation, accelerator setup, or
 	// tracker callbacks.  Concurrent constructors race only on publication;
 	// the loser is closed outside the cache lock after the winner is selected.
-	if cacheable {
-		// Keep this Canvas lifecycle-locked through publication. A tracker may
-		// close it immediately after TrackResource returns; without this guard a
-		// closed loser could be inserted and returned from the cache.
-		c.lifecycleMu.Lock()
-		if c.closed {
-			c.lifecycleMu.Unlock()
-			return nil, ErrCanvasClosed
-		}
-		canvasCache.Lock()
-		winner := canvasCache.entries[key]
-		if winner == nil {
-			c.cacheKey = key
-			c.cached = true
-			canvasCache.entries[key] = c
-		}
-		canvasCache.Unlock()
-		c.lifecycleMu.Unlock()
-
-		if winner != nil {
-			// Winner may have closed after publication while this constructor was
-			// finishing. Verify it using the same cache/lifecycle protocol before
-			// returning; otherwise retry with this key after cleaning up the loser.
-			_ = c.Close()
-			if live, ok := lookupCachedCanvas(provider, key); ok {
-				return live, nil
-			}
-			return NewWithScale(provider, width, height, scale)
-		}
-	}
-
-	// Uncacheable providers have no publication step to serialize with
-	// shutdown, so still reject a synchronous tracker close before returning.
 	if !cacheable {
-		c.lifecycleMu.Lock()
-		closedAfterTracking := c.closed
-		c.lifecycleMu.Unlock()
-		if closedAfterTracking {
-			return nil, ErrCanvasClosed
-		}
+		return finishUncacheableCanvas(c)
 	}
+	return publishCanvas(c, provider, key, width, height, scale)
+}
 
+// finishUncacheableCanvas rejects a synchronous tracker shutdown before a
+// newly-created Canvas is returned. Providers without stable identity are not
+// entered in canvasCache, so there is no publication step to coordinate.
+func finishUncacheableCanvas(c *Canvas) (*Canvas, error) {
+	c.lifecycleMu.Lock()
+	closed := c.closed
+	c.lifecycleMu.Unlock()
+	if closed {
+		return nil, ErrCanvasClosed
+	}
 	return c, nil
+}
+
+// publishCanvas inserts c into the cache, or cleans it up when another
+// constructor won the same key. Keep the Canvas lifecycle-locked through
+// publication: a tracker may close it immediately after TrackResource returns.
+func publishCanvas(c *Canvas, provider gpucontext.DeviceProvider, key canvasCacheKey, width, height int, scale float64) (*Canvas, error) {
+	c.lifecycleMu.Lock()
+	if c.closed {
+		c.lifecycleMu.Unlock()
+		return nil, ErrCanvasClosed
+	}
+	canvasCache.Lock()
+	winner := canvasCache.entries[key]
+	if winner == nil {
+		c.cacheKey = key
+		c.cached = true
+		canvasCache.entries[key] = c
+	}
+	canvasCache.Unlock()
+	c.lifecycleMu.Unlock()
+
+	if winner == nil {
+		return c, nil
+	}
+	// Winner may have closed after publication while this constructor was
+	// finishing. Verify it using the same cache/lifecycle protocol before
+	// returning; otherwise retry with this key after cleaning up the loser.
+	_ = c.Close()
+	if live, ok := lookupCachedCanvas(provider, key); ok {
+		return live, nil
+	}
+	return NewWithScale(provider, width, height, scale)
 }
 
 // MustNew is like New but panics on error.

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -9,6 +9,7 @@ import (
 	"image"
 	"io"
 	"math"
+	"sync"
 
 	"github.com/gogpu/gg"
 	"github.com/gogpu/gpucontext"
@@ -52,15 +53,19 @@ type resourceTracker interface {
 type Canvas struct {
 	ctx                  *gg.Context
 	provider             gpucontext.DeviceProvider
-	texture              any             // Lazy-created texture (*gogpu.Texture)
-	oldTexture           any             // Previous texture awaiting deferred destruction
-	dirty                bool            // Needs GPU upload
-	dirtyRect            image.Rectangle // Accumulated dirty region (zero = full upload)
-	regionBuf            []byte          // Reusable buffer for partial texture upload
-	sizeChanged          bool            // Resize pending — texture must be recreated
+	windowProvider       gpucontext.WindowProvider // latest wrapper for dynamic size/scale
+	texture              any                       // Lazy-created texture (*gogpu.Texture)
+	oldTexture           any                       // Previous texture awaiting deferred destruction
+	dirty                bool                      // Needs GPU upload
+	dirtyRect            image.Rectangle           // Accumulated dirty region (zero = full upload)
+	regionBuf            []byte                    // Reusable buffer for partial texture upload
+	sizeChanged          bool                      // Resize pending — texture must be recreated
 	width                int
 	height               int
 	closed               bool
+	cacheKey             canvasCacheKey
+	cached               bool
+	lifecycleMu          sync.Mutex        // serializes cache-visible lifecycle changes
 	tracked              bool              // true if auto-registered with a ResourceTracker
 	damageOverlay        *ggDamageOverlay  // debug overlay renderer (ADR-066)
 	lastFrameDamageRects []image.Rectangle // damage rects from last Render (for diagnostics)
@@ -78,13 +83,16 @@ type Canvas struct {
 	presentDamageRects []image.Rectangle
 }
 
-// New creates a Canvas for integrated mode.
+// New creates (or reuses) a Canvas for integrated mode.
 // The provider should come from gogpu.App.GPUContextProvider().
 // The width and height are logical dimensions.
 //
 // If the provider also implements gpucontext.WindowProvider, the device
 // scale is auto-detected for HiDPI/Retina support. Otherwise defaults to 1.0.
 // Use Context() to access and configure the drawing context.
+// Repeated calls with the same logical provider identity, dimensions, and
+// normalized scale return the existing Canvas. Call Close to evict it before
+// creating a replacement.
 //
 // Returns error if dimensions are invalid or provider is nil.
 func New(provider gpucontext.DeviceProvider, width, height int) (*Canvas, error) {
@@ -118,13 +126,15 @@ func warnIfPhysicalDimensions(wp gpucontext.WindowProvider, width, height int, s
 	}
 }
 
-// NewWithScale creates a Canvas with HiDPI device scale support.
+// NewWithScale creates (or reuses) a Canvas with HiDPI device scale support.
 // The width and height are logical dimensions. The internal pixmap is
 // allocated at physical resolution (width*scale x height*scale).
 //
 // The provider should come from gogpu.App.GPUContextProvider().
 // Scale factor should come from the platform (e.g., gogpu.Context.ScaleFactor()).
 // Typical values: 1.0 (standard), 2.0 (macOS Retina), 3.0 (mobile HiDPI).
+// Calls with the same provider identity, dimensions, and normalized scale are
+// idempotent; different dimensions or scales retain independent canvases.
 //
 // Example:
 //
@@ -139,8 +149,17 @@ func NewWithScale(provider gpucontext.DeviceProvider, width, height int, scale f
 	if width <= 0 || height <= 0 {
 		return nil, fmt.Errorf("%w: width=%d, height=%d", ErrInvalidDimensions, width, height)
 	}
-	if scale <= 0 {
-		scale = 1.0
+	scale = normalizeScale(scale)
+
+	// The provider returned by gogpu.App.GPUContextProvider is a fresh adapter
+	// on each call.  Cache by its stable GPU handles (or, for zero-handle test
+	// providers, by pointer identity) so constructing a canvas in every frame
+	// reuses the existing context and texture pipeline.
+	key, cacheable := cacheKeyFor(provider, width, height, scale)
+	if cacheable {
+		if cached, ok := lookupCachedCanvas(provider, key); ok {
+			return cached, nil
+		}
 	}
 
 	physW := int(float64(width) * scale)
@@ -170,6 +189,9 @@ func NewWithScale(provider gpucontext.DeviceProvider, width, height int, scale f
 		height:   height,
 		dirty:    true, // Mark dirty so first Flush creates texture
 	}
+	if wp, ok := provider.(gpucontext.WindowProvider); ok {
+		c.windowProvider = wp
+	}
 
 	// Auto-detect LCD subpixel layout from platform (ADR-024).
 	// PlatformProvider exposes OS-level display properties; SubpixelLayout
@@ -187,8 +209,56 @@ func NewWithScale(provider gpucontext.DeviceProvider, width, height int, scale f
 	// This enables automatic cleanup on application shutdown without
 	// requiring manual OnClose callbacks.
 	if tracker, ok := provider.(resourceTracker); ok {
-		tracker.TrackResource(c)
+		// Set the flag before the callback.  A tracker that is already shutting
+		// down may synchronously close a newly tracked resource.
+		c.lifecycleMu.Lock()
 		c.tracked = true
+		c.lifecycleMu.Unlock()
+		tracker.TrackResource(c)
+	}
+	// Do not hold canvasCache across context creation, accelerator setup, or
+	// tracker callbacks.  Concurrent constructors race only on publication;
+	// the loser is closed outside the cache lock after the winner is selected.
+	if cacheable {
+		// Keep this Canvas lifecycle-locked through publication. A tracker may
+		// close it immediately after TrackResource returns; without this guard a
+		// closed loser could be inserted and returned from the cache.
+		c.lifecycleMu.Lock()
+		if c.closed {
+			c.lifecycleMu.Unlock()
+			return nil, ErrCanvasClosed
+		}
+		canvasCache.Lock()
+		winner := canvasCache.entries[key]
+		if winner == nil {
+			c.cacheKey = key
+			c.cached = true
+			canvasCache.entries[key] = c
+		}
+		canvasCache.Unlock()
+		c.lifecycleMu.Unlock()
+
+		if winner != nil {
+			// Winner may have closed after publication while this constructor was
+			// finishing. Verify it using the same cache/lifecycle protocol before
+			// returning; otherwise retry with this key after cleaning up the loser.
+			_ = c.Close()
+			if live, ok := lookupCachedCanvas(provider, key); ok {
+				return live, nil
+			}
+			return NewWithScale(provider, width, height, scale)
+		}
+	}
+
+	// Uncacheable providers have no publication step to serialize with
+	// shutdown, so still reject a synchronous tracker close before returning.
+	if !cacheable {
+		c.lifecycleMu.Lock()
+		closedAfterTracking := c.closed
+		c.lifecycleMu.Unlock()
+		if closedAfterTracking {
+			return nil, ErrCanvasClosed
+		}
 	}
 
 	return c, nil
@@ -281,15 +351,40 @@ func (c *Canvas) PixmapTextureView() gpucontext.TextureView {
 // This delegates to the gg.Context and marks the canvas for re-upload.
 // Scale must be > 0; values <= 0 are ignored.
 func (c *Canvas) SetDeviceScale(scale float64) {
-	if c.closed || c.ctx == nil || scale <= 0 {
+	if scale <= 0 || math.IsNaN(scale) || math.IsInf(scale, 0) {
+		return
+	}
+	scale = normalizeScale(scale)
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+	if c.closed || c.ctx == nil {
 		return
 	}
 	if scale == c.ctx.DeviceScale() {
 		return
 	}
+	// Remove the old key before mutating the context.  A concurrent New call
+	// must not receive a Canvas whose scale no longer matches its cache key.
+	canvasCache.Lock()
+	c.removeFromCanvasCacheLocked()
+	canvasCache.Unlock()
 	c.ctx.SetDeviceScale(scale)
 	c.sizeChanged = true
 	c.dirty = true
+
+	// Re-publish under the new normalized scale.  If another live Canvas already
+	// owns this destination key, leave this one uncached rather than replacing
+	// a legitimate different-size/scale Canvas.
+	key, cacheable := c.cacheKeyFor(c.width, c.height, scale)
+	if cacheable {
+		canvasCache.Lock()
+		if winner := canvasCache.entries[key]; winner == nil || winner == c {
+			c.cacheKey = key
+			c.cached = true
+			canvasCache.entries[key] = c
+		}
+		canvasCache.Unlock()
+	}
 }
 
 // MarkDirty flags the canvas for GPU upload on next Flush().
@@ -430,10 +525,30 @@ func (c *Canvas) MarkDirtyRegion(r image.Rectangle) {
 // Per-frame state (matrix, path, clip, mask) is automatically reset via
 // Push/Pop wrapper (Skia SkAutoCanvasRestore pattern, ADR-032). Configuration
 // state (font, paint color, textMode) persists across frames.
+// If the provider implements gpucontext.WindowProvider, a valid changed
+// logical window size is applied before fn runs. Zero dimensions reported
+// during startup or teardown are ignored.
 func (c *Canvas) Draw(fn func(*gg.Context)) error {
+	c.lifecycleMu.Lock()
 	if c.closed {
+		c.lifecycleMu.Unlock()
 		return ErrCanvasClosed
 	}
+	// A gogpu frame often obtains a fresh GPUContextProvider wrapper.  Its
+	// WindowProvider geometry remains the authoritative logical size, so update
+	// the retained gg context before invoking user drawing code.  During startup
+	// and teardown platforms may report zero; keep the existing valid canvas in
+	// that case rather than attempting an invalid resize.
+	if c.windowProvider != nil {
+		if width, height := c.windowProvider.Size(); width > 0 && height > 0 && (width != c.width || height != c.height) {
+			if err := c.resizeLocked(width, height); err != nil {
+				c.lifecycleMu.Unlock()
+				return err
+			}
+		}
+	}
+	c.lifecycleMu.Unlock()
+
 	gg.BeginAcceleratorFrame()
 	c.ctx.Push()
 	c.ctx.Identity()
@@ -456,6 +571,12 @@ func (c *Canvas) IsDirty() bool {
 //
 // Returns error if dimensions are invalid or canvas is closed.
 func (c *Canvas) Resize(width, height int) error {
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+	return c.resizeLocked(width, height)
+}
+
+func (c *Canvas) resizeLocked(width, height int) error {
 	if c.closed {
 		return ErrCanvasClosed
 	}
@@ -468,8 +589,26 @@ func (c *Canvas) Resize(width, height int) error {
 		return nil
 	}
 
+	oldWidth, oldHeight := c.width, c.height
+	// Evict before changing the gg context so no New call can observe the old
+	// dimensions mapped to a Canvas that is midway through a resize.
+	canvasCache.Lock()
+	c.removeFromCanvasCacheLocked()
+	canvasCache.Unlock()
+
 	// Resize gg context
 	if err := c.ctx.Resize(width, height); err != nil {
+		// Restore the old cache key when the context rejects the resize.
+		key, cacheable := c.cacheKeyFor(oldWidth, oldHeight, c.ctx.DeviceScale())
+		if cacheable {
+			canvasCache.Lock()
+			if winner := canvasCache.entries[key]; winner == nil || winner == c {
+				c.cacheKey = key
+				c.cached = true
+				canvasCache.entries[key] = c
+			}
+			canvasCache.Unlock()
+		}
 		return fmt.Errorf("ggcanvas: context resize failed: %w", err)
 	}
 
@@ -478,6 +617,17 @@ func (c *Canvas) Resize(width, height int) error {
 	c.sizeChanged = true
 	c.dirty = true
 	c.prevFrameDamageRects = nil
+
+	key, cacheable := c.cacheKeyFor(width, height, c.ctx.DeviceScale())
+	if cacheable {
+		canvasCache.Lock()
+		if winner := canvasCache.entries[key]; winner == nil || winner == c {
+			c.cacheKey = key
+			c.cached = true
+			canvasCache.entries[key] = c
+		}
+		canvasCache.Unlock()
+	}
 
 	return nil
 }
@@ -776,8 +926,8 @@ func (c *Canvas) Render(dc RenderTarget) error {
 	// ADR-067: compositor wiring moved to renderDirectToTarget (per-frame via GPURenderTarget.Compositor).
 
 	// Auto-detect DPI scale change (ADR-059). Zero overhead when unchanged.
-	if wp, ok := c.provider.(gpucontext.WindowProvider); ok {
-		if newScale := wp.ScaleFactor(); newScale > 0 && newScale != c.ctx.DeviceScale() {
+	if c.windowProvider != nil {
+		if newScale := c.windowProvider.ScaleFactor(); newScale > 0 && newScale != c.ctx.DeviceScale() {
 			c.SetDeviceScale(newScale)
 		}
 	}
@@ -913,35 +1063,51 @@ func (c *Canvas) Texture() any {
 // After Close, the Canvas should not be used.
 // Close is idempotent - multiple calls are safe.
 func (c *Canvas) Close() error {
+	c.lifecycleMu.Lock()
+	// Evict and mark closed together, before any tracker callback or resource
+	// teardown.  A new constructor can therefore never receive this Canvas
+	// through a stale cache entry.
+	canvasCache.Lock()
 	if c.closed {
+		canvasCache.Unlock()
+		c.lifecycleMu.Unlock()
 		return nil
 	}
+	c.removeFromCanvasCacheLocked()
 	c.closed = true
+	canvasCache.Unlock()
+
+	provider := c.provider
+	tracked := c.tracked
+	c.tracked = false
+	oldTexture := c.oldTexture
+	c.oldTexture = nil
+	texture := c.texture
+	c.texture = nil
+	ctx := c.ctx
+	c.ctx = nil
+	c.provider = nil
+	c.windowProvider = nil
+	c.lifecycleMu.Unlock()
 
 	// Untrack from ResourceTracker if auto-registered, to prevent double-close.
-	if c.tracked {
-		if tracker, ok := c.provider.(resourceTracker); ok {
+	if tracked {
+		if tracker, ok := provider.(resourceTracker); ok {
 			tracker.UntrackResource(c)
 		}
-		c.tracked = false
 	}
 
 	// Note: no need to clear surface target — per-pass View routing handles
 	// target selection. Session-level surfaceView is no longer set.
 
 	// Destroy textures (current and any deferred old texture).
-	destroyTexture(c.oldTexture)
-	c.oldTexture = nil
-	destroyTexture(c.texture)
-	c.texture = nil
+	destroyTexture(oldTexture)
+	destroyTexture(texture)
 
 	// Close gg context
-	if c.ctx != nil {
-		_ = c.ctx.Close()
-		c.ctx = nil
+	if ctx != nil {
+		_ = ctx.Close()
 	}
-
-	c.provider = nil
 	return nil
 }
 

--- a/integration/ggcanvas/doc.go
+++ b/integration/ggcanvas/doc.go
@@ -42,6 +42,7 @@
 //
 //   - Texture is created lazily on first Flush()
 //   - Dirty tracking avoids unnecessary GPU uploads
+//   - New and NewWithScale reuse a Canvas for the same provider, size, and scale
 //   - Consider canvas size vs window size for optimal performance
 //
 // # Integration Without Circular Imports


### PR DESCRIPTION
## Summary

- make `ggcanvas.New` / `NewWithScale` idempotent for the same GPU identity, logical geometry, and device scale
- key fresh provider wrappers by stable device/queue/adapter handles, with a pointer fallback for zero-handle providers
- keep cache publication, close eviction, resize/scale rekeying, and tracker shutdown lifecycle-safe
- synchronize canvas dimensions from `WindowProvider.Size()` before drawing
- document cache/close semantics and add deterministic concurrency, wrapper, resize, tracker, and rollback regressions

## Why

Applications commonly obtain a fresh `GPUContextProvider` wrapper every frame. Reconstructing `ggcanvas.Canvas` for each wrapper repeatedly allocates rendering state and misses window-size changes unless callers manage both lifecycles manually. Reusing the existing canvas by stable GPU identity fixes that pattern while preserving distinct canvases for distinct geometry or scale.

## Verification

- `go test -race -tags nogpu ./integration/ggcanvas`
- cache/tracker/concurrency/rollback regressions repeated 20× under the race detector
- `go vet ./integration/ggcanvas`
- `go build ./integration/ggcanvas`
- all modified coverable statements hit in the local CI-equivalent coverage profile
- `gofmt` and `git diff --check`

Fixes #484

## Review follow-up (2026-08-12)

- ADR-064 / issue #484 now explicitly describes dimension-aware cache identity (`provider + size`), matching the implementation.
- Added `resetCanvasCache(t)` with cleanup to isolate every package-global cache test.
- Clarified the `Canvas` contract: cache-visible lifecycle operations are serialized, while drawing and general concurrent use still require caller synchronization.
