### PR TITLE
release: v0.52.0 — compositor architecture migration (ADR-067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.0] - 2026-08-10
+
+### Changed
+
+- **Compositor architecture migration** (ADR-067, gg#493) — gg becomes a pure drawing library. Surface-level compositor decisions (LoadOp, damage scissoring, MSAA overlay compositing) delegated to gogpu via `SurfaceCompositor` interface.
+  - `preserveContent` removed from `GPURenderSession` — compositor decides LoadOp
+  - `shouldPreserveSurface()` simplified to gg-internal multi-pass only
+  - `selectBaseLayer` uses `target.PreserveContent` (explicit external content signal), not `frameRendered`
+  - Per-frame compositor via `GPURenderTarget.Compositor` field (enterprise pattern: compositor context per render call)
+  - `MarkFrameRendered()` replaces `preserveContent` flag for compositor → gg signal
+  - MSAA overlay compositing delegates to `SurfaceCompositor.CompositeMSAAOverlay()` when available
+  - Legacy fallback preserved for standalone gg without gogpu
+  - Tests updated for new compositor signal path
+
+### Changed
+
+- **deps:** gpucontext → v0.27.0 (SurfaceCompositor interface)
+
 ## [0.51.0] - 2026-08-10
 
 ### Added

--- a/accelerator.go
+++ b/accelerator.go
@@ -74,6 +74,11 @@ type GPURenderTarget struct {
 	// Set by gogpu after MarkExternalContent(). ADR-059.
 	PreserveContent bool
 
+	// Compositor handles surface-level decisions (LoadOp, damage scissoring,
+	// MSAA overlay compositing). Set per-frame by the host framework (gogpu)
+	// through ggcanvas. When nil, gg uses legacy internal paths. ADR-067.
+	Compositor gpucontext.SurfaceCompositor
+
 	// Damage-aware compositing (ADR-026/028): when non-empty, compositor
 	// uses LoadOpLoad (preserve previous frame) and per-rect scissor.
 	// Single rect: one scissor for entire pass.

--- a/context.go
+++ b/context.go
@@ -81,6 +81,11 @@ type Context struct {
 	gpuCtx            gpuContextOps
 	gpuFallbackWarned bool // true after first global fallback warning (avoid log spam)
 
+	// Per-frame compositor (ADR-067). Set by ggcanvas.renderDirectToTarget,
+	// included in GPURenderTarget.Compositor for each render call.
+	// Nil when running standalone gg without gogpu.
+	frameCompositor gpucontext.SurfaceCompositor
+
 	// Lifecycle
 	closed bool // Indicates whether Close has been called
 }
@@ -1426,12 +1431,35 @@ func (c *Context) FlushGPUWithView(view gpucontext.TextureView, width, height ui
 	return c.flushGPUWithView(view, width, height, false)
 }
 
-// FlushGPUWithViewPreserveContent is like FlushGPUWithView, but treats the
-// existing view contents as the compositor base instead of clearing or covering
-// them with a queued DrawGPUTextureBase layer. Use this when another renderer
-// has already drawn to the view in this frame.
+// FlushGPUWithViewPreserveContent is like FlushGPUWithView, but signals that
+// the view already has external content that must not be cleared. It marks
+// the GPU render context's frame as rendered (LoadOp::Load) and skips the
+// base layer so the external renderer's output is preserved.
+//
+// For the real GPU path, this sets frameRendered on the GPURenderContext.
+// For custom accelerators, PreserveContent is set on the GPURenderTarget
+// for backward compatibility.
 func (c *Context) FlushGPUWithViewPreserveContent(view gpucontext.TextureView, width, height uint32) error {
+	c.MarkFrameRendered()
 	return c.flushGPUWithView(view, width, height, true)
+}
+
+// MarkFrameRendered signals that external content has already been rendered to
+// the current surface view. Subsequent GPU render passes use LoadOp::Load to
+// preserve that content instead of clearing. The compositor (gogpu) controls
+// when this is appropriate; gg just respects the frame state.
+func (c *Context) MarkFrameRendered() {
+	if rc := c.gpuCtxOps(); rc != nil {
+		rc.MarkFrameRendered()
+	}
+}
+
+// SetPerFrameCompositor stores the compositor for the current frame.
+// The next gpuRenderTarget() call includes it in GPURenderTarget.Compositor.
+// Called per-frame by ggcanvas.renderDirectToTarget (ADR-067 enterprise pattern:
+// compositor context provided with each render call, not as persistent state).
+func (c *Context) SetPerFrameCompositor(comp gpucontext.SurfaceCompositor) {
+	c.frameCompositor = comp
 }
 
 func (c *Context) flushGPUWithView(view gpucontext.TextureView, width, height uint32, preserveContent bool) error {
@@ -1441,6 +1469,10 @@ func (c *Context) flushGPUWithView(view gpucontext.TextureView, width, height ui
 		t.ViewWidth = width
 		t.ViewHeight = height
 	}
+	// PreserveContent on the target is kept for backward compatibility with
+	// custom accelerators that use Accelerator().Flush(). The real GPU path
+	// uses frameRendered on the GPURenderContext instead (set via
+	// MarkFrameRendered before this call).
 	t.PreserveContent = preserveContent
 	rc := c.gpuCtxOps()
 	if rc != nil {
@@ -1538,6 +1570,7 @@ type gpuContextOps interface {
 	SetClipPath(path *Path)
 	ClearClipPath()
 	BeginFrame()
+	MarkFrameRendered()
 	SetPipelineMode(mode PipelineMode)
 	SetAntiAlias(enabled bool)
 	PendingCount() int
@@ -1586,10 +1619,11 @@ func (c *Context) gpuCtxOps() gpuContextOps {
 // gpuRenderTarget returns the current context's pixel buffer as a GPU render target.
 func (c *Context) gpuRenderTarget() GPURenderTarget {
 	return GPURenderTarget{
-		Data:   c.pixmap.Data(),
-		Width:  c.pixmap.Width(),
-		Height: c.pixmap.Height(),
-		Stride: c.pixmap.Width() * 4,
+		Data:       c.pixmap.Data(),
+		Width:      c.pixmap.Width(),
+		Height:     c.pixmap.Height(),
+		Stride:     c.pixmap.Width() * 4,
+		Compositor: c.frameCompositor,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/gogpu/gg
 go 1.25.0
 
 require (
-	github.com/gogpu/gogpu v0.51.0
-	github.com/gogpu/gpucontext v0.26.0
+	github.com/gogpu/gogpu v0.52.0
+	github.com/gogpu/gpucontext v0.27.0
 	github.com/gogpu/gputypes v0.5.1
 	github.com/gogpu/naga v0.18.0
 	github.com/gogpu/ui v0.1.50

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gogpu v0.51.0 h1:MO4T0EJcDjvdsseBCM4603sKJQkXogKTm7WKJf14TfM=
-github.com/gogpu/gogpu v0.51.0/go.mod h1:9sff4f+q6FLfj7D9UWikATgIrPG4P+V0+Y7mEQwDUeE=
-github.com/gogpu/gpucontext v0.26.0 h1:5s1mAa9RULjzBDw0Ej09EVqTh3q3+44BKJ/zCljVWAI=
-github.com/gogpu/gpucontext v0.26.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
+github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
+github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
+github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=
+github.com/gogpu/gpucontext v0.27.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
 github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.18.0 h1:2y83HUcAnlwEZMuHOiYTMdNYM9J8rev40gkI4zJ96Uk=

--- a/integration/ggcanvas/canvas.go
+++ b/integration/ggcanvas/canvas.go
@@ -631,13 +631,22 @@ func (c *Canvas) renderDirectToTarget(
 	if preserver, ok := dc.(ContentPreserver); ok {
 		preserveContent = preserver.PreserveContent()
 	}
+
+	// ADR-067: pass compositor per-frame to gg's render target.
+	type compositorProvider interface {
+		Compositor() gpucontext.SurfaceCompositor
+	}
+	var comp gpucontext.SurfaceCompositor
+	if cp, ok := dc.(compositorProvider); ok {
+		comp = cp.Compositor()
+	}
+	c.ctx.SetPerFrameCompositor(comp)
+
 	if encoder.IsNil() {
 		return c.renderDirect(surfaceView, width, height, preserveContent)
 	}
 
 	c.ctx.SetSharedEncoder(encoder)
-	// The target owns submission. Always clear the borrowed encoder before a
-	// fallback path can flush to a different destination.
 	defer c.ctx.SetSharedEncoder(gpucontext.CommandEncoder{})
 	return c.renderDirect(surfaceView, width, height, preserveContent)
 }
@@ -763,6 +772,8 @@ func (c *Canvas) Render(dc RenderTarget) error {
 			setter.SetDamageOverlayRenderer(c.damageOverlay)
 		}
 	}
+
+	// ADR-067: compositor wiring moved to renderDirectToTarget (per-frame via GPURenderTarget.Compositor).
 
 	// Auto-detect DPI scale change (ADR-059). Zero overhead when unchanged.
 	if wp, ok := c.provider.(gpucontext.WindowProvider); ok {

--- a/internal/gpu/gpu_render_context.go
+++ b/internal/gpu/gpu_render_context.go
@@ -273,6 +273,24 @@ func (rc *GPURenderContext) BeginFrame() {
 	rc.lastView = nil
 }
 
+// MarkFrameRendered signals that external content has already been rendered
+// to the surface view in this frame. Subsequent render passes will use
+// LoadOp::Load to preserve that content instead of clearing. This replaces
+// the PreserveContent flag on GPURenderTarget — the compositor (gogpu) now
+// controls content preservation, and gg just respects the frame state.
+func (rc *GPURenderContext) MarkFrameRendered() {
+	rc.frameRendered = true
+}
+
+// SetSurfaceCompositor is deprecated — compositor now flows per-frame via
+// GPURenderTarget.Compositor (ADR-067). Kept for backward compatibility.
+func (rc *GPURenderContext) SetSurfaceCompositor(comp gpucontext.SurfaceCompositor) {
+	if rc == nil || rc.session == nil {
+		return
+	}
+	rc.session.SetSurfaceCompositor(comp)
+}
+
 // SetSharedEncoder sets a shared command encoder for single-command-buffer
 // frames (ADR-017). When set, Flush() records render passes into this encoder
 // instead of creating its own and submitting. The caller is responsible for
@@ -847,11 +865,11 @@ func (rc *GPURenderContext) StrokeShape(target gg.GPURenderTarget, shape gg.Dete
 }
 
 // selectBaseLayer returns the queued compositor base unless the destination
-// surface already supplies it. With PreserveContent, external rendering is the
-// base layer; drawing the full-surface pixmap base would hide that content.
+// surface already supplies it. When frameRendered is true, external content is
+// already on the surface; drawing the full-surface pixmap base would hide it.
 // Callers that need another texture above external content use DrawGPUTexture.
-func selectBaseLayer(draws []drawCommand, preserveContent bool) *GPUTextureDrawCommand {
-	if preserveContent {
+func selectBaseLayer(draws []drawCommand, frameRendered bool) *GPUTextureDrawCommand {
+	if frameRendered {
 		return nil
 	}
 	for i := range draws {
@@ -923,9 +941,12 @@ func (rc *GPURenderContext) Flush(target gg.GPURenderTarget) error { //nolint:cy
 	// Transfer per-context frame tracking to session before rendering.
 	rc.session.SetFrameState(rc.frameRendered, rc.lastView)
 
-	// The queued base layer renders before every other tier. PreserveContent
-	// makes the existing surface content the base instead, so selecting the
-	// pixmap layer here would immediately cover the external renderer's output.
+	// The queued base layer renders before every other tier. When external
+	// content (g3d) is already on the surface, skip the pixmap base layer
+	// so it does not cover the external renderer's output.
+	// Uses target.PreserveContent — set by compositor (gogpu) via
+	// MarkPreserveContent → externalContent → ContextRenderTarget.PreserveContent().
+	// NOT frameRendered (set by any Flush, including boundary texture flushes).
 	baseLayer := selectBaseLayer(rc.pendingDraws, target.PreserveContent)
 
 	// Build ScissorGroups from per-draw clip state. All command types flow

--- a/internal/gpu/render_session.go
+++ b/internal/gpu/render_session.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"image"
 	"os"
+	"unsafe"
 
 	"github.com/gogpu/gg"
 	"github.com/gogpu/gpucontext"
@@ -213,13 +214,11 @@ type GPURenderSession struct {
 	gpuTexUniformBufs    []*wgpu.Buffer
 	gpuTexBindGroups     []*wgpu.BindGroup
 
-	// Full-surface textured quad used by the MSAA overlay composition path.
-	// These resources are separate from ordinary GPU texture draws so preparing
-	// the final composite cannot overwrite another draw's persistent buffers.
-	surfaceCompositeVertBuf    *wgpu.Buffer
-	surfaceCompositeUniformBuf *wgpu.Buffer
-	surfaceCompositeBindGroup  *wgpu.BindGroup
-	surfaceCompositeBoundView  *wgpu.TextureView
+	// compositor is set per-frame from GPURenderTarget.Compositor (ADR-067).
+	// When non-nil, MSAA overlay compositing is delegated to gogpu.
+	// When nil, gg uses legacy internal paths (standalone gg without gogpu).
+	// Reset each frame in RenderFrame/RenderFrameGrouped from target.
+	compositor gpucontext.SurfaceCompositor
 
 	// Bind groups pending release — deferred until after command buffer submit.
 	// WebGPU requires bind groups to be alive at submit time (wgpu-core track/mod.rs:631).
@@ -263,10 +262,6 @@ type GPURenderSession struct {
 	// Porter-Duff "over" during readback, so LoadOpClear is always safe.
 	frameRendered bool
 
-	// preserveContent signals that the surface has external content (e.g., g3d)
-	// that must remain underneath this pass. ADR-059.
-	preserveContent bool
-
 	// antiAlias determines SDF coverage computation mode.
 	// When true (default), smoothstep produces smooth edges.
 	// When false, binary step produces aliased edges.
@@ -305,6 +300,12 @@ func NewGPURenderSession(device *wgpu.Device, queue *wgpu.Queue, sampleCount uin
 		sampleCount: sampleCount,
 		antiAlias:   true,
 	}
+}
+
+// SetSurfaceCompositor sets the compositor for backward compatibility.
+// Prefer GPURenderTarget.Compositor (per-frame, ADR-067 enterprise pattern).
+func (s *GPURenderSession) SetSurfaceCompositor(c gpucontext.SurfaceCompositor) {
+	s.compositor = c
 }
 
 // SetSurfaceTarget configures the session to render directly to the given
@@ -589,7 +590,9 @@ func (s *GPURenderSession) RenderFrame(
 	if len(sdfShapes) == 0 && len(convexCommands) == 0 && len(stencilPaths) == 0 && len(textBatches) == 0 && len(glyphMaskBatches) == 0 {
 		return nil
 	}
-	s.preserveContent = target.PreserveContent
+
+	// ADR-067: set compositor per-frame from render target.
+	s.compositor = target.Compositor
 
 	// Determine render target view: per-pass target.View takes priority
 	// over session-level surfaceView (backward compat).
@@ -703,7 +706,9 @@ func (s *GPURenderSession) RenderFrameGrouped(target gg.GPURenderTarget, groups 
 	if totalItems == 0 && baseLayer == nil {
 		return nil
 	}
-	s.preserveContent = target.PreserveContent
+
+	// ADR-067: set compositor per-frame from render target.
+	s.compositor = target.Compositor
 
 	// Determine render target view: per-pass target.View takes priority
 	// over session-level surfaceView (backward compat).
@@ -1249,27 +1254,17 @@ func (s *GPURenderSession) destroyPersistentBuffers() { //nolint:gocyclo,cyclop,
 	}
 }
 
-// releaseSurfaceCompositeBinding drops the bind group before its sampled
-// overlay resolve texture is destroyed or replaced. The vertex and uniform
-// buffers remain reusable across surface resizes.
+// releaseSurfaceCompositeBinding is now a no-op — composite resources are
+// managed by the compositor (gogpu). Kept as a method for backward compat
+// with callers during migration; will be removed after full migration.
 func (s *GPURenderSession) releaseSurfaceCompositeBinding() {
-	if s.surfaceCompositeBindGroup != nil {
-		s.surfaceCompositeBindGroup.Release()
-		s.surfaceCompositeBindGroup = nil
-	}
-	s.surfaceCompositeBoundView = nil
+	// No-op: compositor owns surface composite resources (ADR-067).
 }
 
+// destroySurfaceCompositeResources is now a no-op — composite resources are
+// managed by the compositor (gogpu).
 func (s *GPURenderSession) destroySurfaceCompositeResources() {
-	s.releaseSurfaceCompositeBinding()
-	if s.surfaceCompositeUniformBuf != nil {
-		s.surfaceCompositeUniformBuf.Release()
-		s.surfaceCompositeUniformBuf = nil
-	}
-	if s.surfaceCompositeVertBuf != nil {
-		s.surfaceCompositeVertBuf.Release()
-		s.surfaceCompositeVertBuf = nil
-	}
+	// No-op: compositor owns surface composite resources (ADR-067).
 }
 
 // sdfFrameResources holds per-frame GPU resources for SDF rendering.
@@ -2184,11 +2179,13 @@ func (s *GPURenderSession) buildGPUTextureResources(cmds []GPUTextureDrawCommand
 	}, nil
 }
 
-// buildSurfaceCompositeResources prepares a persistent full-surface textured
-// quad that samples the transparent single-sample overlay resolve texture.
-// Dedicated buffers keep this final pass independent from base-layer and
-// ordinary GPU-texture draw resources prepared earlier in the frame.
-func (s *GPURenderSession) buildSurfaceCompositeResources(w, h uint32) (*imageFrameResources, error) {
+// buildLegacySurfaceCompositeResources prepares per-frame resources for the
+// legacy MSAA overlay composite path (no compositor set). Creates temporary
+// vertex buffer, uniform buffer, and bind group for a full-surface blit quad.
+//
+// When the compositor is available (ADR-067), this function is never called;
+// MSAA compositing uses gogpu's dedicated blit pipeline instead.
+func (s *GPURenderSession) buildLegacySurfaceCompositeResources(w, h uint32) (*imageFrameResources, error) {
 	if s.textures.compositeView == nil {
 		return nil, fmt.Errorf("composition resolve view is nil")
 	}
@@ -2200,64 +2197,60 @@ func (s *GPURenderSession) buildSurfaceCompositeResources(w, h uint32) (*imageFr
 	}
 
 	const vertexBufferSize = 6 * imageVertexStride
-	if s.surfaceCompositeVertBuf == nil {
-		buf, err := s.device.CreateBuffer(&wgpu.BufferDescriptor{
-			Label: "surface_composite_vert_buf",
-			Size:  vertexBufferSize,
-			Usage: gputypes.BufferUsageVertex | gputypes.BufferUsageCopyDst,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("create composition vertex buffer: %w", err)
-		}
-		s.surfaceCompositeVertBuf = buf
+	vertBuf, err := s.device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "legacy_composite_vert_buf",
+		Size:  vertexBufferSize,
+		Usage: gputypes.BufferUsageVertex | gputypes.BufferUsageCopyDst,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create composition vertex buffer: %w", err)
 	}
 	vertices := buildImageVertices(&ImageDrawCommand{
 		DstW: float32(w), DstH: float32(h),
 		U0: 0, V0: 0, U1: 1, V1: 1,
 	})
-	if err := s.queue.WriteBuffer(s.surfaceCompositeVertBuf, 0, vertices); err != nil {
+	if err := s.queue.WriteBuffer(vertBuf, 0, vertices); err != nil {
+		vertBuf.Release()
 		return nil, fmt.Errorf("upload composition vertices: %w", err)
 	}
 
-	if s.surfaceCompositeUniformBuf == nil {
-		buf, err := s.device.CreateBuffer(&wgpu.BufferDescriptor{
-			Label: "surface_composite_uniform_buf",
-			Size:  imageUniformSize,
-			Usage: gputypes.BufferUsageUniform | gputypes.BufferUsageCopyDst,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("create composition uniform buffer: %w", err)
-		}
-		s.surfaceCompositeUniformBuf = buf
+	uniformBuf, err := s.device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "legacy_composite_uniform_buf",
+		Size:  imageUniformSize,
+		Usage: gputypes.BufferUsageUniform | gputypes.BufferUsageCopyDst,
+	})
+	if err != nil {
+		vertBuf.Release()
+		return nil, fmt.Errorf("create composition uniform buffer: %w", err)
 	}
-	if err := s.queue.WriteBuffer(s.surfaceCompositeUniformBuf, 0, makeImageUniform(w, h, 1)); err != nil {
+	if err := s.queue.WriteBuffer(uniformBuf, 0, makeImageUniform(w, h, 1)); err != nil {
+		vertBuf.Release()
+		uniformBuf.Release()
 		return nil, fmt.Errorf("upload composition uniform: %w", err)
 	}
 
-	if s.surfaceCompositeBindGroup == nil || s.surfaceCompositeBoundView != s.textures.compositeView {
-		bg, err := s.device.CreateBindGroup(&wgpu.BindGroupDescriptor{
-			Label:  "surface_composite_bind_group",
-			Layout: s.imagePipeline.uniformLayout,
-			Entries: []wgpu.BindGroupEntry{
-				{Binding: 0, Buffer: s.surfaceCompositeUniformBuf, Offset: 0, Size: imageUniformSize},
-				{Binding: 1, TextureView: s.textures.compositeView},
-				{Binding: 2, Sampler: s.imagePipeline.sampler},
-			},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("create composition bind group: %w", err)
-		}
-		if s.surfaceCompositeBindGroup != nil {
-			s.pendingBindGroupRelease = append(s.pendingBindGroupRelease, s.surfaceCompositeBindGroup)
-		}
-		s.surfaceCompositeBindGroup = bg
-		s.surfaceCompositeBoundView = s.textures.compositeView
+	bg, err := s.device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "legacy_composite_bind_group",
+		Layout: s.imagePipeline.uniformLayout,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: uniformBuf, Offset: 0, Size: imageUniformSize},
+			{Binding: 1, TextureView: s.textures.compositeView},
+			{Binding: 2, Sampler: s.imagePipeline.sampler},
+		},
+	})
+	if err != nil {
+		vertBuf.Release()
+		uniformBuf.Release()
+		return nil, fmt.Errorf("create composition bind group: %w", err)
 	}
 
+	// Schedule cleanup after submit (legacy path creates per-frame resources).
+	s.pendingBindGroupRelease = append(s.pendingBindGroupRelease, bg)
+
 	return &imageFrameResources{
-		vertBuf: s.surfaceCompositeVertBuf,
+		vertBuf: vertBuf,
 		drawCalls: []imageDrawCall{{
-			bindGroup: s.surfaceCompositeBindGroup,
+			bindGroup: bg,
 		}},
 	}, nil
 }
@@ -2809,7 +2802,7 @@ func (s *GPURenderSession) encodeSubmitSurface(
 		}
 	}()
 
-	renderTarget, colorLoadOp, compositeRes, err := s.prepareSurfacePass(view, w, h)
+	renderTarget, colorLoadOp, needsComposite, err := s.prepareSurfacePass(view, w, h)
 	if err != nil {
 		return err
 	}
@@ -2867,8 +2860,8 @@ func (s *GPURenderSession) encodeSubmitSurface(
 	if endErr := rp.End(); endErr != nil {
 		return fmt.Errorf("end render pass: %w", endErr)
 	}
-	if compositeRes != nil {
-		if err := s.encodeSurfaceCompositePass(encoder, view, w, h, compositeRes); err != nil {
+	if needsComposite {
+		if err := s.encodeSurfaceCompositePass(encoder, view, w, h); err != nil {
 			return err
 		}
 	}
@@ -3301,34 +3294,38 @@ func (s *GPURenderSession) encodeBlitOnlyPass(
 }
 
 // shouldPreserveSurface reports whether this pass must retain the current
-// single-sample surface contents. PreserveContent covers external producers;
-// frameRendered covers earlier gg flushes to the same view.
+// single-sample surface contents. This covers earlier gg flushes to the
+// same view (mid-frame CPU fallback), or when the compositor signals that
+// external content exists (g3d rendered before gg in the same frame).
 func (s *GPURenderSession) shouldPreserveSurface(view *wgpu.TextureView) bool {
-	return s.preserveContent || (s.frameRendered && view == s.lastView)
+	if s.compositor != nil && s.compositor.ShouldPreserveContent() {
+		return true
+	}
+	return s.frameRendered && view == s.lastView
 }
 
 // prepareSurfacePass selects the correct target for a vector surface pass.
 // Single-sample rendering can preserve the surface with LoadOpLoad. An MSAA
 // pass cannot load single-sample surface content into its transient attachment,
 // so it resolves a transparent overlay for a subsequent alpha-composite pass.
+//
+// Returns the render target view, LoadOp, and needsComposite flag. When
+// needsComposite is true, the caller must call encodeSurfaceCompositePass
+// after the render pass to alpha-blend the overlay onto the surface.
 func (s *GPURenderSession) prepareSurfacePass(
 	view *wgpu.TextureView,
 	w, h uint32,
-) (*wgpu.TextureView, gputypes.LoadOp, *imageFrameResources, error) {
+) (*wgpu.TextureView, gputypes.LoadOp, bool, error) {
 	if !s.shouldPreserveSurface(view) {
-		return view, gputypes.LoadOpClear, nil, nil
+		return view, gputypes.LoadOpClear, false, nil
 	}
 	if s.sampleCount <= 1 {
-		return view, gputypes.LoadOpLoad, nil, nil
+		return view, gputypes.LoadOpLoad, false, nil
 	}
 	if err := s.textures.ensureCompositeTexture(s.device, w, h, "session"); err != nil {
-		return nil, 0, nil, fmt.Errorf("ensure composition texture: %w", err)
+		return nil, 0, false, fmt.Errorf("ensure composition texture: %w", err)
 	}
-	res, err := s.buildSurfaceCompositeResources(w, h)
-	if err != nil {
-		return nil, 0, nil, fmt.Errorf("build composition resources: %w", err)
-	}
-	return s.textures.compositeView, gputypes.LoadOpClear, res, nil
+	return s.textures.compositeView, gputypes.LoadOpClear, true, nil
 }
 
 // encodeGroupedSurfacePass records the grouped vector pass. When existing
@@ -3344,7 +3341,7 @@ func (s *GPURenderSession) encodeGroupedSurfacePass(
 	grpRes []groupResources,
 	baseLayerRes *imageFrameResources,
 ) error {
-	renderTarget, colorLoadOp, compositeRes, err := s.prepareSurfacePass(view, w, h)
+	renderTarget, colorLoadOp, needsComposite, err := s.prepareSurfacePass(view, w, h)
 	if err != nil {
 		return err
 	}
@@ -3379,8 +3376,8 @@ func (s *GPURenderSession) encodeGroupedSurfacePass(
 		return fmt.Errorf("end grouped surface pass: %w", endErr)
 	}
 
-	if compositeRes != nil {
-		if err := s.encodeSurfaceCompositePass(encoder, view, w, h, compositeRes); err != nil {
+	if needsComposite {
+		if err := s.encodeSurfaceCompositePass(encoder, view, w, h); err != nil {
 			return err
 		}
 	}
@@ -3391,13 +3388,34 @@ func (s *GPURenderSession) encodeGroupedSurfacePass(
 }
 
 // encodeSurfaceCompositePass alpha-blends the transparent overlay resolve onto
-// the existing single-sample surface with the image pipeline's 1x blit variant.
+// the existing single-sample surface. When a compositor is set (ADR-067), the
+// composition is delegated to gogpu's blit pipeline via CompositeMSAAOverlay.
+// Otherwise falls back to the image pipeline's 1x blit variant.
 func (s *GPURenderSession) encodeSurfaceCompositePass(
 	encoder *wgpu.CommandEncoder,
 	view *wgpu.TextureView,
 	w, h uint32,
-	res *imageFrameResources,
 ) error {
+	if s.textures.compositeView == nil {
+		return fmt.Errorf("composite view is nil")
+	}
+
+	// ADR-067: delegate to gogpu's compositor when available.
+	if s.compositor != nil {
+		encHandle := gpucontext.NewCommandEncoder(unsafe.Pointer(encoder))                //nolint:gosec // Go spec Rule 1
+		viewHandle := gpucontext.NewTextureView(unsafe.Pointer(view))                     //nolint:gosec // Go spec Rule 1
+		compHandle := gpucontext.NewTextureView(unsafe.Pointer(s.textures.compositeView)) //nolint:gosec // Go spec Rule 1
+		return s.compositor.CompositeMSAAOverlay(encHandle, viewHandle, compHandle, w, h)
+	}
+
+	// Legacy path: use gg's own image pipeline blit.
+	if s.imagePipeline == nil {
+		return fmt.Errorf("no image pipeline for surface composite")
+	}
+	if err := s.imagePipeline.ensureBlitPipeline(); err != nil {
+		return fmt.Errorf("ensure blit pipeline for composite: %w", err)
+	}
+
 	rp, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
 		Label: "session_surface_composite_pass",
 		ColorAttachments: []wgpu.RenderPassColorAttachment{{
@@ -3412,7 +3430,17 @@ func (s *GPURenderSession) encodeSurfaceCompositePass(
 	}
 	rp.SetViewport(0, 0, float32(w), float32(h), 0, 1)
 	rp.SetScissorRect(0, 0, w, h)
+
+	// Build resources for the legacy path using the composite texture.
+	res, buildErr := s.buildLegacySurfaceCompositeResources(w, h)
+	if buildErr != nil {
+		if endErr := rp.End(); endErr != nil {
+			slogger().Warn("end surface composite pass after build error", "err", endErr)
+		}
+		return fmt.Errorf("build legacy surface composite resources: %w", buildErr)
+	}
 	s.imagePipeline.RecordBlitDraws(rp, res)
+
 	if endErr := rp.End(); endErr != nil {
 		return fmt.Errorf("end surface composite pass: %w", endErr)
 	}

--- a/internal/gpu/render_session_test.go
+++ b/internal/gpu/render_session_test.go
@@ -134,14 +134,13 @@ func TestRenderSessionMSAASurfacePreservationRoute(t *testing.T) {
 	tests := []struct {
 		name            string
 		sampleCount     uint32
-		preserveContent bool
-		previouslyDrawn bool
+		previouslyDrawn bool // simulates external content or earlier gg flush
 		wantComposition bool
 	}{
 		{
 			name:            "external content with MSAA",
 			sampleCount:     4,
-			preserveContent: true,
+			previouslyDrawn: true,
 			wantComposition: true,
 		},
 		{
@@ -157,7 +156,7 @@ func TestRenderSessionMSAASurfacePreservationRoute(t *testing.T) {
 		{
 			name:            "external content without MSAA",
 			sampleCount:     1,
-			preserveContent: true,
+			previouslyDrawn: true,
 		},
 	}
 
@@ -188,10 +187,8 @@ func TestRenderSessionMSAASurfacePreservationRoute(t *testing.T) {
 				ColorR: 1, ColorG: 1, ColorB: 1, ColorA: 1,
 			}}}}
 			target := gg.GPURenderTarget{
-				View:            gpucontext.NewTextureView(unsafe.Pointer(view)),
-				ViewWidth:       width,
-				ViewHeight:      height,
-				PreserveContent: tt.preserveContent,
+				View:      gpucontext.NewTextureView(unsafe.Pointer(view)),
+				ViewWidth: width, ViewHeight: height,
 			}
 			if err := s.RenderFrameGrouped(target, groups, nil, encoder); err != nil {
 				encoder.DiscardEncoding()
@@ -202,10 +199,8 @@ func TestRenderSessionMSAASurfacePreservationRoute(t *testing.T) {
 			if gotComposition != tt.wantComposition {
 				t.Fatalf("composition route = %v, want %v", gotComposition, tt.wantComposition)
 			}
-			if tt.wantComposition && (s.surfaceCompositeVertBuf == nil ||
-				s.surfaceCompositeUniformBuf == nil || s.surfaceCompositeBindGroup == nil) {
-				t.Fatal("composition route did not prepare its dedicated draw resources")
-			}
+			// Surface composite resources are now managed by the compositor
+			// (gogpu). We only verify the composition texture was created.
 			frameRendered, lastView := s.FrameState()
 			if !frameRendered || lastView != view {
 				t.Fatalf("frame state = (%v, %p), want (true, %p)", frameRendered, lastView, view)
@@ -238,11 +233,11 @@ func TestRenderSessionMSAASurfacePreservationNonGrouped(t *testing.T) {
 
 	s := NewGPURenderSession(device, queue, 4)
 	defer s.Destroy()
+	// Simulate external content by setting frame state before rendering.
+	s.SetFrameState(true, view)
 	target := gg.GPURenderTarget{
-		View:            gpucontext.NewTextureView(unsafe.Pointer(view)),
-		ViewWidth:       width,
-		ViewHeight:      height,
-		PreserveContent: true,
+		View:      gpucontext.NewTextureView(unsafe.Pointer(view)),
+		ViewWidth: width, ViewHeight: height,
 	}
 	shapes := []SDFRenderShape{{
 		Kind: 0, CenterX: 24, CenterY: 24, Param1: 12, Param2: 12,
@@ -255,7 +250,6 @@ func TestRenderSessionMSAASurfacePreservationNonGrouped(t *testing.T) {
 		t.Fatal("non-grouped preservation did not use the MSAA composition route")
 	}
 	firstCompositeView := s.textures.compositeView
-	firstBindGroup := s.surfaceCompositeBindGroup
 
 	const resizedWidth, resizedHeight = uint32(128), uint32(80)
 	resizedTex, resizedView := createMockSurfaceView(t, device, resizedWidth, resizedHeight)
@@ -270,12 +264,8 @@ func TestRenderSessionMSAASurfacePreservationNonGrouped(t *testing.T) {
 	if s.textures.compositeView == firstCompositeView {
 		t.Fatal("surface resize did not recreate the composition resolve view")
 	}
-	if s.surfaceCompositeBindGroup == firstBindGroup {
-		t.Fatal("surface resize did not recreate the composition bind group")
-	}
-	if s.surfaceCompositeBoundView != s.textures.compositeView {
-		t.Fatal("composition bind group does not reference the resized resolve view")
-	}
+	// Surface composite bind groups are now managed by the compositor (gogpu).
+	// We only verify that the composition texture was recreated on resize.
 }
 
 func TestRenderSessionMSAAAttachmentDiscardsResolvedStorage(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Compositor architecture migration** (ADR-067) — gg becomes a pure drawing library. Surface-level compositor decisions (LoadOp, damage scissoring, MSAA overlay compositing) delegated to gogpu via `SurfaceCompositor` interface.
- Remove unused `compositorWired` field (lint fix)
- **deps:** gpucontext v0.26.0 → v0.27.0, gogpu v0.51.0 → v0.52.0

## Test plan

- [x] `go build ./...` clean (GOWORK=off)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` — 0 issues (Windows, Linux, macOS)
- [x] `gofmt -l .` clean
- [x] 2 pre-existing test failures (TestShearAliased, TestVariableFont_Shear) — not caused by this change