### PR TITLE
fix: preserve transformed rectangular clips

### DIFF
--- a/context_clip.go
+++ b/context_clip.go
@@ -58,8 +58,21 @@ func (c *Context) ClipRect(x, y, w, h float64) {
 		c.initClipStack()
 	}
 
-	// Transform the rectangle corners to device coordinates.
 	tm := c.totalMatrix()
+	// A scissor rectangle can represent the transformed shape only when the
+	// linear part of the transform keeps the rectangle axis-aligned.  The old
+	// implementation transformed just two opposite corners and took their
+	// bounding box, which collapses a square at 45 degrees and clips the wrong
+	// pixels for any rotation or shear.  Preserve the cheap rectangle path for
+	// translations/scales, and rasterize the exact device-space quadrilateral
+	// otherwise.
+	if !isAxisAlignedTransform(tm) {
+		devicePath := transformedRectPath(tm, x, y, w, h)
+		c.pushDevicePathClip(devicePath)
+		return
+	}
+
+	// Transform the rectangle corners to device coordinates.
 	p1 := tm.TransformPoint(Pt(x, y))
 	p2 := tm.TransformPoint(Pt(x+w, y+h))
 
@@ -76,12 +89,16 @@ func (c *Context) ClipRect(x, y, w, h float64) {
 
 // ClipRoundRect sets a rounded rectangle clipping region.
 // The rectangle is defined by (x, y, w, h) in user coordinates and the
-// corners are rounded with the given radius. The radius is clamped to
-// min(w, h)/2. If radius is zero, this is equivalent to ClipRect.
+// corners are rounded with the given radius. The radius is clamped to half the
+// minimum absolute dimension. If radius is zero, this is equivalent to
+// ClipRect.
 //
-// On GPU, this uses a two-level clip strategy:
+// On GPU, axis-aligned clips use a two-level strategy:
 //   - Scissor rect (hardware, free) for the bounding box
 //   - Analytic SDF in the fragment shader for the rounded corners
+//
+// Transformed clips use the depth clip path so the rotated/sheared shape is
+// preserved exactly.
 //
 // On CPU, the SDF is evaluated per-pixel during coverage computation.
 func (c *Context) ClipRoundRect(x, y, w, h, radius float64) {
@@ -94,8 +111,21 @@ func (c *Context) ClipRoundRect(x, y, w, h, radius float64) {
 		c.initClipStack()
 	}
 
-	// Transform the rectangle corners to device coordinates.
 	tm := c.totalMatrix()
+	// A rounded rectangle remains an axis-aligned rounded rectangle only when
+	// the transform has no rotation/shear and applies the same magnitude of
+	// scale on both axes. Under a general affine transform its quarter-circles
+	// become rotated/elliptical curves, so use a transformed path rather than
+	// approximating the shape with its bounding box and a scalar radius.
+	if !isUniformAxisAlignedTransform(tm) {
+		pathX, pathY, pathW, pathH := normalizeRect(x, y, w, h)
+		userPath := NewPath()
+		userPath.RoundedRectangle(pathX, pathY, pathW, pathH, radius)
+		c.pushDevicePathClip(userPath.Transform(tm))
+		return
+	}
+
+	// Transform the rectangle corners to device coordinates.
 	p1 := tm.TransformPoint(Pt(x, y))
 	p2 := tm.TransformPoint(Pt(x+w, y+h))
 
@@ -116,6 +146,66 @@ func (c *Context) ClipRoundRect(x, y, w, h, radius float64) {
 
 	rect := clip.NewRect(devX, devY, devW, devH)
 	c.clipStack.PushRRect(rect, scaledRadius)
+}
+
+// isAxisAlignedTransform reports whether the linear part of m keeps the axes
+// axis-aligned, possibly swapping them. Use exact comparisons: treating a
+// small shear as zero can produce a large clipping error when combined with
+// large coordinates or a very small axis scale.
+func isAxisAlignedTransform(m Matrix) bool {
+	return (m.B == 0 && m.D == 0) || (m.A == 0 && m.E == 0)
+}
+
+// isUniformAxisAlignedTransform reports whether m keeps rounded rectangles
+// axis-aligned without changing circular corners into ellipses. Reflections
+// are included; only the magnitudes of the two axis scales must match.
+func isUniformAxisAlignedTransform(m Matrix) bool {
+	switch {
+	case m.B == 0 && m.D == 0:
+		return math.Abs(m.A) == math.Abs(m.E)
+	case m.A == 0 && m.E == 0:
+		return math.Abs(m.B) == math.Abs(m.D)
+	default:
+		return false
+	}
+}
+
+// normalizeRect rewrites a rectangle with negative dimensions using its
+// geometric top-left corner and positive extents. This matches ClipRect's
+// min/abs handling and keeps transformed rounded-rectangle paths well formed.
+func normalizeRect(x, y, w, h float64) (float64, float64, float64, float64) {
+	if w < 0 {
+		x += w
+		w = -w
+	}
+	if h < 0 {
+		y += h
+		h = -h
+	}
+	return x, y, w, h
+}
+
+// transformedRectPath builds a closed rectangle in device coordinates.
+func transformedRectPath(tm Matrix, x, y, w, h float64) *Path {
+	p := NewPath()
+	p1 := tm.TransformPoint(Pt(x, y))
+	p2 := tm.TransformPoint(Pt(x+w, y))
+	p3 := tm.TransformPoint(Pt(x+w, y+h))
+	p4 := tm.TransformPoint(Pt(x, y+h))
+	p.MoveTo(p1.X, p1.Y)
+	p.LineTo(p2.X, p2.Y)
+	p.LineTo(p3.X, p3.Y)
+	p.LineTo(p4.X, p4.Y)
+	p.Close()
+	return p
+}
+
+// pushDevicePathClip adds an already device-space path to the clip stack and
+// keeps a copy for the GPU depth-clip path when a GPU backend is active.
+func (c *Context) pushDevicePathClip(devicePath *Path) {
+	clipVerbs, clipCoords := ConvertPathToClipVerbs(devicePath)
+	_ = c.clipStack.PushPath(clipVerbs, clipCoords, true)
+	c.gpuClipPath = devicePath.Clone()
 }
 
 // ResetClip removes all clipping regions, restoring the full canvas as drawable.

--- a/context_clip_transform_test.go
+++ b/context_clip_transform_test.go
@@ -1,0 +1,271 @@
+package gg
+
+import (
+	"math"
+	"testing"
+)
+
+func TestClipRectRotated45PreservesShape(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+	dc.Translate(100, 100)
+	dc.Rotate(math.Pi / 4)
+	dc.Translate(-100, -100)
+	dc.ClipRect(60, 60, 80, 80)
+	if dc.clipStack.IsRectOnly() {
+		t.Fatal("rotated ClipRect should use an exact path clip")
+	}
+
+	dc.SetRGB(1, 0, 0)
+	dc.DrawRectangle(0, 0, 200, 200)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill() failed: %v", err)
+	}
+
+	// The center is inside the rotated square.
+	assertPixelRed(t, dc.pixmap.GetPixel(100, 100), "center")
+	// A point on the top edge of the axis-aligned bounding box is outside the
+	// rotated square and must remain the white background.
+	assertPixelWhite(t, dc.pixmap.GetPixel(100, 40), "outside rotated square")
+}
+
+func TestClipRoundRectRotated45PreservesShape(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+	dc.Translate(100, 100)
+	dc.Rotate(math.Pi / 4)
+	dc.Translate(-100, -100)
+	dc.ClipRoundRect(60, 60, 80, 80, 12)
+	if dc.clipStack.IsRRectOnly() {
+		t.Fatal("rotated ClipRoundRect should use an exact path clip")
+	}
+
+	dc.SetRGB(1, 0, 0)
+	dc.DrawRectangle(0, 0, 200, 200)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill() failed: %v", err)
+	}
+
+	assertPixelRed(t, dc.pixmap.GetPixel(100, 100), "center")
+	assertPixelWhite(t, dc.pixmap.GetPixel(100, 40), "outside rotated rounded square")
+}
+
+func TestClipRectShearedPreservesShape(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+	dc.Translate(100, 100)
+	dc.Shear(0.5, 0)
+	dc.Translate(-100, -100)
+	dc.ClipRect(60, 60, 80, 80)
+
+	dc.SetRGB(1, 0, 0)
+	dc.DrawRectangle(0, 0, 200, 200)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill() failed: %v", err)
+	}
+
+	assertPixelRed(t, dc.pixmap.GetPixel(100, 100), "sheared clip center")
+	assertPixelWhite(t, dc.pixmap.GetPixel(50, 130), "outside sheared clip")
+}
+
+func TestClipRoundRectShearedPreservesShape(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+	dc.Translate(100, 100)
+	dc.Shear(0.5, 0)
+	dc.Translate(-100, -100)
+	dc.ClipRoundRect(60, 60, 80, 80, 12)
+
+	dc.SetRGB(1, 0, 0)
+	dc.DrawRectangle(0, 0, 200, 200)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill() failed: %v", err)
+	}
+
+	assertPixelRed(t, dc.pixmap.GetPixel(100, 100), "sheared rounded clip center")
+	assertPixelWhite(t, dc.pixmap.GetPixel(50, 130), "outside sheared rounded clip")
+}
+
+func TestClipRoundRectNonUniformScaleMatchesPath(t *testing.T) {
+	got := renderNonUniformRoundRectClip(false)
+	want := renderNonUniformRoundRectClip(true)
+	assertPixmapsEqual(t, got, want)
+}
+
+func TestClipRoundRectRotatedNegativeDimensionsMatchesPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		x, y, w, h float64
+	}{
+		{name: "width", x: 140, y: 60, w: -80, h: 80},
+		{name: "height", x: 60, y: 140, w: 80, h: -80},
+		{name: "both", x: 140, y: 140, w: -80, h: -80},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderRotatedNegativeRoundRectClip(false, tt.x, tt.y, tt.w, tt.h)
+			want := renderRotatedNegativeRoundRectClip(true, tt.x, tt.y, tt.w, tt.h)
+			assertPixmapsEqual(t, got, want)
+		})
+	}
+}
+
+func TestClipRectScaleTranslatePreservesFastPath(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+	dc.Translate(20, 30)
+	dc.Scale(2, 3)
+	dc.ClipRect(10, 10, 20, 20)
+	if !dc.clipStack.IsRectOnly() {
+		t.Fatal("axis-aligned ClipRect should keep the rectangular clip fast path")
+	}
+
+	dc.SetRGB(1, 0, 0)
+	dc.DrawRectangle(0, 0, 200, 200)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill() failed: %v", err)
+	}
+
+	assertPixelRed(t, dc.pixmap.GetPixel(60, 90), "scaled clip center")
+	assertPixelWhite(t, dc.pixmap.GetPixel(20, 20), "outside scaled clip")
+}
+
+func TestClipRoundRectScaleTranslatePreservesFastPath(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.ClearWithColor(White)
+	dc.Translate(20, 30)
+	dc.Scale(2, 2)
+	dc.ClipRoundRect(10, 10, 20, 20, 4)
+	if !dc.clipStack.IsRRectOnly() {
+		t.Fatal("axis-aligned ClipRoundRect should keep the rounded-rectangle clip path")
+	}
+
+	dc.SetRGB(1, 0, 0)
+	dc.DrawRectangle(0, 0, 200, 200)
+	if err := dc.Fill(); err != nil {
+		t.Fatalf("Fill() failed: %v", err)
+	}
+
+	assertPixelRed(t, dc.pixmap.GetPixel(60, 70), "scaled rounded clip center")
+	assertPixelWhite(t, dc.pixmap.GetPixel(20, 20), "outside scaled rounded clip")
+}
+
+func TestClipRectAxisAlignedReflectionKeepsFastPath(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.Scale(-2, 3)
+	dc.ClipRect(10, 10, 20, 20)
+	if !dc.clipStack.IsRectOnly() {
+		t.Fatal("axis-aligned reflection should keep the rectangular clip fast path")
+	}
+}
+
+func TestClipRectExactAxisSwapKeepsFastPath(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.SetTransform(Matrix{B: -2, D: 3})
+	dc.ClipRect(10, 10, 20, 30)
+	if !dc.clipStack.IsRectOnly() {
+		t.Fatal("exact axis swap should keep the rectangular clip fast path")
+	}
+}
+
+func TestClipRectTinyShearUsesPath(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.SetTransform(Matrix{A: 1, B: 5e-13, E: 1})
+	dc.ClipRect(10, 10, 20, 30)
+	if dc.clipStack.IsRectOnly() {
+		t.Fatal("a non-zero shear must not use the rectangular clip fast path")
+	}
+}
+
+func TestClipRoundRectTinyNonUniformScaleUsesPath(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.SetTransform(Matrix{A: 1e-13, E: 2e-13})
+	dc.ClipRoundRect(10, 10, 20, 30, 4)
+	if dc.clipStack.IsRRectOnly() {
+		t.Fatal("non-uniform scale must not use the rounded-rectangle clip fast path")
+	}
+}
+
+func TestClipRoundRectExactAxisSwapKeepsFastPath(t *testing.T) {
+	dc := NewContext(200, 200)
+	dc.SetTransform(Matrix{B: -2, D: 2})
+	dc.ClipRoundRect(10, 10, 20, 30, 4)
+	if !dc.clipStack.IsRRectOnly() {
+		t.Fatal("uniform axis swap should keep the rounded-rectangle clip fast path")
+	}
+}
+
+func renderNonUniformRoundRectClip(directPath bool) *Context {
+	dc := NewContext(300, 300)
+	dc.ClearWithColor(White)
+	if directPath {
+		path := NewPath()
+		path.RoundedRectangle(20, 20, 100, 80, 20)
+		dc.SetPath(path.Transform(Scale(2, 3)))
+		dc.Clip()
+		dc.SetRGB(1, 0, 0)
+		dc.DrawRectangle(0, 0, 300, 300)
+	} else {
+		dc.Scale(2, 3)
+		dc.ClipRoundRect(20, 20, 100, 80, 20)
+		dc.SetTransform(Identity())
+		dc.SetRGB(1, 0, 0)
+		dc.DrawRectangle(0, 0, 300, 300)
+	}
+	_ = dc.Fill()
+	return dc
+}
+
+func renderRotatedNegativeRoundRectClip(directPath bool, x, y, w, h float64) *Context {
+	dc := NewContext(240, 240)
+	dc.ClearWithColor(White)
+	dc.Translate(120, 120)
+	dc.Rotate(math.Pi / 4)
+	dc.Translate(-120, -120)
+	tm := dc.GetTransform()
+	if directPath {
+		path := NewPath()
+		// All cases above describe the same 80×80 user-space rectangle at
+		// (60,60), using different negative-dimension spellings.
+		path.RoundedRectangle(60, 60, 80, 80, 12)
+		dc.SetTransform(Identity())
+		dc.SetPath(path.Transform(tm))
+		dc.Clip()
+		dc.SetRGB(1, 0, 0)
+		dc.DrawRectangle(0, 0, 240, 240)
+	} else {
+		dc.ClipRoundRect(x, y, w, h, 12)
+		dc.SetTransform(Identity())
+		dc.SetRGB(1, 0, 0)
+		dc.DrawRectangle(0, 0, 240, 240)
+	}
+	_ = dc.Fill()
+	return dc
+}
+
+func assertPixmapsEqual(t *testing.T, got, want *Context) {
+	t.Helper()
+	for y := 0; y < got.pixmap.Height(); y++ {
+		for x := 0; x < got.pixmap.Width(); x++ {
+			gotPixel := got.pixmap.GetPixel(x, y)
+			wantPixel := want.pixmap.GetPixel(x, y)
+			if gotPixel != wantPixel {
+				t.Fatalf("pixel mismatch at (%d,%d): got=%+v want=%+v", x, y, gotPixel, wantPixel)
+			}
+		}
+	}
+}
+
+func assertPixelRed(t *testing.T, got RGBA, label string) {
+	t.Helper()
+	if got.R < 0.9 || got.G > 0.1 || got.B > 0.1 {
+		t.Errorf("%s: expected red, got R=%.3f G=%.3f B=%.3f A=%.3f", label, got.R, got.G, got.B, got.A)
+	}
+}
+
+func assertPixelWhite(t *testing.T, got RGBA, label string) {
+	t.Helper()
+	if got.R < 0.9 || got.G < 0.9 || got.B < 0.9 {
+		t.Errorf("%s: expected white, got R=%.3f G=%.3f B=%.3f A=%.3f", label, got.R, got.G, got.B, got.A)
+	}
+}


### PR DESCRIPTION
## What changed

- preserve `ClipRect` geometry under rotation and shear by using an exact transformed quadrilateral path
- preserve `ClipRoundRect` geometry under rotation, shear, and non-uniform scale by using an exact transformed rounded path
- retain rectangular and rounded-rectangle fast paths only for transforms that represent the result exactly, including exact axis swaps and reflections
- avoid approximate fast-path classification so even tiny shears and non-uniform scales preserve geometry
- normalize negative rounded-rectangle dimensions consistently
- add regressions for rotation, shear, non-uniform scale, axis swaps, reflection, negative dimensions, and fast-path preservation

## Why

`ClipRect` and `ClipRoundRect` transformed only two opposite corners and reduced the result to an axis-aligned rectangle. A 45-degree rotation could collapse those corners to the same x-coordinate, producing an empty clip, while other rotations and shears clipped to the wrong bounding box. Rounded rectangles also used a single scaled radius under non-uniform scale, changing the intended elliptical corner geometry.

The fix keeps the optimized clip representation only when the transformed shape can be represented exactly, and otherwise rasterizes the actual device-space path.

## Impact

Rotated, sheared, reflected, and non-uniformly scaled rectangular clips now match the corresponding transformed paths. Existing exact axis-aligned and axis-swapped fast paths remain available.

## Verification

- focused transformed clip and direct-path parity regressions
- `go test -tags nogpu ./... -count=1`
- `go test -race -tags nogpu ./... -count=1`
- `go build ./...`
- `CGO_ENABLED=0 go vet ./...`
- `gofmt` and `git diff --check`
- baseline discrimination and independent implementation review
