### PR TITLE
fix(recording): apply raster clip regions

### DIFF
--- a/context.go
+++ b/context.go
@@ -41,7 +41,7 @@ type Context struct {
 	matrix         Matrix // user transform (starts as Identity, user-space only)
 	deviceMatrix   Matrix // device scale transform (Identity when scale=1.0, NEVER modified by user)
 	stack          []Matrix
-	clipStackDepth []int // Tracks clip stack depth for each Push/Pop
+	clipStateStack []contextClipState
 
 	// Layer support
 	layerStack *layerStack // Layer stack for compositing
@@ -88,6 +88,11 @@ type Context struct {
 
 	// Lifecycle
 	closed bool // Indicates whether Close has been called
+}
+
+type contextClipState struct {
+	stack       *clip.ClipStack
+	gpuClipPath *Path
 }
 
 // Ensure Context implements io.Closer
@@ -178,7 +183,7 @@ func NewContext(width, height int, opts ...ContextOption) *Context {
 		matrix:                Identity(),
 		deviceMatrix:          deviceMatrix,
 		stack:                 make([]Matrix, 0, 8),
-		clipStackDepth:        make([]int, 0, 8),
+		clipStateStack:        make([]contextClipState, 0, 8),
 		pipelineMode:          options.pipelineMode,
 		damageTrackingEnabled: true,
 		antiAlias:             true,
@@ -217,7 +222,7 @@ func NewContextForImage(img image.Image, opts ...ContextOption) *Context {
 		matrix:         Identity(),
 		deviceMatrix:   Identity(),
 		stack:          make([]Matrix, 0, 8),
-		clipStackDepth: make([]int, 0, 8),
+		clipStateStack: make([]contextClipState, 0, 8),
 		pipelineMode:   options.pipelineMode,
 	}
 }
@@ -275,7 +280,7 @@ func (c *Context) Close() error {
 
 	// Clear state stack
 	c.stack = nil
-	c.clipStackDepth = nil
+	c.clipStateStack = nil
 	c.maskStack = nil
 	c.mask = nil
 	c.gpuClipPath = nil
@@ -454,6 +459,7 @@ func (c *Context) SetDeviceScale(scale float64) {
 	// Reset clip stack (clip regions are in pixel coordinates)
 	c.clipStack = nil
 	c.gpuClipPath = nil
+	clear(c.clipStateStack)
 	c.ClearPath()
 }
 
@@ -926,12 +932,12 @@ func (c *Context) StrokePreserve() error {
 func (c *Context) Push() {
 	c.stack = append(c.stack, c.matrix)
 
-	// Save current clip stack depth
-	depth := 0
-	if c.clipStack != nil {
-		depth = c.clipStack.Depth()
-	}
-	c.clipStackDepth = append(c.clipStackDepth, depth)
+	// Save an independent clip stack so ResetClip and replacement clips inside
+	// the saved scope cannot destroy the state that Pop must restore.
+	c.clipStateStack = append(c.clipStateStack, contextClipState{
+		stack:       c.clipStack.Clone(),
+		gpuClipPath: c.gpuClipPath,
+	})
 
 	// Save current mask (clone if exists)
 	var maskCopy *Mask
@@ -958,21 +964,13 @@ func (c *Context) Pop() {
 	c.matrix = c.stack[len(c.stack)-1]
 	c.stack = c.stack[:len(c.stack)-1]
 
-	// Restore clip stack depth
-	if len(c.clipStackDepth) > 0 {
-		targetDepth := c.clipStackDepth[len(c.clipStackDepth)-1]
-		c.clipStackDepth = c.clipStackDepth[:len(c.clipStackDepth)-1]
-
-		// Pop clip stack entries until we reach the target depth
-		if c.clipStack != nil {
-			for c.clipStack.Depth() > targetDepth {
-				c.clipStack.Pop()
-			}
-			// Clear GPU clip path if all path clips were popped.
-			if c.gpuClipPath != nil && c.clipStack.IsRRectOnly() {
-				c.gpuClipPath = nil
-			}
-		}
+	// Restore the complete saved clip state. Restoring only a depth is not
+	// sufficient after ResetClip, which removes the entries themselves.
+	if len(c.clipStateStack) > 0 {
+		state := c.clipStateStack[len(c.clipStateStack)-1]
+		c.clipStateStack = c.clipStateStack[:len(c.clipStateStack)-1]
+		c.clipStack = state.stack
+		c.gpuClipPath = state.gpuClipPath
 	}
 
 	// Restore mask
@@ -1322,6 +1320,7 @@ func (c *Context) Resize(width, height int) error {
 	// Reset clip stack to full rectangle
 	c.clipStack = nil
 	c.gpuClipPath = nil
+	clear(c.clipStateStack)
 
 	// Clear any existing path
 	c.ClearPath()

--- a/context_clip.go
+++ b/context_clip.go
@@ -20,7 +20,7 @@ func (c *Context) Clip() {
 	clipVerbs, clipCoords := ConvertPathToClipVerbs(devicePath)
 
 	// Push the path as a clip region
-	_ = c.clipStack.PushPath(clipVerbs, clipCoords, true) // anti-aliased by default
+	_ = c.clipStack.PushPathWithRule(clipVerbs, clipCoords, true, clipFillRule(c.paint.FillRule)) // anti-aliased by default
 
 	// Store the device-space path for GPU depth clipping (GPU-CLIP-003a).
 	// The GPU DepthClipPipeline fan-tessellates this path at draw time.
@@ -43,11 +43,18 @@ func (c *Context) ClipPreserve() {
 	clipVerbs, clipCoords := ConvertPathToClipVerbs(devicePath)
 
 	// Push the path as a clip region
-	_ = c.clipStack.PushPath(clipVerbs, clipCoords, true) // anti-aliased by default
+	_ = c.clipStack.PushPathWithRule(clipVerbs, clipCoords, true, clipFillRule(c.paint.FillRule)) // anti-aliased by default
 
 	// Store the device-space path for GPU depth clipping (GPU-CLIP-003a).
 	c.gpuClipPath = devicePath.Clone()
 	// Path is preserved
+}
+
+func clipFillRule(rule FillRule) clip.FillRule {
+	if rule == FillRuleEvenOdd {
+		return clip.FillRuleEvenOdd
+	}
+	return clip.FillRuleNonZero
 }
 
 // ClipRect sets a rectangular clipping region.

--- a/context_clip_test.go
+++ b/context_clip_test.go
@@ -29,6 +29,59 @@ func TestClip(t *testing.T) {
 	}
 }
 
+func TestClipPathFillRule(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		rule       FillRule
+		centerDraw bool
+	}{
+		{name: "non-zero", rule: FillRuleNonZero, centerDraw: true},
+		{name: "even-odd", rule: FillRuleEvenOdd, centerDraw: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := NewContext(100, 100)
+			dc.SetFillRule(tc.rule)
+			dc.DrawRectangle(10, 10, 80, 80)
+			dc.DrawRectangle(30, 30, 40, 40)
+			dc.Clip()
+			dc.SetRGB(1, 0, 0)
+			dc.DrawRectangle(0, 0, 100, 100)
+			if err := dc.Fill(); err != nil {
+				t.Fatalf("Fill: %v", err)
+			}
+
+			center := dc.pixmap.GetPixel(50, 50)
+			if tc.centerDraw && center.A < 0.9 {
+				t.Errorf("non-zero center alpha = %.2f, want opaque", center.A)
+			}
+			if !tc.centerDraw && center.A > 0.1 {
+				t.Errorf("even-odd center alpha = %.2f, want transparent", center.A)
+			}
+		})
+	}
+}
+
+func TestClipPreservePathFillRule(t *testing.T) {
+	dc := NewContext(100, 100)
+	dc.SetFillRule(FillRuleEvenOdd)
+	dc.DrawRectangle(10, 10, 80, 80)
+	dc.DrawRectangle(30, 30, 40, 40)
+	dc.ClipPreserve()
+	if dc.path.NumVerbs() == 0 {
+		t.Fatal("ClipPreserve cleared the current path")
+	}
+
+	dc.ClearPath()
+	dc.SetRGB(1, 0, 0)
+	dc.DrawRectangle(0, 0, 100, 100)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill: %v", err)
+	}
+	if center := dc.pixmap.GetPixel(50, 50); center.A > 0.1 {
+		t.Errorf("even-odd ClipPreserve center alpha = %.2f, want transparent", center.A)
+	}
+}
+
 func TestClipPreserve(t *testing.T) {
 	dc := NewContext(100, 100)
 
@@ -133,8 +186,8 @@ func TestClipWithPushPop(t *testing.T) {
 
 	// Pop should restore to depth 0
 	dc.Pop()
-	if dc.clipStack.Depth() != 0 {
-		t.Errorf("Expected clip depth 0 after second Pop(), got %d", dc.clipStack.Depth())
+	if dc.clipStack != nil {
+		t.Errorf("Expected nil clip stack after second Pop(), got depth %d", dc.clipStack.Depth())
 	}
 }
 
@@ -565,6 +618,37 @@ func TestClipPathClearedOnResetClip(t *testing.T) {
 	dc.ResetClip()
 	if dc.gpuClipPath != nil {
 		t.Error("gpuClipPath should be nil after ResetClip")
+	}
+}
+
+func TestClipResetRestoredByPop(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.DrawCircle(100, 100, 50)
+	dc.Clip()
+	wantPathBounds := dc.gpuClipPath.Bounds()
+
+	dc.Push()
+	dc.ClipRect(75, 75, 50, 50)
+	dc.Push()
+	dc.ResetClip()
+	if dc.clipStack.Depth() != 0 || dc.gpuClipPath != nil {
+		t.Fatal("ResetClip() should clear the active clip state")
+	}
+
+	dc.Pop()
+	if got := dc.clipStack.Depth(); got != 2 {
+		t.Fatalf("clip depth after inner Pop() = %d, want 2", got)
+	}
+	if dc.gpuClipPath == nil || dc.gpuClipPath.Bounds() != wantPathBounds {
+		t.Fatal("inner Pop() did not restore the saved GPU clip path")
+	}
+
+	dc.Pop()
+	if got := dc.clipStack.Depth(); got != 1 {
+		t.Fatalf("clip depth after outer Pop() = %d, want 1", got)
+	}
+	if dc.gpuClipPath == nil || dc.gpuClipPath.Bounds() != wantPathBounds {
+		t.Fatal("outer Pop() did not restore the original GPU clip path")
 	}
 }
 

--- a/context_resize_test.go
+++ b/context_resize_test.go
@@ -169,3 +169,46 @@ func TestContextResizeResetsClip(t *testing.T) {
 		t.Error("Resize should reset clip stack")
 	}
 }
+
+func TestContextSurfaceChangeInvalidatesSavedClips(t *testing.T) {
+	tests := []struct {
+		name   string
+		change func(*testing.T, *Context)
+	}{
+		{
+			name: "resize",
+			change: func(t *testing.T, ctx *Context) {
+				t.Helper()
+				if err := ctx.Resize(200, 200); err != nil {
+					t.Fatalf("Resize() error = %v", err)
+				}
+			},
+		},
+		{
+			name: "device scale",
+			change: func(_ *testing.T, ctx *Context) {
+				ctx.SetDeviceScale(2)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := NewContext(100, 100)
+			defer func() { _ = ctx.Close() }()
+
+			ctx.ClipRect(10, 10, 80, 80)
+			ctx.Push()
+			tc.change(t, ctx)
+			ctx.ClipRect(20, 20, 20, 20)
+			ctx.Pop()
+
+			if ctx.clipStack != nil {
+				t.Fatalf("surface change and Pop() restored a clip stack with depth %d", ctx.clipStack.Depth())
+			}
+			if ctx.gpuClipPath != nil {
+				t.Fatal("surface change and Pop() restored a stale GPU clip path")
+			}
+		})
+	}
+}

--- a/internal/clip/fill_rule.go
+++ b/internal/clip/fill_rule.go
@@ -1,0 +1,12 @@
+package clip
+
+// FillRule controls how a path is converted to a clip mask.
+//
+// The values intentionally mirror gg.FillRule without importing the parent
+// package (which would create an import cycle).
+type FillRule uint8
+
+const (
+	FillRuleNonZero FillRule = iota
+	FillRuleEvenOdd
+)

--- a/internal/clip/mask.go
+++ b/internal/clip/mask.go
@@ -27,6 +27,7 @@ const (
 type MaskClipper struct {
 	mask   *image.ImageBuf
 	bounds Rect
+	rule   FillRule
 }
 
 // NewMaskClipper creates a mask clipper by rasterizing the given path
@@ -40,6 +41,11 @@ type MaskClipper struct {
 //
 // The mask is stored as FormatGray8 (1 byte per pixel) for memory efficiency.
 func NewMaskClipper(verbs []PathVerb, coords []float64, bounds Rect, antiAlias bool) (*MaskClipper, error) {
+	return NewMaskClipperWithRule(verbs, coords, bounds, antiAlias, FillRuleNonZero)
+}
+
+// NewMaskClipperWithRule creates a mask clipper using the requested fill rule.
+func NewMaskClipperWithRule(verbs []PathVerb, coords []float64, bounds Rect, antiAlias bool, rule FillRule) (*MaskClipper, error) {
 	// Validate bounds - empty bounds means no clipping needed
 	if bounds.IsEmpty() {
 		return nil, image.ErrInvalidDimensions
@@ -61,6 +67,7 @@ func NewMaskClipper(verbs []PathVerb, coords []float64, bounds Rect, antiAlias b
 	mc := &MaskClipper{
 		mask:   mask,
 		bounds: bounds,
+		rule:   rule,
 	}
 
 	// Rasterize path into mask
@@ -132,24 +139,30 @@ func (mc *MaskClipper) rasterizePath(verbs []PathVerb, coords []float64, antiAli
 		return
 	}
 
-	// Flatten path to line segments
-	points := mc.flattenPath(verbs, coords)
-	if len(points) < 2 {
+	// Flatten path to line segments. Keep each subpath separate so that an
+	// implicit move between subpaths cannot become a spurious connecting edge.
+	subpaths := mc.flattenPath(verbs, coords)
+	if len(subpaths) == 0 {
 		return
 	}
 
 	// Build edge list for scanline rasterization
-	edges := make([]edge, 0, len(points))
-	for i := 0; i < len(points)-1; i++ {
-		p0 := points[i]
-		p1 := points[i+1]
-
-		// Skip horizontal edges
-		if p1.Y == p0.Y {
+	edges := make([]edge, 0)
+	for _, points := range subpaths {
+		if len(points) < 2 {
 			continue
 		}
+		for i := 0; i < len(points)-1; i++ {
+			p0 := points[i]
+			p1 := points[i+1]
 
-		edges = append(edges, mc.makeEdge(p0, p1))
+			// Skip horizontal edges
+			if p1.Y == p0.Y {
+				continue
+			}
+
+			edges = append(edges, mc.makeEdge(p0, p1))
+		}
 	}
 
 	if len(edges) == 0 {
@@ -173,6 +186,15 @@ type edge struct {
 	x0, y0 float64 // Start point
 	x1, y1 float64 // End point
 	dir    int     // Direction: +1 for down, -1 for up
+}
+
+type intersection struct {
+	x   float64
+	dir int
+}
+
+type span struct {
+	x1, x2 float64
 }
 
 // makeEdge creates an edge from two points, ensuring y0 < y1.
@@ -206,23 +228,23 @@ func (mc *MaskClipper) rasterizeScanlineAA(edges []edge, y int) {
 		scanY := float64(y) + off
 
 		// Find edge intersections at this sub-scanline.
-		var intersections []float64
+		intersections := make([]intersection, 0, len(edges))
 		for _, e := range edges {
 			if e.y0 <= scanY && scanY < e.y1 {
 				t := (scanY - e.y0) / (e.y1 - e.y0)
 				x := e.x0 + t*(e.x1-e.x0)
-				intersections = append(intersections, x)
+				intersections = append(intersections, intersection{x: x, dir: e.dir})
 			}
 		}
 		if len(intersections) == 0 {
 			continue
 		}
-		sortFloats(intersections)
+		sortIntersections(intersections)
 
 		// Fill spans with fractional edge coverage.
-		for i := 0; i+1 < len(intersections); i += 2 {
-			x1 := intersections[i]
-			x2 := intersections[i+1]
+		for _, s := range spans(intersections, mc.rule) {
+			x1 := s.x1
+			x2 := s.x2
 
 			px1 := int(x1)
 			px2 := int(x2)
@@ -288,18 +310,18 @@ func (mc *MaskClipper) rasterizeScanlineAA(edges []edge, y int) {
 	}
 }
 
-// rasterizeScanline fills a single scanline using the non-zero winding rule.
+// rasterizeScanline fills a single scanline using the configured fill rule.
 func (mc *MaskClipper) rasterizeScanline(edges []edge, y int) {
 	scanY := float64(y) + 0.5
 
 	// Find edges that intersect this scanline
-	var intersections []float64
+	intersections := make([]intersection, 0, len(edges))
 	for _, e := range edges {
 		if e.y0 <= scanY && scanY < e.y1 {
 			// Compute x intersection
 			t := (scanY - e.y0) / (e.y1 - e.y0)
 			x := e.x0 + t*(e.x1-e.x0)
-			intersections = append(intersections, x)
+			intersections = append(intersections, intersection{x: x, dir: e.dir})
 		}
 	}
 
@@ -308,12 +330,11 @@ func (mc *MaskClipper) rasterizeScanline(edges []edge, y int) {
 	}
 
 	// Sort intersections
-	sortFloats(intersections)
+	sortIntersections(intersections)
 
-	// Fill spans using even-odd rule (pairs of intersections)
-	for i := 0; i+1 < len(intersections); i += 2 {
-		x1 := intersections[i]
-		x2 := intersections[i+1]
+	for _, s := range spans(intersections, mc.rule) {
+		x1 := s.x1
+		x2 := s.x2
 
 		// Convert to pixel coordinates
 		px1 := int(x1)
@@ -334,16 +355,37 @@ func (mc *MaskClipper) rasterizeScanline(edges []edge, y int) {
 	}
 }
 
-// flattenPath converts path (verb+coords) into a sequence of points.
-func (mc *MaskClipper) flattenPath(verbs []PathVerb, coords []float64) []Point {
+// flattenPath converts path (verb+coords) into independent subpaths of points.
+// Keeping subpaths separate prevents the edge builder from joining a MoveTo
+// in one subpath to the preceding point in another subpath.
+func (mc *MaskClipper) flattenPath(verbs []PathVerb, coords []float64) [][]Point {
+	var subpaths [][]Point
 	var points []Point
 	var current Point
+	var subpathStart Point
 	ci := 0
+	closeSubpath := func() {
+		if len(points) > 0 && (current.X != subpathStart.X || current.Y != subpathStart.Y) {
+			points = append(points, subpathStart)
+			current = subpathStart
+		}
+	}
+	flush := func() {
+		if len(points) > 0 {
+			// Filling implicitly closes an open contour, just like the main
+			// rasterizer does at the next MoveTo and at end of path.
+			closeSubpath()
+			subpaths = append(subpaths, points)
+			points = nil
+		}
+	}
 
 	for _, v := range verbs {
 		switch v {
 		case VerbMoveTo:
+			flush()
 			current = Point{X: coords[ci], Y: coords[ci+1]}
+			subpathStart = current
 			points = append(points, current)
 			ci += 2
 
@@ -380,13 +422,12 @@ func (mc *MaskClipper) flattenPath(verbs []PathVerb, coords []float64) []Point {
 			ci += 6
 
 		case VerbClose:
-			if len(points) > 0 {
-				points = append(points, points[0])
-			}
+			closeSubpath()
 		}
 	}
 
-	return points
+	flush()
+	return subpaths
 }
 
 // evalQuadraticBezier evaluates a quadratic Bezier curve at parameter t.
@@ -411,7 +452,18 @@ func evalCubicBezier(p0, p1, p2, p3 Point, t float64) Point {
 	}
 }
 
-// sortFloats sorts a slice of float64 values (simple bubble sort for small slices).
+func sortIntersections(values []intersection) {
+	n := len(values)
+	for i := 0; i < n-1; i++ {
+		for j := 0; j < n-i-1; j++ {
+			if values[j].x > values[j+1].x {
+				values[j], values[j+1] = values[j+1], values[j]
+			}
+		}
+	}
+}
+
+// sortFloats is retained for the package's raster helper tests.
 func sortFloats(values []float64) {
 	n := len(values)
 	for i := 0; i < n-1; i++ {
@@ -421,4 +473,29 @@ func sortFloats(values []float64) {
 			}
 		}
 	}
+}
+
+func spans(intersections []intersection, rule FillRule) []span {
+	result := make([]span, 0, len(intersections)/2)
+	if rule == FillRuleEvenOdd {
+		for i := 0; i+1 < len(intersections); i += 2 {
+			result = append(result, span{x1: intersections[i].x, x2: intersections[i+1].x})
+		}
+		return result
+	}
+
+	winding := 0
+	var start float64
+	for _, crossing := range intersections {
+		wasInside := winding != 0
+		winding += crossing.dir
+		isInside := winding != 0
+		switch {
+		case !wasInside && isInside:
+			start = crossing.x
+		case wasInside && !isInside:
+			result = append(result, span{x1: start, x2: crossing.x})
+		}
+	}
+	return result
 }

--- a/internal/clip/mask_fill_rule_test.go
+++ b/internal/clip/mask_fill_rule_test.go
@@ -1,0 +1,218 @@
+package clip
+
+import "testing"
+
+func TestMaskClipperFillRulesAcrossRasterModes(t *testing.T) {
+	for _, antiAlias := range []bool{false, true} {
+		for _, rule := range []FillRule{FillRuleNonZero, FillRuleEvenOdd} {
+			for _, reverseInner := range []bool{false, true} {
+				name := "nonzero"
+				if rule == FillRuleEvenOdd {
+					name = "evenodd"
+				}
+				if reverseInner {
+					name += "-reverse-inner"
+				}
+				t.Run(name+"/aa="+boolName(antiAlias), func(t *testing.T) {
+					verbs, coords := nestedRectPath(reverseInner)
+					mask, err := NewMaskClipperWithRule(verbs, coords, NewRect(0, 0, 100, 100), antiAlias, rule)
+					if err != nil {
+						t.Fatalf("NewMaskClipperWithRule: %v", err)
+					}
+					center := mask.Coverage(50, 50)
+					wantCenter := byte(0)
+					if rule == FillRuleNonZero && !reverseInner {
+						wantCenter = 255
+					}
+					if center != wantCenter {
+						t.Errorf("center coverage = %d, want %d", center, wantCenter)
+					}
+					if got := mask.Coverage(15, 50); got == 0 {
+						t.Errorf("outer-only coverage = %d, want non-zero", got)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestMaskClipperDefaultsToNonZero(t *testing.T) {
+	verbs, coords := nestedRectPath(false)
+	for _, antiAlias := range []bool{false, true} {
+		mask, err := NewMaskClipper(verbs, coords, NewRect(0, 0, 100, 100), antiAlias)
+		if err != nil {
+			t.Fatalf("NewMaskClipper(aa=%v): %v", antiAlias, err)
+		}
+		if got := mask.Coverage(50, 50); got == 0 {
+			t.Errorf("default center coverage (aa=%v) = %d, want non-zero", antiAlias, got)
+		}
+	}
+
+	stack := NewClipStack(NewRect(0, 0, 100, 100))
+	if err := stack.PushPath(verbs, coords, true); err != nil {
+		t.Fatalf("ClipStack.PushPath: %v", err)
+	}
+	if got := stack.Coverage(50, 50); got == 0 {
+		t.Errorf("default stack center coverage = %d, want non-zero", got)
+	}
+}
+
+func TestMaskClipperDegenerateSubpathsProduceEmptyMask(t *testing.T) {
+	tests := []struct {
+		name   string
+		verbs  []PathVerb
+		coords []float64
+	}{
+		{
+			name:  "close-without-subpath",
+			verbs: []PathVerb{VerbClose},
+		},
+		{
+			name:   "move-only-subpath",
+			verbs:  []PathVerb{VerbMoveTo},
+			coords: []float64{50, 50},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mask, err := NewMaskClipperWithRule(tc.verbs, tc.coords, NewRect(0, 0, 100, 100), true, FillRuleNonZero)
+			if err != nil {
+				t.Fatalf("NewMaskClipperWithRule: %v", err)
+			}
+			if got := mask.Coverage(50, 50); got != 0 {
+				t.Errorf("coverage = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestMaskClipperDuplicateXAndTouchingEdges(t *testing.T) {
+	paths := []struct {
+		name   string
+		verbs  []PathVerb
+		coords []float64
+	}{
+		{
+			name:   "duplicate-x",
+			verbs:  []PathVerb{VerbMoveTo, VerbLineTo, VerbLineTo, VerbClose, VerbMoveTo, VerbLineTo, VerbLineTo, VerbClose},
+			coords: []float64{10, 10, 50, 50, 10, 90, 50, 50, 90, 10, 90, 90},
+		},
+		{
+			name: "touching-edges",
+			verbs: []PathVerb{
+				VerbMoveTo, VerbLineTo, VerbLineTo, VerbLineTo, VerbClose,
+				VerbMoveTo, VerbLineTo, VerbLineTo, VerbLineTo, VerbClose,
+			},
+			coords: []float64{10, 10, 50, 10, 50, 90, 10, 90, 50, 10, 90, 10, 90, 90, 50, 90},
+		},
+	}
+
+	for _, tc := range paths {
+		t.Run(tc.name, func(t *testing.T) {
+			mask, err := NewMaskClipperWithRule(tc.verbs, tc.coords, NewRect(0, 0, 100, 100), true, FillRuleNonZero)
+			if err != nil {
+				t.Fatalf("NewMaskClipperWithRule: %v", err)
+			}
+			if got := mask.Coverage(25, 50); got == 0 {
+				t.Errorf("left coverage = %d, want non-zero", got)
+			}
+			if got := mask.Coverage(75, 50); got == 0 {
+				t.Errorf("right coverage = %d, want non-zero", got)
+			}
+		})
+	}
+}
+
+func TestMaskClipperDisjointSubpathsDoNotConnect(t *testing.T) {
+	verbs := []PathVerb{
+		VerbMoveTo, VerbLineTo, VerbLineTo, VerbLineTo, VerbClose,
+		VerbMoveTo, VerbLineTo, VerbLineTo, VerbLineTo, VerbClose,
+	}
+	coords := []float64{
+		10, 10, 30, 10, 30, 30, 10, 30,
+		70, 70, 90, 70, 90, 90, 70, 90,
+	}
+
+	for _, antiAlias := range []bool{false, true} {
+		for _, rule := range []FillRule{FillRuleNonZero, FillRuleEvenOdd} {
+			name := "nonzero"
+			if rule == FillRuleEvenOdd {
+				name = "evenodd"
+			}
+			t.Run(name+"/aa="+boolName(antiAlias), func(t *testing.T) {
+				mask, err := NewMaskClipperWithRule(verbs, coords, NewRect(0, 0, 100, 100), antiAlias, rule)
+				if err != nil {
+					t.Fatalf("NewMaskClipperWithRule: %v", err)
+				}
+				if got := mask.Coverage(20, 20); got == 0 {
+					t.Errorf("first subpath coverage = %d, want non-zero", got)
+				}
+				if got := mask.Coverage(80, 80); got == 0 {
+					t.Errorf("second subpath coverage = %d, want non-zero", got)
+				}
+				if got := mask.Coverage(50, 50); got != 0 {
+					t.Errorf("between-subpaths coverage = %d, want 0", got)
+				}
+			})
+		}
+	}
+}
+
+func TestMaskClipperImplicitlyClosesOpenSubpaths(t *testing.T) {
+	// Neither contour has a VerbClose. Fill semantics still close each contour
+	// independently at the following MoveTo and at end of path.
+	verbs := []PathVerb{
+		VerbMoveTo, VerbLineTo, VerbLineTo, VerbLineTo,
+		VerbMoveTo, VerbLineTo, VerbLineTo, VerbLineTo,
+	}
+	coords := []float64{
+		10, 10, 30, 10, 30, 30, 10, 30,
+		70, 70, 90, 70, 90, 90, 70, 90,
+	}
+
+	for _, antiAlias := range []bool{false, true} {
+		for _, rule := range []FillRule{FillRuleNonZero, FillRuleEvenOdd} {
+			name := "nonzero"
+			if rule == FillRuleEvenOdd {
+				name = "evenodd"
+			}
+			t.Run(name+"/aa="+boolName(antiAlias), func(t *testing.T) {
+				mask, err := NewMaskClipperWithRule(verbs, coords, NewRect(0, 0, 100, 100), antiAlias, rule)
+				if err != nil {
+					t.Fatalf("NewMaskClipperWithRule: %v", err)
+				}
+				if got := mask.Coverage(20, 20); got == 0 {
+					t.Errorf("first open subpath coverage = %d, want non-zero", got)
+				}
+				if got := mask.Coverage(80, 80); got == 0 {
+					t.Errorf("second open subpath coverage = %d, want non-zero", got)
+				}
+				if got := mask.Coverage(50, 50); got != 0 {
+					t.Errorf("between-subpaths coverage = %d, want 0", got)
+				}
+			})
+		}
+	}
+}
+
+func nestedRectPath(reverseInner bool) ([]PathVerb, []float64) {
+	verbs := []PathVerb{
+		VerbMoveTo, VerbLineTo, VerbLineTo, VerbLineTo, VerbClose,
+		VerbMoveTo, VerbLineTo, VerbLineTo, VerbLineTo, VerbClose,
+	}
+	coords := []float64{10, 10, 90, 10, 90, 90, 10, 90}
+	if reverseInner {
+		coords = append(coords, 30, 30, 30, 70, 70, 70, 70, 30)
+	} else {
+		coords = append(coords, 30, 30, 70, 30, 70, 70, 30, 70)
+	}
+	return verbs, coords
+}
+
+func boolName(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/clip/stack.go
+++ b/internal/clip/stack.go
@@ -18,6 +18,19 @@ type ClipStack struct {
 	bounds  Rect
 }
 
+// Clone returns an independent copy of the clip stack. Clip masks and rounded
+// rectangle descriptors are immutable after construction, so the entries can
+// safely share those underlying values while retaining independent stack state.
+func (cs *ClipStack) Clone() *ClipStack {
+	if cs == nil {
+		return nil
+	}
+	return &ClipStack{
+		entries: append([]clipEntry(nil), cs.entries...),
+		bounds:  cs.bounds,
+	}
+}
+
 // clipEntry represents a single clip operation in the stack.
 type clipEntry struct {
 	prevBounds Rect
@@ -84,8 +97,13 @@ func (cs *ClipStack) PushRRect(r Rect, radius float64) {
 // The path (given as SOA verb+coords) is rasterized into a mask using the current bounds.
 // If antiAlias is true, the mask will use anti-aliased rendering.
 func (cs *ClipStack) PushPath(verbs []PathVerb, coords []float64, antiAlias bool) error {
+	return cs.PushPathWithRule(verbs, coords, antiAlias, FillRuleNonZero)
+}
+
+// PushPathWithRule pushes a path clip using the requested fill rule.
+func (cs *ClipStack) PushPathWithRule(verbs []PathVerb, coords []float64, antiAlias bool, rule FillRule) error {
 	// Create mask clipper from path
-	mask, err := NewMaskClipper(verbs, coords, cs.bounds, antiAlias)
+	mask, err := NewMaskClipperWithRule(verbs, coords, cs.bounds, antiAlias, rule)
 	if err != nil {
 		return err
 	}

--- a/internal/clip/stack_test.go
+++ b/internal/clip/stack_test.go
@@ -21,6 +21,28 @@ func TestNewClipStack(t *testing.T) {
 	}
 }
 
+func TestClipStackClone(t *testing.T) {
+	var nilStack *ClipStack
+	if nilStack.Clone() != nil {
+		t.Fatal("Clone() of nil stack should be nil")
+	}
+
+	stack := NewClipStack(NewRect(0, 0, 100, 100))
+	stack.PushRect(NewRect(10, 10, 80, 80))
+	clone := stack.Clone()
+
+	clone.Pop()
+	if stack.Depth() != 1 {
+		t.Fatalf("modifying clone changed original depth: got %d, want 1", stack.Depth())
+	}
+	if got, want := stack.Bounds(), NewRect(10, 10, 80, 80); got != want {
+		t.Fatalf("modifying clone changed original bounds: got %v, want %v", got, want)
+	}
+	if got, want := clone.Bounds(), NewRect(0, 0, 100, 100); got != want {
+		t.Fatalf("clone bounds after Pop() = %v, want %v", got, want)
+	}
+}
+
 func TestClipStack_PushRect(t *testing.T) {
 	stack := NewClipStack(NewRect(0, 0, 100, 100))
 

--- a/recording/backends/raster/backend.go
+++ b/recording/backends/raster/backend.go
@@ -121,18 +121,22 @@ func (b *Backend) SetClip(path *gg.Path, rule recording.FillRule) {
 		return
 	}
 
-	// Set the path on the context
+	// Recording paths are already transformed into world coordinates. Build the
+	// path with an identity user transform so a transform command from the
+	// recording does not transform it a second time.
+	transform := b.ctx.GetTransform()
+	b.ctx.Identity()
 	b.ctx.ClearPath()
 	b.setPathFromElements(path)
 	b.ctx.SetFillRule(convertFillRule(rule))
-	// Note: gg.Context doesn't have a direct Clip method, so we use ClipPreserve behavior
-	// by setting path and letting fill/stroke respect it
+	b.ctx.Clip()
+	// Keep the backend's current transform unchanged for subsequent commands.
+	b.ctx.SetTransform(transform)
 }
 
 // ClearClip removes any clipping region.
 func (b *Backend) ClearClip() {
-	// gg.Context doesn't expose ResetClip directly
-	// We handle this by pushing/popping state around clip operations
+	b.ctx.ResetClip()
 }
 
 // FillPath fills the given path with the brush.

--- a/recording/backends/raster/clip_test.go
+++ b/recording/backends/raster/clip_test.go
@@ -1,0 +1,254 @@
+package raster
+
+import (
+	"image"
+	"image/color"
+	"math"
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/gg/recording"
+)
+
+func TestRecordingRasterClipSetClip(t *testing.T) {
+	rec := recording.NewRecorder(100, 100)
+	rec.Translate(10, 10)
+	rec.SetRGB(1, 0, 0)
+	rec.DrawRectangle(0, 0, 20, 20)
+	rec.Clip()
+	rec.FillRectangle(0, 0, 100, 100)
+
+	img := playbackRaster(t, rec.FinishRecording())
+	assertOpaqueRed(t, img, 15, 15)
+	assertTransparent(t, img, 35, 35)
+}
+
+func TestRecordingRasterClipIntersectsSuccessiveClips(t *testing.T) {
+	rec := recording.NewRecorder(100, 100)
+	clipRecorderRect(rec, 10, 10, 80, 80)
+	clipRecorderRect(rec, 40, 40, 30, 30)
+	rec.SetRGB(1, 0, 0)
+	rec.FillRectangle(0, 0, 100, 100)
+
+	img := playbackRaster(t, rec.FinishRecording())
+	assertOpaqueRed(t, img, 50, 50)
+	assertTransparent(t, img, 20, 20)
+	assertTransparent(t, img, 80, 80)
+}
+
+func TestRecordingRasterClipClearClip(t *testing.T) {
+	rec := recording.NewRecorder(100, 100)
+	clipRecorderRect(rec, 20, 20, 60, 60)
+	rec.SetRGB(1, 0, 0)
+	rec.FillRectangle(0, 0, 100, 100)
+	rec.ResetClip()
+	rec.SetRGB(0, 0, 1)
+	rec.FillRectangle(0, 0, 20, 100)
+
+	img := playbackRaster(t, rec.FinishRecording())
+	assertOpaqueBlue(t, img, 10, 50)
+	assertOpaqueRed(t, img, 50, 50)
+	assertTransparent(t, img, 90, 50)
+}
+
+func TestRecordingRasterClipClearClipRestoredByRestore(t *testing.T) {
+	rec := recording.NewRecorder(100, 100)
+	clipRecorderRect(rec, 10, 10, 80, 80)
+	rec.Save()
+	rec.ResetClip()
+	rec.Restore()
+	rec.SetRGB(1, 0, 0)
+	rec.FillRectangle(0, 0, 100, 100)
+
+	img := playbackRaster(t, rec.FinishRecording())
+	assertOpaqueRed(t, img, 50, 50)
+	assertTransparent(t, img, 5, 5)
+}
+
+func TestRecordingRasterClipSaveRestore(t *testing.T) {
+	rec := recording.NewRecorder(100, 100)
+	clipRecorderRect(rec, 10, 10, 80, 80)
+	rec.Save()
+	clipRecorderRect(rec, 30, 30, 40, 40)
+	rec.Restore()
+	rec.SetRGB(1, 0, 0)
+	rec.FillRectangle(0, 0, 20, 100)
+
+	img := playbackRaster(t, rec.FinishRecording())
+	assertOpaqueRed(t, img, 15, 50)
+	assertTransparent(t, img, 50, 50)
+	assertTransparent(t, img, 5, 5)
+}
+
+func TestRecordingRasterClipHonorsFillRule(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		rule       recording.FillRule
+		centerDraw bool
+	}{
+		{name: "non-zero", rule: recording.FillRuleNonZero, centerDraw: true},
+		{name: "even-odd", rule: recording.FillRuleEvenOdd, centerDraw: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := recording.NewRecorder(100, 100)
+			rec.SetFillRule(tc.rule)
+			rec.DrawRectangle(10, 10, 80, 80)
+			rec.DrawRectangle(30, 30, 40, 40)
+			rec.Clip()
+			rec.SetRGB(1, 0, 0)
+			rec.FillRectangle(0, 0, 100, 100)
+
+			img := playbackRaster(t, rec.FinishRecording())
+			assertOpaqueRed(t, img, 15, 50)
+			if tc.centerDraw {
+				assertOpaqueRed(t, img, 50, 50)
+			} else {
+				assertTransparent(t, img, 50, 50)
+			}
+			assertTransparent(t, img, 5, 5)
+		})
+	}
+}
+
+func TestRecordingRasterClipRoundRectTransformParity(t *testing.T) {
+	tests := []struct {
+		name              string
+		transformContext  func(*gg.Context)
+		transformRecorder func(*recording.Recorder)
+		points            []image.Point
+	}{
+		{
+			name:              "translation",
+			transformContext:  func(dc *gg.Context) { dc.Translate(15, 8) },
+			transformRecorder: func(rec *recording.Recorder) { rec.Translate(15, 8) },
+			points:            []image.Point{{X: 55, Y: 43}, {X: 25, Y: 35}},
+		},
+		{
+			name: "scale",
+			transformContext: func(dc *gg.Context) {
+				dc.Translate(5, 5)
+				dc.Scale(1.5, 0.75)
+			},
+			transformRecorder: func(rec *recording.Recorder) {
+				rec.Translate(5, 5)
+				rec.Scale(1.5, 0.75)
+			},
+			points: []image.Point{{X: 42, Y: 21}, {X: 60, Y: 50}},
+		},
+		{
+			name: "rotation",
+			transformContext: func(dc *gg.Context) {
+				dc.Translate(60, 5)
+				dc.Rotate(math.Pi / 6)
+			},
+			transformRecorder: func(rec *recording.Recorder) {
+				rec.Translate(60, 5)
+				rec.Rotate(math.Pi / 6)
+			},
+			points: []image.Point{{X: 74, Y: 33}, {X: 60, Y: 50}},
+		},
+		{
+			name: "shear",
+			transformContext: func(dc *gg.Context) {
+				dc.Translate(5, 5)
+				dc.Shear(0.6, 0.2)
+			},
+			transformRecorder: func(rec *recording.Recorder) {
+				rec.Translate(5, 5)
+				rec.Shear(0.6, 0.2)
+			},
+			points: []image.Point{{X: 52, Y: 30}, {X: 25, Y: 25}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			direct := gg.NewContext(120, 120)
+			tc.transformContext(direct)
+			direct.ClipRoundRect(20, 20, 40, 30, 12)
+			direct.Identity()
+			direct.SetRGB(1, 0, 0)
+			direct.DrawRectangle(0, 0, 120, 120)
+			if err := direct.Fill(); err != nil {
+				t.Fatalf("direct fill failed: %v", err)
+			}
+
+			rec := recording.NewRecorder(120, 120)
+			tc.transformRecorder(rec)
+			rec.ClipRoundRect(20, 20, 40, 30, 12)
+			rec.Identity()
+			rec.SetRGB(1, 0, 0)
+			rec.FillRectangle(0, 0, 120, 120)
+			recorded := playbackRaster(t, rec.FinishRecording())
+
+			for _, point := range tc.points {
+				want := color.NRGBAModel.Convert(direct.Image().At(point.X, point.Y)).(color.NRGBA).A
+				got := color.NRGBAModel.Convert(recorded.At(point.X, point.Y)).(color.NRGBA).A
+				if got != want {
+					t.Errorf("alpha at %v = %#02x, want direct alpha %#02x", point, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRecordingRasterClipDisjointSubpaths(t *testing.T) {
+	for _, rule := range []recording.FillRule{recording.FillRuleNonZero, recording.FillRuleEvenOdd} {
+		name := "non-zero"
+		if rule == recording.FillRuleEvenOdd {
+			name = "even-odd"
+		}
+		t.Run(name, func(t *testing.T) {
+			rec := recording.NewRecorder(100, 100)
+			rec.SetFillRule(rule)
+			rec.DrawRectangle(10, 10, 20, 20)
+			rec.DrawRectangle(70, 70, 20, 20)
+			rec.Clip()
+			rec.SetRGB(1, 0, 0)
+			rec.FillRectangle(0, 0, 100, 100)
+
+			img := playbackRaster(t, rec.FinishRecording())
+			assertOpaqueRed(t, img, 20, 20)
+			assertOpaqueRed(t, img, 80, 80)
+			assertTransparent(t, img, 50, 50)
+		})
+	}
+}
+
+func clipRecorderRect(rec *recording.Recorder, x, y, w, h float64) {
+	rec.DrawRectangle(x, y, w, h)
+	rec.Clip()
+}
+
+func playbackRaster(t *testing.T, rec *recording.Recording) image.Image {
+	t.Helper()
+	backend := NewBackend()
+	if err := rec.Playback(backend); err != nil {
+		t.Fatalf("recording playback failed: %v", err)
+	}
+	return backend.Image()
+}
+
+func assertOpaqueRed(t *testing.T, img image.Image, x, y int) {
+	t.Helper()
+	r, g, b, a := img.At(x, y).RGBA()
+	if a < 0xc000 || r < 0xc000 || g > 0x1000 || b > 0x1000 {
+		t.Errorf("pixel at (%d,%d) = %#04x %#04x %#04x %#04x, want opaque red", x, y, r, g, b, a)
+	}
+}
+
+func assertOpaqueBlue(t *testing.T, img image.Image, x, y int) {
+	t.Helper()
+	r, g, b, a := img.At(x, y).RGBA()
+	if a < 0xc000 || r > 0x1000 || g > 0x1000 || b < 0xc000 {
+		t.Errorf("pixel at (%d,%d) = %#04x %#04x %#04x %#04x, want opaque blue", x, y, r, g, b, a)
+	}
+}
+
+func assertTransparent(t *testing.T, img image.Image, x, y int) {
+	t.Helper()
+	rgba := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
+	if rgba.A > 0x10 {
+		t.Errorf("pixel at (%d,%d) has alpha %#02x, want transparent", x, y, rgba.A)
+	}
+}

--- a/recording/recorder.go
+++ b/recording/recorder.go
@@ -141,25 +141,47 @@ func (r *Recording) Playback(backend Backend) error {
 		return err
 	}
 
+	transform := Identity()
+	transformStack := make([]Matrix, 0, 8)
+
 	// Replay each command
 	for _, cmd := range r.commands {
 		switch c := cmd.(type) {
 		case SaveCommand:
+			transformStack = append(transformStack, transform)
 			backend.Save()
 		case RestoreCommand:
 			backend.Restore()
+			if len(transformStack) > 0 {
+				transform = transformStack[len(transformStack)-1]
+				transformStack = transformStack[:len(transformStack)-1]
+			}
 		case SetTransformCommand:
+			transform = c.Matrix
 			backend.SetTransform(c.Matrix)
 		case SetClipCommand:
 			path := r.resources.GetPath(c.Path)
-			backend.SetClip(path, c.Rule)
+			setPlaybackClip(backend, path, c.Rule, transform)
 		case ClearClipCommand:
 			backend.ClearClip()
 		case ClipRoundRectCommand:
 			// Convert RRect clip to a path for backends that don't
-			// natively support rounded rectangle clipping.
-			rrPath := gg.BuildPath().RoundRect(c.X, c.Y, c.W, c.H, c.Radius).Build()
-			backend.SetClip(rrPath, FillRuleNonZero)
+			// natively support rounded rectangle clipping. Match Context's
+			// ClipRoundRect transform semantics: transform the two diagonal
+			// corners into an axis-aligned box and scale the corner radius.
+			x1, y1 := transform.TransformPoint(c.X, c.Y)
+			x2, y2 := transform.TransformPoint(c.X+c.W, c.Y+c.H)
+			x := math.Min(x1, x2)
+			y := math.Min(y1, y2)
+			w := math.Abs(x2 - x1)
+			h := math.Abs(y2 - y1)
+			radius := 0.0
+			if c.Radius > 0 {
+				radius = c.Radius * transform.ScaleFactor()
+				radius = math.Min(radius, math.Min(w, h)/2)
+			}
+			rrPath := gg.BuildPath().RoundRect(x, y, w, h, radius).Build()
+			setPlaybackClip(backend, rrPath, FillRuleNonZero, transform)
 		case FillPathCommand:
 			path := r.resources.GetPath(c.Path)
 			brush := r.resources.GetBrush(c.Brush)
@@ -195,6 +217,15 @@ func (r *Recording) Playback(backend Backend) error {
 	}
 
 	return backend.End()
+}
+
+// setPlaybackClip applies a world-space clip without disturbing the backend's
+// current transform. Save/Restore cannot be used here because Restore would
+// also discard the newly installed clip.
+func setPlaybackClip(backend Backend, path *gg.Path, rule FillRule, transform Matrix) {
+	backend.SetTransform(Identity())
+	backend.SetClip(path, rule)
+	backend.SetTransform(transform)
 }
 
 // --------------------------------------------------------------------------

--- a/recording/recorder_coverage_test.go
+++ b/recording/recorder_coverage_test.go
@@ -252,6 +252,59 @@ func (m *playbackMockBackend) FillRect(_ Rect, _ Brush)                         
 func (m *playbackMockBackend) DrawImage(_ image.Image, _, _ Rect, _ ImageOptions)    {}
 func (m *playbackMockBackend) DrawText(_ string, _, _ float64, _ text.Face, _ Brush) {}
 
+type clipTransformBackend struct {
+	playbackMockBackend
+	transform     Matrix
+	clipTransform Matrix
+	clipBounds    image.Rectangle
+}
+
+func (b *clipTransformBackend) SetTransform(transform Matrix) {
+	b.transform = transform
+}
+
+func (b *clipTransformBackend) SetClip(path *gg.Path, _ FillRule) {
+	b.clipTransform = b.transform
+	b.clipBounds = path.Bounds()
+}
+
+func TestRecordingPlaybackClipRoundRectTransformOwnership(t *testing.T) {
+	rec := NewRecorder(100, 100)
+	rec.Translate(30, 0)
+	rec.Save()
+	rec.Translate(10, 0)
+	rec.Restore()
+	rec.ClipRoundRect(10, 10, 20, 20, 5)
+	recording := rec.FinishRecording()
+
+	// Exercise Playback's defensive handling of an unmatched Restore command.
+	recording.commands = append([]Command{RestoreCommand{}}, recording.commands...)
+
+	backend := &clipTransformBackend{}
+	if err := recording.Playback(backend); err != nil {
+		t.Fatalf("Playback failed: %v", err)
+	}
+	if !backend.clipTransform.IsIdentity() {
+		t.Fatalf("SetClip transform = %+v, want identity", backend.clipTransform)
+	}
+	if got, want := backend.clipBounds, image.Rect(40, 10, 60, 30); got != want {
+		t.Fatalf("SetClip path bounds = %v, want %v", got, want)
+	}
+	if got, want := backend.transform, Translate(30, 0); got != want {
+		t.Fatalf("transform after SetClip = %+v, want %+v", got, want)
+	}
+
+	zeroRadius := NewRecorder(100, 100)
+	zeroRadius.ClipRoundRect(10, 10, 20, 20, 0)
+	zeroBackend := &clipTransformBackend{}
+	if err := zeroRadius.FinishRecording().Playback(zeroBackend); err != nil {
+		t.Fatalf("zero-radius Playback failed: %v", err)
+	}
+	if got, want := zeroBackend.clipBounds, image.Rect(10, 10, 30, 30); got != want {
+		t.Fatalf("zero-radius SetClip path bounds = %v, want %v", got, want)
+	}
+}
+
 // --- Additional recorder coverage tests ---
 
 func TestRecorderDrawStringWrapped(t *testing.T) {


### PR DESCRIPTION
## Summary

- make the recording raster backend apply and clear clip regions instead of treating both commands as no-ops
- preserve backend transforms while applying recorder-provided world-space clips, including transformed rounded rectangles
- restore complete saved clip state across `Save`/`Restore`, including `ResetClip`, while invalidating pixel-space snapshots on resize/device-scale changes
- propagate non-zero and even-odd fill rules through the CPU clip stack
- keep independent/open subpaths separate and implicitly close filled contours without introducing connector edges
- add focused raster, backend-contract, clip-stack, transform-parity, lifecycle, and mask-rasterization regressions

## Why

`recording/backends/raster.SetClip` rebuilt the current path but never pushed it into the `gg.Context` clip stack, while `ClearClip` did nothing. Recorded drawings therefore leaked outside their clip regions. Applying the clip also exposed two existing CPU mask issues: the mask rasterizer always paired intersections as even-odd despite the requested fill rule, and it flattened multiple subpaths into one point stream, creating diagonal edges between otherwise disjoint contours.

The backend now applies recorder world-space paths under an identity transform and restores the drawing transform without using `Save`/`Restore`, which would discard the new clip. Playback tracks the recorded transform stack so legacy/public `ClipRoundRectCommand` values retain their zero-value compatibility and transformed rounded clips match `Context.ClipRoundRect` semantics for translation, scale, rotation, and shear.

`Context.Push` now snapshots the complete clip stack and GPU clip path rather than only a depth, so `ResetClip` inside a saved scope cannot destroy the state needed by `Pop`. Resize and device-scale changes invalidate saved pixel-space clip snapshots while preserving transform-stack alignment.

`Context.Clip` and `ClipPreserve` forward the selected fill rule into the internal mask clipper. The clipper rasterizes each implicitly closed subpath independently and computes spans using either winding or parity semantics.

## Verification

- focused clip/reset/resize/device-scale, `ClipStack.Clone`, degenerate-mask, generic-backend transform, and raster transform-parity tests
- `go test -tags nogpu -count=1 ./...`
- `go test -race -tags nogpu -count=1 -coverprofile=coverage.out -covermode=atomic ./...`
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go build ./examples/...`
- `CGO_ENABLED=0 go build ./cmd/ggdemo`
- `CGO_ENABLED=0 go vet ./...`
- `go mod verify`
- repository-wide `gofmt` and `git diff --check`
- independent final review: no correctness blockers

## Scope note

This fixes CPU/raster clipping. The existing GPU arbitrary-path stencil path still uses non-zero behavior and does not yet carry even-odd metadata; that is a separate pre-existing GPU follow-up.
