### PR TITLE
fix: preserve path bounds across reuse

### DIFF
--- a/context_output_test.go
+++ b/context_output_test.go
@@ -2,6 +2,7 @@ package gg
 
 import (
 	"bytes"
+	"image"
 	"image/jpeg"
 	"image/png"
 	"io"
@@ -294,6 +295,9 @@ func TestSetPath(t *testing.T) {
 	if x != 30 || y != 40 {
 		t.Errorf("GetCurrentPoint() = (%v, %v), want (30, 40)", x, y)
 	}
+	if got, want := dc.path.Bounds(), image.Rect(10, 20, 30, 40); got != want {
+		t.Errorf("SetPath bounds = %v, want %v", got, want)
+	}
 }
 
 func TestSetPathNil(t *testing.T) {
@@ -326,6 +330,9 @@ func TestAppendPath(t *testing.T) {
 	}
 	if x != 70 || y != 80 {
 		t.Errorf("GetCurrentPoint() = (%v, %v), want (70, 80)", x, y)
+	}
+	if got, want := dc.path.Bounds(), image.Rect(10, 20, 70, 80); got != want {
+		t.Errorf("AppendPath bounds = %v, want %v", got, want)
 	}
 }
 

--- a/path.go
+++ b/path.go
@@ -182,6 +182,7 @@ func (p *Path) Reset() {
 	p.coords = p.coords[:0]
 	p.start = Point{}
 	p.current = Point{}
+	p.boundsValid = false
 }
 
 // Append adds all elements from other to this path.
@@ -194,6 +195,10 @@ func (p *Path) Append(other *Path) {
 	p.coords = append(p.coords, other.coords...)
 	p.current = other.current
 	p.start = other.start
+	if other.boundsValid {
+		p.expandBounds(other.boundsMinX, other.boundsMinY)
+		p.expandBounds(other.boundsMaxX, other.boundsMaxY)
+	}
 }
 
 // Iterate calls fn for each verb in the path with the corresponding coordinate slice.
@@ -392,10 +397,15 @@ func (p *Path) RoundedRectangle(x, y, w, h, r float64) {
 // Clone creates a deep copy of the path.
 func (p *Path) Clone() *Path {
 	result := &Path{
-		verbs:   make([]PathVerb, len(p.verbs)),
-		coords:  make([]float64, len(p.coords)),
-		start:   p.start,
-		current: p.current,
+		verbs:       make([]PathVerb, len(p.verbs)),
+		coords:      make([]float64, len(p.coords)),
+		start:       p.start,
+		current:     p.current,
+		boundsMinX:  p.boundsMinX,
+		boundsMinY:  p.boundsMinY,
+		boundsMaxX:  p.boundsMaxX,
+		boundsMaxY:  p.boundsMaxY,
+		boundsValid: p.boundsValid,
 	}
 	copy(result.verbs, p.verbs)
 	copy(result.coords, p.coords)

--- a/path_bounds_test.go
+++ b/path_bounds_test.go
@@ -134,6 +134,49 @@ func TestContextFrameDamage_AfterFill(t *testing.T) {
 	}
 }
 
+func TestContextFrameDamage_PathAPIs(t *testing.T) {
+	path := NewPath()
+	path.Rectangle(10, 20, 20, 30)
+
+	tests := []struct {
+		name  string
+		setup func(*Context)
+		want  image.Rectangle
+	}{
+		{
+			name: "SetPath",
+			setup: func(dc *Context) {
+				dc.SetPath(path)
+			},
+			want: image.Rect(10, 20, 30, 50),
+		},
+		{
+			name: "AppendPath",
+			setup: func(dc *Context) {
+				dc.DrawRectangle(0, 0, 5, 5)
+				dc.AppendPath(path)
+			},
+			want: image.Rect(0, 0, 30, 50),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := NewContext(100, 100)
+			defer dc.Close()
+
+			tc.setup(dc)
+			if err := dc.Fill(); err != nil {
+				t.Fatalf("Fill: %v", err)
+			}
+			got := dc.FrameDamage()
+			if len(got) != 1 || got[0] != tc.want {
+				t.Fatalf("FrameDamage = %v, want [%v]", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestContextFrameDamage_MultipleFillsSeparateRects(t *testing.T) {
 	dc := NewContext(400, 400)
 	defer dc.Close()

--- a/path_test.go
+++ b/path_test.go
@@ -1,6 +1,7 @@
 package gg
 
 import (
+	"image"
 	"math"
 	"testing"
 )
@@ -263,6 +264,15 @@ func TestPath_Reset(t *testing.T) {
 	}
 	if cap(p.coords) != coordCap {
 		t.Errorf("After Reset: coord capacity changed from %d to %d", coordCap, cap(p.coords))
+	}
+	if got := p.Bounds(); !got.Empty() {
+		t.Errorf("After Reset: bounds = %v, want empty", got)
+	}
+
+	p.MoveTo(-100, -80)
+	p.LineTo(-60, -40)
+	if got, want := p.Bounds(), image.Rect(-100, -80, -60, -40); got != want {
+		t.Errorf("After Reset and reuse: bounds = %v, want %v", got, want)
 	}
 }
 
@@ -944,6 +954,75 @@ func TestPath_Append(t *testing.T) {
 	if p1.current != p2.current {
 		t.Errorf("After Append: current = %v, want %v", p1.current, p2.current)
 	}
+	if got, want := p1.Bounds(), image.Rect(0, 0, 30, 30); got != want {
+		t.Errorf("After Append: bounds = %v, want %v", got, want)
+	}
+}
+
+func TestPath_AppendIntoEmptyPreservesBounds(t *testing.T) {
+	p := NewPath()
+	other := NewPath()
+	other.MoveTo(20, 30)
+	other.LineTo(40, 60)
+
+	p.Append(other)
+
+	if got, want := p.Bounds(), image.Rect(20, 30, 40, 60); got != want {
+		t.Errorf("Append into empty path: bounds = %v, want %v", got, want)
+	}
+}
+
+func TestPath_AppendPreservesComplexBounds(t *testing.T) {
+	p := NewPath()
+	p.Rectangle(0, 0, 10, 10)
+
+	other := NewPath()
+	other.MoveTo(20, 20)
+	other.QuadraticTo(40, -30, 30, 30)
+	other.MoveTo(-50, 5)
+	other.LineTo(-40, 15)
+
+	p.Append(other)
+
+	if got, want := p.Bounds(), image.Rect(-50, -30, 40, 30); got != want {
+		t.Errorf("Append complex path: bounds = %v, want %v", got, want)
+	}
+}
+
+func TestPath_AppendSelfPreservesBounds(t *testing.T) {
+	p := NewPath()
+	p.MoveTo(-10, 5)
+	p.QuadraticTo(20, -30, 40, 10)
+	want := p.Bounds()
+	wantVerbs := 2 * p.NumVerbs()
+
+	p.Append(p)
+
+	if got := p.Bounds(); got != want {
+		t.Errorf("Append self: bounds = %v, want %v", got, want)
+	}
+	if got := p.NumVerbs(); got != wantVerbs {
+		t.Errorf("Append self: %d verbs, want %d", got, wantVerbs)
+	}
+}
+
+func TestPath_ClonePreservesBounds(t *testing.T) {
+	p := NewPath()
+	p.MoveTo(-10, 20)
+	p.LineTo(30, 40)
+
+	clone := p.Clone()
+	if got, want := clone.Bounds(), image.Rect(-10, 20, 30, 40); got != want {
+		t.Errorf("Clone bounds = %v, want %v", got, want)
+	}
+
+	clone.LineTo(100, 200)
+	if got, want := p.Bounds(), image.Rect(-10, 20, 30, 40); got != want {
+		t.Errorf("Original bounds after modifying clone = %v, want %v", got, want)
+	}
+	if got, want := clone.Bounds(), image.Rect(-10, 20, 100, 200); got != want {
+		t.Errorf("Modified clone bounds = %v, want %v", got, want)
+	}
 }
 
 func TestPath_Append_Nil(t *testing.T) {
@@ -957,10 +1036,14 @@ func TestPath_Append_Nil(t *testing.T) {
 
 func TestPath_Append_Empty(t *testing.T) {
 	p := NewPath()
-	p.MoveTo(0, 0)
+	p.MoveTo(7, 9)
+	wantBounds := p.Bounds()
 	p.Append(NewPath()) // Append empty path
 	if len(p.verbs) != 1 {
 		t.Errorf("After Append(empty): %d verbs, want 1", len(p.verbs))
+	}
+	if got := p.Bounds(); got != wantBounds {
+		t.Errorf("After Append(empty): bounds = %v, want %v", got, wantBounds)
 	}
 }
 


### PR DESCRIPTION
## Summary

- invalidate cached bounds when a path is reset
- merge appended geometry into the destination path's bounds
- preserve bounds metadata when cloning a path
- add path, context, and frame-damage regressions for reuse and composition APIs

## Why

`Path.Reset` cleared commands and points but left the previous bounds cache valid, so reusing a path could retain old geometry in `Bounds()`.

`Path.Append` and therefore `Context.SetPath` / `AppendPath` copied commands without merging the source bounds. `Path.Clone` similarly omitted bounds metadata. These cases could return empty or incomplete bounds and under-report frame damage even though drawing commands were present.

## Verification

- baseline Reset retains stale prior bounds
- baseline Append/SetPath/AppendPath omit appended geometry bounds
- baseline Clone reports empty bounds
- empty, non-empty, self-append, control-point, multi-subpath, and clone-isolation cases pass
- public frame-damage checks cover SetPath and AppendPath
- `go test -tags nogpu ./...`
- `go test -race -tags nogpu ./...`
- `go build ./...`
- `go vet ./...`
- `gofmt` and `git diff --check`

The default untagged suite still has known unrelated aliased-text, Bézier debug, and Metal-stencil failures, all reproduced on base `f9b3d62`; the full `nogpu` race suite is green locally and in CI.

