### PR TITLE
fix: size layers and masks in physical pixels

### DIFF
--- a/context_layer.go
+++ b/context_layer.go
@@ -65,8 +65,10 @@ func (c *Context) PushLayer(blendMode BlendMode, opacity float64) {
 		c.basePixmap = c.pixmap
 	}
 
-	// Create new pixmap for the layer (same size as context)
-	layerPixmap := NewPixmap(c.width, c.height)
+	// Create the layer at the physical resolution used by the renderer. The
+	// context dimensions are logical when deviceScale != 1, but drawing paths
+	// are transformed into device coordinates before rasterization.
+	layerPixmap := NewPixmap(c.PixelWidth(), c.PixelHeight())
 	layerPixmap.Clear(Transparent)
 
 	// Create layer
@@ -162,8 +164,10 @@ func (c *Context) PushMaskLayer(mask *Mask) {
 		c.basePixmap = c.pixmap
 	}
 
-	// Create new pixmap for the layer (same size as context).
-	layerPixmap := NewPixmap(c.width, c.height)
+	// Create the layer at the physical resolution used by the renderer. The
+	// context dimensions are logical when deviceScale != 1, but drawing paths
+	// are transformed into device coordinates before rasterization.
+	layerPixmap := NewPixmap(c.PixelWidth(), c.PixelHeight())
 	layerPixmap.Clear(Transparent)
 
 	// Create layer with mask.

--- a/context_layer_test.go
+++ b/context_layer_test.go
@@ -92,6 +92,93 @@ func TestLayerCompositing(t *testing.T) {
 	}
 }
 
+// TestPushLayerDeviceScaleCompositesPhysicalBounds verifies that a layer uses
+// the physical dimensions of a HiDPI context. Rendering still uses logical
+// coordinates, but the transformed path covers the complete physical target.
+func TestPushLayerDeviceScaleCompositesPhysicalBounds(t *testing.T) {
+	const (
+		logicalWidth  = 3
+		logicalHeight = 2
+		deviceScale   = 2.0
+	)
+
+	dc := NewContext(logicalWidth, logicalHeight, WithDeviceScale(deviceScale))
+	defer func() { _ = dc.Close() }()
+
+	dc.PushLayer(BlendNormal, 1.0)
+	if got, want := dc.pixmap.Width(), dc.PixelWidth(); got != want {
+		t.Fatalf("layer width = %d, want physical width %d", got, want)
+	}
+	if got, want := dc.pixmap.Height(), dc.PixelHeight(); got != want {
+		t.Fatalf("layer height = %d, want physical height %d", got, want)
+	}
+
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, logicalWidth, logicalHeight)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+	dc.PopLayer()
+
+	if got, want := dc.Image().Bounds().Dx(), dc.PixelWidth(); got != want {
+		t.Fatalf("composited image width = %d, want physical width %d", got, want)
+	}
+	if got, want := dc.Image().Bounds().Dy(), dc.PixelHeight(); got != want {
+		t.Fatalf("composited image height = %d, want physical height %d", got, want)
+	}
+
+	for _, point := range [][2]int{
+		{0, 0},
+		{dc.PixelWidth() - 1, 0},
+		{0, dc.PixelHeight() - 1},
+		{dc.PixelWidth() - 1, dc.PixelHeight() - 1},
+	} {
+		pixel := dc.pixmap.GetPixel(point[0], point[1])
+		if pixel.R < 0.9 || pixel.A < 0.9 {
+			t.Errorf("pixel at physical (%d,%d) = %+v, want opaque red", point[0], point[1], pixel)
+		}
+	}
+}
+
+// TestPushLayerWithPhysicalPixmapDeviceScale verifies that a custom pixmap
+// sized to the physical HiDPI dimensions remains the layer compositing target.
+func TestPushLayerWithPhysicalPixmapDeviceScale(t *testing.T) {
+	const (
+		logicalWidth  = 3
+		logicalHeight = 2
+		deviceScale   = 2.0
+	)
+
+	physicalPixmap := NewPixmap(logicalWidth*2, logicalHeight*2)
+	dc := NewContext(logicalWidth, logicalHeight,
+		WithDeviceScale(deviceScale), WithPixmap(physicalPixmap))
+	defer func() { _ = dc.Close() }()
+
+	if dc.pixmap != physicalPixmap {
+		t.Fatal("context did not use the supplied physical pixmap")
+	}
+
+	dc.PushLayer(BlendNormal, 1.0)
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, logicalWidth, logicalHeight)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+	dc.PopLayer()
+
+	for _, point := range [][2]int{
+		{0, 0},
+		{dc.PixelWidth() - 1, 0},
+		{0, dc.PixelHeight() - 1},
+		{dc.PixelWidth() - 1, dc.PixelHeight() - 1},
+	} {
+		pixel := physicalPixmap.GetPixel(point[0], point[1])
+		if pixel.R < 0.9 || pixel.A < 0.9 {
+			t.Errorf("pixel at physical (%d,%d) = %+v, want opaque red", point[0], point[1], pixel)
+		}
+	}
+}
+
 // TestPopWithoutPush tests that PopLayer doesn't crash when no layer is pushed.
 func TestPopWithoutPush(t *testing.T) {
 	dc := NewContext(100, 100)

--- a/context_mask.go
+++ b/context_mask.go
@@ -1,6 +1,8 @@
 package gg
 
-// SetMask sets an alpha mask for subsequent drawing operations.
+// SetMask sets an alpha mask for subsequent drawing operations. Mask
+// coordinates are physical pixel coordinates; AsMask returns a mask at the
+// context's physical dimensions.
 // The mask modulates the alpha of all Fill and Stroke operations —
 // each pixel's coverage is multiplied by the mask value at that pixel.
 // A mask value of 255 means fully visible, 0 means fully transparent.
@@ -32,7 +34,8 @@ func (c *Context) ClearMask() {
 }
 
 // ApplyMask applies a mask to already-drawn content using DestinationIn blending.
-// For each pixel, the alpha is modulated by the mask value:
+// Mask coordinates are physical pixel coordinates. For each pixel, the alpha
+// is modulated by the mask value:
 //
 //	pixel.A = pixel.A * mask.At(x,y) / 255
 //
@@ -80,10 +83,14 @@ func (c *Context) ApplyMask(mask *Mask) {
 //	dc.Fill()              // clears the path!
 //	mask := dc.AsMask()    // path is empty → mask is all zeros
 func (c *Context) AsMask() *Mask {
-	mask := NewMask(c.Width(), c.Height())
+	// Masks are indexed in device pixels, just like the context pixmap. Keep
+	// AsMask output physical-sized so it can be passed directly to SetMask,
+	// ApplyMask, or PushMaskLayer at any device scale.
+	mask := NewMask(c.PixelWidth(), c.PixelHeight())
 
-	// Create a temporary context for rasterizing the path
-	temp := NewContext(c.Width(), c.Height())
+	// Create a temporary context for rasterizing the path at the same device
+	// scale as the source context.
+	temp := NewContext(c.Width(), c.Height(), WithDeviceScale(c.deviceScale))
 	temp.path = c.path.Clone()
 	temp.SetRGBA(1, 1, 1, 1)
 	_ = temp.Fill() // Software renderer never fails

--- a/mask.go
+++ b/mask.go
@@ -3,15 +3,18 @@ package gg
 import "image"
 
 // Mask represents an alpha mask for compositing operations.
-// Values range from 0 (fully transparent) to 255 (fully opaque).
+// Values range from 0 (fully transparent) to 255 (fully opaque). Mask dimensions
+// and coordinates are in pixel space; for HiDPI Contexts, use physical
+// dimensions (PixelWidth/PixelHeight).
 type Mask struct {
 	width  int
 	height int
 	data   []uint8
 }
 
-// NewMask creates a new empty mask with the given dimensions.
-// All values are initialized to 0 (fully transparent).
+// NewMask creates a new empty mask with the given pixel dimensions.
+// All values are initialized to 0 (fully transparent). For a HiDPI Context,
+// use PixelWidth and PixelHeight rather than Width and Height.
 func NewMask(width, height int) *Mask {
 	return &Mask{
 		width:  width,

--- a/mask_test.go
+++ b/mask_test.go
@@ -494,6 +494,94 @@ func TestAsMask_AfterFill(t *testing.T) {
 	}
 }
 
+// TestAsMaskPushMaskLayerDeviceScale verifies that AsMask returns a mask in
+// the physical pixel space used by a HiDPI context. The mask can then be
+// passed directly to PushMaskLayer without losing the scaled path bounds.
+func TestAsMaskPushMaskLayerDeviceScale(t *testing.T) {
+	const (
+		logicalWidth  = 3
+		logicalHeight = 2
+		deviceScale   = 2.0
+	)
+
+	dc := NewContext(logicalWidth, logicalHeight, WithDeviceScale(deviceScale))
+	defer func() { _ = dc.Close() }()
+
+	dc.DrawRectangle(0, 0, logicalWidth, logicalHeight)
+	mask := dc.AsMask()
+	if got, want := mask.Width(), dc.PixelWidth(); got != want {
+		t.Fatalf("AsMask width = %d, want physical width %d", got, want)
+	}
+	if got, want := mask.Height(), dc.PixelHeight(); got != want {
+		t.Fatalf("AsMask height = %d, want physical height %d", got, want)
+	}
+	dc.ClearPath()
+
+	dc.PushMaskLayer(mask)
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, logicalWidth, logicalHeight)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+	dc.PopLayer()
+
+	for _, point := range [][2]int{
+		{0, 0},
+		{dc.PixelWidth() - 1, 0},
+		{0, dc.PixelHeight() - 1},
+		{dc.PixelWidth() - 1, dc.PixelHeight() - 1},
+	} {
+		pixel := dc.pixmap.GetPixel(point[0], point[1])
+		if pixel.R < 0.9 || pixel.A < 0.9 {
+			t.Errorf("pixel at physical (%d,%d) = %+v, want opaque red", point[0], point[1], pixel)
+		}
+	}
+}
+
+// TestAsMaskPushMaskLayerDeviceScaleNested verifies that independently
+// generated physical masks compose correctly through nested masked layers.
+func TestAsMaskPushMaskLayerDeviceScaleNested(t *testing.T) {
+	const (
+		logicalSize = 4
+		deviceScale = 2.0
+	)
+
+	dc := NewContext(logicalSize, logicalSize, WithDeviceScale(deviceScale))
+	defer func() { _ = dc.Close() }()
+
+	// The outer mask covers the whole logical canvas; the inner mask covers its
+	// centered 2x2 logical rectangle.
+	dc.DrawRectangle(0, 0, logicalSize, logicalSize)
+	outerMask := dc.AsMask()
+	dc.ClearPath()
+	dc.DrawRectangle(1, 1, 2, 2)
+	innerMask := dc.AsMask()
+	dc.ClearPath()
+
+	dc.PushMaskLayer(outerMask)
+	dc.PushMaskLayer(innerMask)
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, logicalSize, logicalSize)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+	dc.PopLayer()
+	dc.PopLayer()
+
+	for _, point := range [][2]int{{4, 4}} {
+		pixel := dc.pixmap.GetPixel(point[0], point[1])
+		if pixel.R < 0.9 || pixel.A < 0.9 {
+			t.Errorf("pixel inside nested masks at physical (%d,%d) = %+v, want opaque red", point[0], point[1], pixel)
+		}
+	}
+	for _, point := range [][2]int{{0, 0}, {1, 1}, {7, 7}} {
+		pixel := dc.pixmap.GetPixel(point[0], point[1])
+		if pixel.A != 0 {
+			t.Errorf("pixel outside nested masks at physical (%d,%d) = %+v, want transparent", point[0], point[1], pixel)
+		}
+	}
+}
+
 // TestSetMask_Rider21Reproduction reproduces the exact scenario from gg#238.
 // User creates a mask from a circle, sets it, then fills a rectangle.
 // Without the fix, the mask was ignored and the full rectangle was drawn.
@@ -789,6 +877,56 @@ func TestPushMaskLayer_Basic(t *testing.T) {
 	aCorner := pixelAlpha(img, 5, 5)
 	if aCorner != 0 {
 		t.Errorf("corner should be transparent, got a=%d", aCorner)
+	}
+}
+
+// TestPushMaskLayerDeviceScaleCompositesPhysicalBounds verifies that masked
+// layers are allocated at the physical resolution of a HiDPI context. Masks
+// are pixel-space data, so this test supplies one at the physical dimensions.
+func TestPushMaskLayerDeviceScaleCompositesPhysicalBounds(t *testing.T) {
+	const (
+		logicalWidth  = 3
+		logicalHeight = 2
+		deviceScale   = 2.0
+	)
+
+	dc := NewContext(logicalWidth, logicalHeight, WithDeviceScale(deviceScale))
+	defer func() { _ = dc.Close() }()
+
+	mask := NewMask(dc.PixelWidth(), dc.PixelHeight())
+	mask.Fill(255)
+	dc.PushMaskLayer(mask)
+	if got, want := dc.pixmap.Width(), dc.PixelWidth(); got != want {
+		t.Fatalf("masked layer width = %d, want physical width %d", got, want)
+	}
+	if got, want := dc.pixmap.Height(), dc.PixelHeight(); got != want {
+		t.Fatalf("masked layer height = %d, want physical height %d", got, want)
+	}
+
+	dc.SetRGBA(1, 0, 0, 1)
+	dc.DrawRectangle(0, 0, logicalWidth, logicalHeight)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+	dc.PopLayer()
+
+	if got, want := dc.Image().Bounds().Dx(), dc.PixelWidth(); got != want {
+		t.Fatalf("composited image width = %d, want physical width %d", got, want)
+	}
+	if got, want := dc.Image().Bounds().Dy(), dc.PixelHeight(); got != want {
+		t.Fatalf("composited image height = %d, want physical height %d", got, want)
+	}
+
+	for _, point := range [][2]int{
+		{0, 0},
+		{dc.PixelWidth() - 1, 0},
+		{0, dc.PixelHeight() - 1},
+		{dc.PixelWidth() - 1, dc.PixelHeight() - 1},
+	} {
+		pixel := dc.pixmap.GetPixel(point[0], point[1])
+		if pixel.R < 0.9 || pixel.A < 0.9 {
+			t.Errorf("pixel at physical (%d,%d) = %+v, want opaque red", point[0], point[1], pixel)
+		}
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -48,12 +48,19 @@ func WithRenderer(r Renderer) ContextOption {
 }
 
 // WithPixmap sets a custom pixmap for the Context.
-// The pixmap dimensions should match the Context dimensions.
+// The pixmap dimensions must match the Context's physical dimensions. At the
+// default device scale, this is Width x Height; when WithDeviceScale is used,
+// allocate PixelWidth x PixelHeight (logical dimensions multiplied by scale).
 //
 // Example:
 //
 //	pm := gg.NewPixmap(800, 600)
 //	dc := gg.NewContext(800, 600, gg.WithPixmap(pm))
+//
+// For a 2x context, use a physical pixmap:
+//
+//	pm := gg.NewPixmap(1600, 1200)
+//	dc := gg.NewContext(800, 600, gg.WithDeviceScale(2), gg.WithPixmap(pm))
 func WithPixmap(pm *Pixmap) ContextOption {
 	return func(o *contextOptions) {
 		o.pixmap = pm


### PR DESCRIPTION
## What changed

- allocate `PushLayer` and `PushMaskLayer` pixmaps at the context's physical pixel dimensions
- make `AsMask` rasterize and return a physical-sized mask at the context's device scale
- document the physical-pixel contract for masks and custom pixmaps
- add HiDPI regressions for plain layers, masked layers, nested generated masks, and custom physical pixmaps

## Why

HiDPI drawing paths are transformed into device coordinates, but layers were allocated with logical `Context` dimensions. At a 2x device scale, the layer covered only the top-left quarter of the physical target, so drawing near the right or bottom edge was clipped away. `AsMask` had the same logical/physical mismatch, making its output unsafe to feed directly into `SetMask`, `ApplyMask`, or `PushMaskLayer`.

The fix keeps all layer and mask storage in the same physical pixel space as the renderer while preserving logical drawing coordinates.

## Impact

Layer compositing and mask workflows now cover the full backing pixmap on Retina/HiDPI contexts. Scale-1 behavior is unchanged. Callers supplying custom pixmaps or masks now have an explicit physical-dimension contract.

## Verification

- focused layer/mask/AsMask/custom-pixmap regression tests
- `go test -tags nogpu ./... -count=1`
- `go test -race -tags nogpu ./... -count=1`
- `go build ./...`
- `CGO_ENABLED=0 go vet ./...`
- `gofmt` and `git diff --check`
- independent implementation review and baseline discrimination
