### PR TITLE
fix(recording): replay stroked rectangles

### DIFF
--- a/recording/backends/raster/backend_test.go
+++ b/recording/backends/raster/backend_test.go
@@ -3,6 +3,7 @@ package raster
 import (
 	"bytes"
 	"image"
+	"math"
 	"testing"
 
 	"github.com/gogpu/gg"
@@ -449,6 +450,85 @@ func TestRecordingPlaybackViaRegistry(t *testing.T) {
 	pixel := rgba.RGBAAt(50, 50)
 	if pixel.G < 200 || pixel.R > 50 || pixel.B > 50 {
 		t.Errorf("pixel = %v, expected green", pixel)
+	}
+}
+
+func TestRecordingPlaybackStrokeRectangle(t *testing.T) {
+	rec := recording.NewRecorder(100, 100)
+	rec.SetStrokeRGB(1, 0, 0)
+	rec.SetLineWidth(4)
+	rec.StrokeRectangle(20, 20, 60, 60)
+
+	backend := NewBackend()
+	if err := rec.FinishRecording().Playback(backend); err != nil {
+		t.Fatalf("Playback failed: %v", err)
+	}
+
+	rgba, ok := backend.Image().(*image.RGBA)
+	if !ok {
+		t.Fatal("expected *image.RGBA")
+	}
+	if pixel := rgba.RGBAAt(20, 50); pixel.R < 200 || pixel.G > 50 || pixel.B > 50 || pixel.A == 0 {
+		t.Fatalf("left rectangle edge pixel = %v, want opaque red", pixel)
+	}
+	if pixel := rgba.RGBAAt(50, 50); pixel.A != 0 {
+		t.Fatalf("rectangle interior pixel = %v, want transparent", pixel)
+	}
+}
+
+func TestRecordingPlaybackStrokeRectangleMatchesDirect(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		x, y, width, height float64
+		transform           recording.Matrix
+	}{
+		{name: "translation", x: 20, y: 20, width: 60, height: 50, transform: recording.Translate(10, 15)},
+		{name: "positive nonuniform scale", x: 20, y: 20, width: 50, height: 60, transform: recording.Matrix{A: 1.5, C: 5, E: 0.75, F: 10}},
+		{name: "scale down", x: 20, y: 20, width: 80, height: 80, transform: recording.Matrix{A: 0.5, C: 10, E: 0.75, F: 10}},
+		{name: "zero scale", x: 20, y: 20, width: 80, height: 80, transform: recording.Matrix{C: 90, F: 90}},
+		{name: "rotation", x: -30, y: -20, width: 60, height: 40, transform: recording.Translate(90, 90).Multiply(recording.Rotate(math.Pi / 4))},
+		{name: "shear", x: 10, y: 10, width: 60, height: 50, transform: recording.Translate(20, 20).Multiply(recording.Shear(0.4, 0.2))},
+		{name: "reflection", x: 20, y: 20, width: 60, height: 50, transform: recording.Translate(130, 0).Multiply(recording.Scale(-1, 1))},
+		{name: "negative width", x: 80, y: 20, width: -60, height: 60, transform: recording.Identity()},
+		{name: "negative height", x: 20, y: 80, width: 60, height: -60, transform: recording.Identity()},
+		{name: "negative width and height", x: 80, y: 80, width: -60, height: -60, transform: recording.Identity()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			direct := gg.NewContext(180, 180)
+			direct.SetRGB(0, 0, 0)
+			direct.SetLineWidth(2)
+			direct.SetDash(11, 7)
+			direct.SetDashOffset(3)
+			direct.SetTransform(gg.Matrix{
+				A: tc.transform.A, B: tc.transform.B, C: tc.transform.C,
+				D: tc.transform.D, E: tc.transform.E, F: tc.transform.F,
+			})
+			direct.DrawRectangle(tc.x, tc.y, tc.width, tc.height)
+			if err := direct.Stroke(); err != nil {
+				t.Fatalf("direct Stroke failed: %v", err)
+			}
+
+			rec := recording.NewRecorder(180, 180)
+			rec.SetStrokeRGB(0, 0, 0)
+			rec.SetLineWidth(2)
+			rec.SetDash(11, 7)
+			rec.SetDashOffset(3)
+			rec.SetTransform(tc.transform)
+			rec.StrokeRectangle(tc.x, tc.y, tc.width, tc.height)
+			backend := NewBackend()
+			if err := rec.FinishRecording().Playback(backend); err != nil {
+				t.Fatalf("Playback failed: %v", err)
+			}
+
+			got, ok := backend.Image().(*image.RGBA)
+			if !ok {
+				t.Fatal("expected raster backend to return *image.RGBA")
+			}
+			want := direct.Image().(*image.RGBA)
+			if !bytes.Equal(got.Pix, want.Pix) {
+				t.Fatalf("recorded stroke differs from direct stroke for transform %#v and dimensions (%v,%v)", tc.transform, tc.width, tc.height)
+			}
+		})
 	}
 }
 

--- a/recording/recorder.go
+++ b/recording/recorder.go
@@ -171,6 +171,16 @@ func (r *Recording) Playback(backend Backend) error {
 		case FillRectCommand:
 			brush := r.resources.GetBrush(c.Brush)
 			backend.FillRect(c.Rect, brush)
+		case StrokeRectCommand:
+			brush := r.resources.GetBrush(c.Brush)
+			path := gg.BuildPath().Rect(c.Rect.MinX, c.Rect.MinY, c.Rect.Width(), c.Rect.Height()).Build()
+			// StrokeRectCommand stores world-space bounds. Isolate the identity
+			// transform so backends do not apply the recording transform twice,
+			// then restore their complete graphics state for later commands.
+			backend.Save()
+			backend.SetTransform(Identity())
+			backend.StrokePath(path, brush, c.Stroke)
+			backend.Restore()
 		case DrawImageCommand:
 			img := r.resources.GetImage(c.Image)
 			backend.DrawImage(img, c.SrcRect, c.DstRect, c.Options)
@@ -839,13 +849,6 @@ func (r *Recorder) FillRectangle(x, y, w, h float64) {
 
 // StrokeRectangle strokes a rectangle without adding it to the path.
 func (r *Recorder) StrokeRectangle(x, y, w, h float64) {
-	// Transform corners
-	x1, y1 := r.transform.TransformPoint(x, y)
-	x2, y2 := r.transform.TransformPoint(x+w, y+h)
-
-	rect := NewRectFromPoints(x1, y1, x2, y2)
-	brushRef := r.resources.AddBrush(r.strokeBrush)
-
 	stroke := Stroke{
 		Width:       r.lineWidth,
 		Cap:         r.lineCap,
@@ -854,6 +857,61 @@ func (r *Recorder) StrokeRectangle(x, y, w, h float64) {
 		DashPattern: r.dashPattern,
 		DashOffset:  r.dashOffset,
 	}
+	// Recorder paths contain world-space coordinates, while gg applies the
+	// current transform's scale to stroke metrics at draw time. Playback uses
+	// identity for those world-space paths, so capture the same metric scaling
+	// in the command. Dash lengths follow gg's current convention and scale
+	// only when the transform enlarges the path.
+	transformScale := r.transform.ScaleFactor()
+	if transformScale <= 0 {
+		transformScale = 1
+	}
+	stroke.Width *= transformScale
+	if transformScale > 1 && len(stroke.DashPattern) > 0 {
+		stroke.DashPattern = append([]float64(nil), stroke.DashPattern...)
+		for i := range stroke.DashPattern {
+			stroke.DashPattern[i] *= transformScale
+		}
+		stroke.DashOffset *= transformScale
+	}
+	brushRef := r.resources.AddBrush(r.strokeBrush)
+
+	// StrokeRectCommand stores only normalized world-space bounds, so it is
+	// exact only when translation is the complete transform and the input
+	// dimensions preserve the path's top-left start and clockwise traversal.
+	// Other transforms need all four transformed corners, especially for
+	// dashed strokes where traversal direction is observable.
+	translationOnly := r.transform.A == 1 && r.transform.B == 0 &&
+		r.transform.D == 0 && r.transform.E == 1
+	if w < 0 || h < 0 || !translationOnly {
+		path := gg.NewPath()
+		x1, y1 := r.transform.TransformPoint(x, y)
+		path.MoveTo(x1, y1)
+		x2, y2 := r.transform.TransformPoint(x+w, y)
+		path.LineTo(x2, y2)
+		x3, y3 := r.transform.TransformPoint(x+w, y+h)
+		path.LineTo(x3, y3)
+		x4, y4 := r.transform.TransformPoint(x, y+h)
+		path.LineTo(x4, y4)
+		path.Close()
+		pathRef := r.resources.AddPath(path)
+
+		// Isolate identity around the world-space path so every backend applies
+		// its coordinates and captured stroke metrics exactly once.
+		r.commands = append(r.commands,
+			SaveCommand{},
+			SetTransformCommand{Matrix: Identity()},
+			StrokePathCommand{Path: pathRef, Brush: brushRef, Stroke: stroke},
+			RestoreCommand{},
+		)
+		return
+	}
+
+	// Keep the compact representation for the common axis-aligned,
+	// traversal-preserving case.
+	x1, y1 := r.transform.TransformPoint(x, y)
+	x2, y2 := r.transform.TransformPoint(x+w, y+h)
+	rect := NewRectFromPoints(x1, y1, x2, y2)
 
 	r.commands = append(r.commands, StrokeRectCommand{
 		Rect:   rect,

--- a/recording/stroke_rect_playback_test.go
+++ b/recording/stroke_rect_playback_test.go
@@ -1,0 +1,392 @@
+package recording
+
+import (
+	"image"
+	"reflect"
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/text"
+)
+
+// strokeRectBackend records the geometry and style supplied by Playback. It
+// deliberately does not render anything, so this test exercises the recording
+// command-to-backend contract without depending on a particular renderer.
+type strokeRectBackend struct {
+	strokeCalls     int
+	saveCalls       int
+	restoreCalls    int
+	transform       Matrix
+	transformStack  []Matrix
+	strokeTransform Matrix
+	path            *gg.Path
+	brush           Brush
+	stroke          Stroke
+}
+
+func (b *strokeRectBackend) Begin(_, _ int) error {
+	b.transform = Identity()
+	return nil
+}
+func (b *strokeRectBackend) End() error { return nil }
+func (b *strokeRectBackend) Save() {
+	b.saveCalls++
+	b.transformStack = append(b.transformStack, b.transform)
+}
+func (b *strokeRectBackend) Restore() {
+	b.restoreCalls++
+	if len(b.transformStack) == 0 {
+		return
+	}
+	b.transform = b.transformStack[len(b.transformStack)-1]
+	b.transformStack = b.transformStack[:len(b.transformStack)-1]
+}
+func (b *strokeRectBackend) SetTransform(transform Matrix) { b.transform = transform }
+func (b *strokeRectBackend) SetClip(*gg.Path, FillRule) {
+}
+func (b *strokeRectBackend) ClearClip() {}
+func (b *strokeRectBackend) FillPath(*gg.Path, Brush, FillRule) {
+}
+func (b *strokeRectBackend) StrokePath(path *gg.Path, brush Brush, stroke Stroke) {
+	b.strokeCalls++
+	b.strokeTransform = b.transform
+	b.path = path.Clone()
+	b.brush = brush
+	b.stroke = stroke.Clone()
+}
+func (b *strokeRectBackend) FillRect(Rect, Brush) {}
+func (b *strokeRectBackend) DrawImage(image.Image, Rect, Rect, ImageOptions) {
+}
+func (b *strokeRectBackend) DrawText(string, float64, float64, text.Face, Brush) {
+}
+
+func TestRecordingPlaybackStrokeRectangle(t *testing.T) {
+	rec := NewRecorder(100, 100)
+	rec.SetStrokeRGB(0, 0, 1)
+	rec.SetLineWidth(3)
+	rec.SetLineCap(LineCapRound)
+	rec.SetLineJoin(LineJoinBevel)
+	rec.SetMiterLimit(7)
+	rec.SetDash(4, 2)
+	rec.Translate(10, 15)
+	rec.StrokeRectangle(5, 6, 20, 30)
+
+	backend := &strokeRectBackend{}
+	if err := rec.FinishRecording().Playback(backend); err != nil {
+		t.Fatalf("Playback failed: %v", err)
+	}
+	if backend.strokeCalls != 1 {
+		t.Fatalf("StrokePath calls = %d, want 1", backend.strokeCalls)
+	}
+	if backend.saveCalls != 1 || backend.restoreCalls != 1 {
+		t.Fatalf("backend state calls = Save %d, Restore %d; want one each", backend.saveCalls, backend.restoreCalls)
+	}
+	if backend.strokeTransform != Identity() {
+		t.Fatalf("stroke transform = %#v, want identity", backend.strokeTransform)
+	}
+	if got, want := backend.transform, Translate(10, 15); got != want {
+		t.Fatalf("transform after stroke = %#v, want restored %#v", got, want)
+	}
+
+	wantVerbs := []gg.PathVerb{gg.MoveTo, gg.LineTo, gg.LineTo, gg.LineTo, gg.Close}
+	if got := backend.path.Verbs(); !reflect.DeepEqual(got, wantVerbs) {
+		t.Fatalf("rectangle verbs = %v, want %v", got, wantVerbs)
+	}
+	wantCoords := []float64{15, 21, 35, 21, 35, 51, 15, 51}
+	if got := backend.path.Coords(); !reflect.DeepEqual(got, wantCoords) {
+		t.Fatalf("rectangle coordinates = %v, want %v", got, wantCoords)
+	}
+	if got, want := backend.brush, NewSolidBrush(gg.Blue); got != want {
+		t.Fatalf("brush = %#v, want %#v", got, want)
+	}
+	wantStroke := Stroke{
+		Width:       3,
+		Cap:         LineCapRound,
+		Join:        LineJoinBevel,
+		MiterLimit:  7,
+		DashPattern: []float64{4, 2},
+		DashOffset:  0,
+	}
+	if !reflect.DeepEqual(backend.stroke, wantStroke) {
+		t.Fatalf("stroke = %#v, want %#v", backend.stroke, wantStroke)
+	}
+}
+
+func TestRecordingPlaybackTransformedStrokeRectangleRestoresBackendState(t *testing.T) {
+	transform := Matrix{A: 0, B: -1, C: 100, D: 1, E: 0}
+	rec := NewRecorder(100, 100)
+	rec.SetTransform(transform)
+	rec.StrokeRectangle(10, 20, 30, 40)
+
+	backend := &strokeRectBackend{}
+	if err := rec.FinishRecording().Playback(backend); err != nil {
+		t.Fatalf("Playback failed: %v", err)
+	}
+	if backend.strokeCalls != 1 {
+		t.Fatalf("StrokePath calls = %d, want 1", backend.strokeCalls)
+	}
+	if backend.saveCalls != 1 || backend.restoreCalls != 1 {
+		t.Fatalf("backend state calls = Save %d, Restore %d; want one each", backend.saveCalls, backend.restoreCalls)
+	}
+	if backend.strokeTransform != Identity() {
+		t.Fatalf("stroke transform = %#v, want identity", backend.strokeTransform)
+	}
+	if backend.transform != transform {
+		t.Fatalf("transform after stroke = %#v, want restored %#v", backend.transform, transform)
+	}
+}
+
+func assertStrokePathCommand(t *testing.T, r *Recording, drawing Command, wantStroke Stroke, wantCoords []float64) {
+	t.Helper()
+
+	cmd, ok := drawing.(StrokePathCommand)
+	if !ok {
+		t.Fatalf("drawing command = %T, want StrokePathCommand", drawing)
+	}
+	if cmd.Brush != BrushRef(1) {
+		t.Errorf("stroke brush ref = %d, want 1", cmd.Brush)
+	}
+	if !reflect.DeepEqual(cmd.Stroke, wantStroke) {
+		t.Errorf("stroke style = %#v, want %#v", cmd.Stroke, wantStroke)
+	}
+	if got, want := r.Resources().PathCount(), 1; got != want {
+		t.Fatalf("path count = %d, want %d", got, want)
+	}
+	path := r.Resources().GetPath(cmd.Path)
+	wantVerbs := []gg.PathVerb{gg.MoveTo, gg.LineTo, gg.LineTo, gg.LineTo, gg.Close}
+	if got := path.Verbs(); !reflect.DeepEqual(got, wantVerbs) {
+		t.Errorf("path verbs = %v, want %v", got, wantVerbs)
+	}
+	if got := path.Coords(); !reflect.DeepEqual(got, wantCoords) {
+		t.Errorf("path coordinates = %v, want %v", got, wantCoords)
+	}
+
+	var drawingIndex = -1
+	for i, recorded := range r.Commands() {
+		if _, ok := recorded.(StrokePathCommand); ok {
+			drawingIndex = i
+			break
+		}
+	}
+	if drawingIndex < 2 || drawingIndex+1 >= len(r.Commands()) {
+		t.Fatalf("stroke path at command %d is missing its state wrapper", drawingIndex)
+	}
+	if _, ok := r.Commands()[drawingIndex-2].(SaveCommand); !ok {
+		t.Errorf("command before identity transform = %T, want SaveCommand", r.Commands()[drawingIndex-2])
+	}
+	transform, ok := r.Commands()[drawingIndex-1].(SetTransformCommand)
+	if !ok || transform.Matrix != Identity() {
+		t.Errorf("command before stroke path = %#v, want identity SetTransformCommand", r.Commands()[drawingIndex-1])
+	}
+	if _, ok := r.Commands()[drawingIndex+1].(RestoreCommand); !ok {
+		t.Errorf("command after stroke path = %T, want RestoreCommand", r.Commands()[drawingIndex+1])
+	}
+}
+
+func assertStrokeRectCommand(t *testing.T, r *Recording, drawing Command, wantStroke Stroke, wantRect Rect) {
+	t.Helper()
+
+	cmd, ok := drawing.(StrokeRectCommand)
+	if !ok {
+		t.Fatalf("drawing command = %T, want StrokeRectCommand", drawing)
+	}
+	if cmd.Brush != BrushRef(1) {
+		t.Errorf("stroke brush ref = %d, want 1", cmd.Brush)
+	}
+	if cmd.Rect != wantRect {
+		t.Errorf("rectangle = %#v, want %#v", cmd.Rect, wantRect)
+	}
+	if !reflect.DeepEqual(cmd.Stroke, wantStroke) {
+		t.Errorf("stroke style = %#v, want %#v", cmd.Stroke, wantStroke)
+	}
+	if got := r.Resources().PathCount(); got != 0 {
+		t.Errorf("path count = %d, want 0", got)
+	}
+}
+
+func TestRecorderStrokeRectangleCommandEncoding(t *testing.T) {
+	wantBrush := NewSolidBrush(gg.Blue)
+	wantStroke := Stroke{
+		Width:       2.5,
+		Cap:         LineCapRound,
+		Join:        LineJoinBevel,
+		MiterLimit:  6,
+		DashPattern: []float64{4, 3},
+		DashOffset:  1.5,
+	}
+	tests := []struct {
+		name         string
+		x, y, w, h   float64
+		transform    Matrix
+		setTransform bool
+		wantPath     bool
+		wantRect     Rect
+		wantCoords   []float64
+	}{
+		{
+			name:     "positive dimensions use optimized command",
+			x:        10,
+			y:        20,
+			w:        30,
+			h:        40,
+			wantRect: NewRect(10, 20, 30, 40),
+		},
+		{
+			name:     "zero width stays optimized",
+			x:        10,
+			y:        20,
+			w:        0,
+			h:        40,
+			wantRect: NewRect(10, 20, 0, 40),
+		},
+		{
+			name:      "translation stays optimized",
+			x:         10,
+			y:         20,
+			w:         30,
+			h:         40,
+			transform: Translate(5, 7),
+			wantRect:  NewRect(15, 27, 30, 40),
+		},
+		{
+			name:       "positive axis scale preserves stroke metrics",
+			x:          10,
+			y:          20,
+			w:          30,
+			h:          40,
+			transform:  Matrix{A: 2, E: 0.5, C: 5, F: 7},
+			wantPath:   true,
+			wantCoords: []float64{25, 17, 85, 17, 85, 37, 25, 37},
+		},
+		{
+			name:         "zero scale keeps unscaled stroke metrics",
+			x:            10,
+			y:            20,
+			w:            30,
+			h:            40,
+			transform:    Matrix{C: 90, F: 90},
+			setTransform: true,
+			wantPath:     true,
+			wantCoords:   []float64{90, 90, 90, 90, 90, 90, 90, 90},
+		},
+		{
+			name:       "negative width preserves path direction",
+			x:          40,
+			y:          20,
+			w:          -30,
+			h:          40,
+			wantPath:   true,
+			wantCoords: []float64{40, 20, 10, 20, 10, 60, 40, 60},
+		},
+		{
+			name:       "negative height preserves path direction",
+			x:          10,
+			y:          60,
+			w:          30,
+			h:          -40,
+			wantPath:   true,
+			wantCoords: []float64{10, 60, 40, 60, 40, 20, 10, 20},
+		},
+		{
+			name:       "negative width and height preserve path direction",
+			x:          40,
+			y:          60,
+			w:          -30,
+			h:          -40,
+			wantPath:   true,
+			wantCoords: []float64{40, 60, 10, 60, 10, 20, 40, 20},
+		},
+		{
+			name:       "rotation preserves all transformed corners",
+			x:          10,
+			y:          20,
+			w:          30,
+			h:          40,
+			transform:  Matrix{A: 0, B: -1, C: 100, D: 1, E: 0},
+			wantPath:   true,
+			wantCoords: []float64{80, 10, 80, 40, 40, 40, 40, 10},
+		},
+		{
+			name:       "shear preserves all transformed corners",
+			x:          10,
+			y:          20,
+			w:          30,
+			h:          40,
+			transform:  Matrix{A: 1, B: 0.5, D: 0.25, E: 1},
+			wantPath:   true,
+			wantCoords: []float64{20, 22.5, 50, 30, 70, 70, 40, 62.5},
+		},
+		{
+			name:       "reflection preserves path direction",
+			x:          10,
+			y:          20,
+			w:          30,
+			h:          40,
+			transform:  Matrix{A: -1, C: 100, E: 1},
+			wantPath:   true,
+			wantCoords: []float64{90, 20, 60, 20, 60, 60, 90, 60},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := NewRecorder(100, 100)
+			rec.SetStrokeStyle(wantBrush)
+			rec.SetLineWidth(wantStroke.Width)
+			rec.SetLineCap(wantStroke.Cap)
+			rec.SetLineJoin(wantStroke.Join)
+			rec.SetMiterLimit(wantStroke.MiterLimit)
+			rec.SetDash(wantStroke.DashPattern...)
+			rec.SetDashOffset(wantStroke.DashOffset)
+			transform := tt.transform
+			if transform == (Matrix{}) && !tt.setTransform {
+				transform = Identity()
+			} else {
+				rec.SetTransform(transform)
+			}
+			rec.StrokeRectangle(tt.x, tt.y, tt.w, tt.h)
+
+			r := rec.FinishRecording()
+			if got, want := r.Resources().BrushCount(), 2; got != want {
+				t.Fatalf("brush count = %d, want %d", got, want)
+			}
+			if got := r.Resources().GetBrush(BrushRef(1)); got != wantBrush {
+				t.Fatalf("stroke brush resource = %#v, want %#v", got, wantBrush)
+			}
+
+			var drawing Command
+			for _, cmd := range r.Commands() {
+				switch cmd.(type) {
+				case StrokeRectCommand, StrokePathCommand:
+					if drawing != nil {
+						t.Fatal("recorded more than one rectangle drawing command")
+					}
+					drawing = cmd
+				}
+			}
+			if drawing == nil {
+				t.Fatal("missing rectangle drawing command")
+			}
+
+			wantCommandStroke := wantStroke.Clone()
+			transformScale := transform.ScaleFactor()
+			if transformScale <= 0 {
+				transformScale = 1
+			}
+			wantCommandStroke.Width *= transformScale
+			if transformScale > 1 {
+				for i := range wantCommandStroke.DashPattern {
+					wantCommandStroke.DashPattern[i] *= transformScale
+				}
+				wantCommandStroke.DashOffset *= transformScale
+			}
+
+			if tt.wantPath {
+				assertStrokePathCommand(t, r, drawing, wantCommandStroke, tt.wantCoords)
+				return
+			}
+
+			assertStrokeRectCommand(t, r, drawing, wantCommandStroke, tt.wantRect)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- replay recorded `StrokeRectCommand` values through the backend's common `StrokePath` contract
- preserve brush, width, cap, join, miter, dash pattern, and dash offset
- isolate world-space playback under the identity transform and restore backend state afterward
- preserve exact four-corner geometry and dashed traversal for negative dimensions, rotation, shear, scale, and reflection
- capture transform-dependent stroke width and dash metrics using the same scaling convention as `gg.Context`
- add fake-backend contract tests and direct-vs-recorded raster regressions

## Why

`Recorder.StrokeRectangle` emitted `StrokeRectCommand`, but `Recording.Playback` had no switch branch for that command. Every recorded stroked rectangle therefore disappeared during playback on every backend.

The compact rectangle command stores normalized world-space bounds. That representation is exact only for nonnegative rectangles under identity/translation transforms. Normalization loses traversal direction for negative dimensions and reflections, while two diagonal corners cannot represent rotated or sheared rectangles. Those cases now use an exact transformed four-corner path. The command stream temporarily selects identity while replaying world-space geometry and then restores the backend state. Transform scale is captured in stroke width and, where `gg.Context` scales them, dash lengths and offset.

## Verification

- direct-vs-recorded raster parity for translation, scale up/down/zero, rotation, shear, reflection, and all signed-dimension combinations
- command-contract coverage for compact and exact-path encodings, style capture, identity isolation, and transform restoration
- `go test ./recording/... -count=1`
- `go test -race -tags nogpu ./recording/... -count=1`
- `go test -race -tags nogpu -coverprofile=/tmp/gg498-coverage.txt -covermode=atomic ./...`
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go build ./examples/...`
- `CGO_ENABLED=0 go build ./cmd/ggdemo`
- `CGO_ENABLED=0 go vet ./...`
- `gofmt` and `git diff --check`

- [GitHub Actions CI run 31436577909](https://github.com/gogpu/gg/actions/runs/31436577909): all 10 jobs pass
- Codecov patch coverage: 100% (41 hits, 0 misses, 0 partials)
