### PR TITLE
fix(render): preserve premultiplied fill colors

### DIFF
--- a/render/software.go
+++ b/render/software.go
@@ -152,7 +152,8 @@ func (r *SoftwareRenderer) renderClear(pixels []byte, width, height, stride int,
 
 // renderFill fills a path with a solid color.
 func (r *SoftwareRenderer) renderFill(pixels []byte, width, height, stride int, path *pathBuilder, c color.Color, fillRule raster.FillRule) {
-	// Convert color to RGBA (mask ensures value fits in uint8)
+	// Convert color's premultiplied channels to target RGBA bytes (mask
+	// ensures each value fits in uint8).
 	cr, cg, cb, ca := c.RGBA()
 	//nolint:gosec // G115: mask ensures no overflow
 	pr := uint8((cr >> 8) & 0xFF)
@@ -197,10 +198,13 @@ func (r *SoftwareRenderer) renderFill(pixels []byte, width, height, stride int, 
 
 				offset := rowOffset + x*4
 
-				// Source-over alpha blending
-				// out = src * srcAlpha + dst * (1 - srcAlpha)
-				alpha := uint16(run.Alpha) * uint16(pa)
-				alpha = (alpha + 255) >> 8 // Normalize to 0-255
+				// Source-over alpha blending. PixmapTarget wraps image.RGBA,
+				// whose pixel buffer stores premultiplied RGBA bytes. RGBA()
+				// already returns premultiplied color channels, so coverage is
+				// applied to the channels and alpha independently. Multiplying
+				// the channels by alpha here would premultiply them twice.
+				coverage := uint16(run.Alpha)
+				alpha := mul255(coverage, uint16(pa))
 
 				if alpha == 0 {
 					continue
@@ -214,17 +218,22 @@ func (r *SoftwareRenderer) renderFill(pixels []byte, width, height, stride int, 
 					pixels[offset+3] = pa
 				} else {
 					// Alpha blend
-					invAlpha := 255 - alpha
+					invAlpha := uint16(255) - alpha
 
 					dstR := uint16(pixels[offset])
 					dstG := uint16(pixels[offset+1])
 					dstB := uint16(pixels[offset+2])
 					dstA := uint16(pixels[offset+3])
 
-					outR := (uint16(pr)*alpha + dstR*invAlpha + 127) / 255
-					outG := (uint16(pg)*alpha + dstG*invAlpha + 127) / 255
-					outB := (uint16(pb)*alpha + dstB*invAlpha + 127) / 255
-					outA := (uint16(pa)*alpha + dstA*invAlpha + 127) / 255
+					// The source channels are already premultiplied by pa;
+					// only coverage needs to be applied before source-over.
+					srcR := mul255(coverage, uint16(pr))
+					srcG := mul255(coverage, uint16(pg))
+					srcB := mul255(coverage, uint16(pb))
+					outR := srcR + mul255(dstR, invAlpha)
+					outG := srcG + mul255(dstG, invAlpha)
+					outB := srcB + mul255(dstB, invAlpha)
+					outA := alpha + mul255(dstA, invAlpha)
 
 					//nolint:gosec // G115: mask ensures no overflow
 					pixels[offset] = uint8(outR & 0xFF)
@@ -238,6 +247,12 @@ func (r *SoftwareRenderer) renderFill(pixels []byte, width, height, stride int, 
 			}
 		}
 	})
+}
+
+// mul255 multiplies two 8-bit values and rounds the result back to 8-bit.
+// It is used for coverage and premultiplied source-over arithmetic.
+func mul255(a, b uint16) uint16 {
+	return (a*b + 127) / 255
 }
 
 // renderStroke strokes a path with a solid color.

--- a/render/software_test.go
+++ b/render/software_test.go
@@ -191,8 +191,10 @@ func TestSoftwareRendererAlphaBlend(t *testing.T) {
 	// Fill with opaque red
 	scene.Clear(color.RGBA{255, 0, 0, 255})
 
-	// Overlay with semi-transparent blue
-	scene.SetFillColor(color.RGBA{0, 0, 255, 128})
+	// Overlay with semi-transparent blue. NRGBA is used here because RGBA
+	// stores premultiplied channels and {0, 0, 255, 128} is not a valid
+	// premultiplied color.
+	scene.SetFillColor(color.NRGBA{0, 0, 255, 128})
 	scene.Rectangle(0, 0, 100, 100)
 	scene.Fill()
 
@@ -212,6 +214,78 @@ func TestSoftwareRendererAlphaBlend(t *testing.T) {
 	}
 	if pixel.B < 50 || pixel.B > 180 {
 		t.Errorf("Blended B = %d, expected some blue", pixel.B)
+	}
+}
+
+func TestSoftwareRendererFillPremultipliedColorModels(t *testing.T) {
+	// color.Color.RGBA returns premultiplied channels. The software target
+	// (image.RGBA) stores those channels directly, so a half-alpha red fill
+	// must retain a premultiplied red value of 128 rather than multiplying it
+	// by alpha for a second time.
+	colors := []struct {
+		name  string
+		color color.Color
+	}{
+		{name: "RGBA", color: color.RGBA{R: 128, G: 0, B: 0, A: 128}},
+		{name: "NRGBA", color: color.NRGBA{R: 255, G: 0, B: 0, A: 128}},
+		{name: "RGBA64", color: color.RGBA64{R: 0x8000, G: 0, B: 0, A: 0x8000}},
+		{name: "NRGBA64", color: color.NRGBA64{R: 0xffff, G: 0, B: 0, A: 0x8000}},
+	}
+
+	destinations := []struct {
+		name string
+		color.Color
+		want color.RGBA
+	}{
+		{name: "transparent", want: color.RGBA{R: 128, G: 0, B: 0, A: 128}},
+		{name: "opaque", Color: color.RGBA{R: 0, G: 0, B: 255, A: 255}, want: color.RGBA{R: 128, G: 0, B: 127, A: 255}},
+		{name: "semi-transparent", Color: color.RGBA{R: 0, G: 0, B: 128, A: 128}, want: color.RGBA{R: 128, G: 0, B: 64, A: 192}},
+	}
+
+	for _, source := range colors {
+		for _, destination := range destinations {
+			t.Run(source.name+"/"+destination.name, func(t *testing.T) {
+				target := NewPixmapTarget(1, 1)
+				if destination.Color != nil {
+					target.SetPixel(0, 0, destination.Color)
+				}
+
+				scene := NewScene()
+				scene.SetFillColor(source.color)
+				scene.Rectangle(0, 0, 1, 1)
+				scene.Fill()
+				if err := NewSoftwareRenderer().Render(target, scene); err != nil {
+					t.Fatalf("Render() error = %v", err)
+				}
+
+				got := target.GetPixel(0, 0).(color.RGBA)
+				if got != destination.want {
+					t.Errorf("pixel = %v, want %v", got, destination.want)
+				}
+			})
+		}
+	}
+}
+
+func TestSoftwareRendererFillPremultipliedCoverage(t *testing.T) {
+	target := NewPixmapTarget(2, 1)
+	scene := NewScene()
+	scene.SetFillColor(color.NRGBA{R: 255, G: 0, B: 0, A: 128})
+	// This rectangle covers half of each pixel, exercising the AA coverage
+	// multiplier independently from the paint opacity multiplier.
+	scene.Rectangle(0.5, 0, 1, 1)
+	scene.Fill()
+
+	if err := NewSoftwareRenderer().Render(target, scene); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	for x := 0; x < 2; x++ {
+		got := target.GetPixel(x, 0).(color.RGBA)
+		want := color.RGBA{R: 64, G: 0, B: 0, A: 64}
+		if got != want {
+			t.Errorf("pixel (%d, 0) = %v, want %v", x, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- fix software path fills to composite premultiplied source colors without multiplying alpha twice
- apply raster coverage to premultiplied RGB and alpha independently
- add color-model, destination-alpha, and antialiasing coverage regressions
- correct the existing semi-transparent test color to use the straight-alpha `color.NRGBA` type

## Why

`color.Color.RGBA()` returns premultiplied channels, and `PixmapTarget` stores an `image.RGBA` premultiplied pixel buffer. `renderFill` treated those source channels as straight RGB and multiplied them by the effective alpha again. A 50% red fill over transparency therefore produced premultiplied red 64 instead of 128, visibly darkening every translucent software-rendered fill.

The compositor now scales premultiplied source channels only by coverage, computes effective alpha from coverage and source alpha, and performs standard premultiplied source-over against the destination.

## Verification

- clean baseline returns `{64,0,0,64}` instead of `{128,0,0,128}` for half-alpha red across RGBA, NRGBA, RGBA64, and NRGBA64 inputs
- independent math/edge review covers transparent, opaque, and semi-transparent destinations plus partial antialiasing coverage
- `go test ./render`
- `go test -race ./render`
- `go test -race -tags nogpu ./...`
- `go vet -tags nogpu ./...`
- `go build ./...`
- `gofmt` and `git diff --check`

The GPU-enabled full suite retains unrelated pre-existing internal GPU golden/debug failures; the full nogpu race suite passes.
