### PR TITLE
release: v0.52.2 — community bug fixes (@besmpl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.2] - 2026-08-11
+
+### Fixed
+
+- **Concurrent global text cache race** ([#494](https://github.com/gogpu/gg/pull/494), @besmpl) —
+  `globalGlyphCache` and `globalSubpixelCache` used bare pointer reads/writes.
+  Replaced with `atomic.Pointer[T]` for lock-free thread safety.
+
+- **Path bounds not preserved across Reset/Append/Clone** ([#497](https://github.com/gogpu/gg/pull/497), @besmpl) —
+  `Reset()` did not clear `boundsValid`, `Append()` did not merge bounds,
+  `Clone()` did not copy bounds fields. Fixed all three operations.
+
+- **Premultiplied alpha double-multiplication in scene renderer** ([#500](https://github.com/gogpu/gg/pull/500), @besmpl) —
+  `render/software.go` multiplied already-premultiplied source channels by alpha
+  a second time, making semi-transparent fills appear darker than correct.
+
+- **HiDPI layer and mask dimensions** ([#502](https://github.com/gogpu/gg/pull/502), @besmpl) —
+  `PushLayer`, `PushMaskLayer`, and `AsMask` used logical dimensions instead of
+  physical (`PixelWidth`/`PixelHeight`), clipping content at non-1x device scales.
+
+- **Transformed rectangular clips** ([#503](https://github.com/gogpu/gg/pull/503), @besmpl) —
+  `ClipRect` and `ClipRoundRect` transformed only two diagonal corners, producing
+  axis-aligned bounding box clips under rotation/shear. Now transforms all four
+  corners and uses a path clip for non-axis-aligned transforms.
+
+- **Recording stroke rectangles under transforms** ([#498](https://github.com/gogpu/gg/pull/498), @besmpl) —
+  `StrokeRectangle` in the recording system used the same two-corner transform bug.
+  Now transforms all four corners for non-translation transforms, with scaled
+  stroke metrics matching direct rendering.
+
+- **Recording clips were no-ops** ([#499](https://github.com/gogpu/gg/pull/499), @besmpl) —
+  Raster backend `SetClip` set the path but never called `Clip()`.
+  `ClearClip` was empty. Also fixed mask clipper fill rule (was hardcoded
+  even-odd), subpath separation, and Push/Pop clip state restoration.
+
+- **Recording ClipRoundRect transform parity** — Playback `ClipRoundRectCommand`
+  now matches `Context.ClipRoundRect` for non-uniform/non-axis-aligned transforms
+  (interaction fix between #499 and #503).
+
 ## [0.52.1] - 2026-08-11
 
 ### Fixed

--- a/recording/recorder.go
+++ b/recording/recorder.go
@@ -165,22 +165,7 @@ func (r *Recording) Playback(backend Backend) error {
 		case ClearClipCommand:
 			backend.ClearClip()
 		case ClipRoundRectCommand:
-			// Convert RRect clip to a path for backends that don't
-			// natively support rounded rectangle clipping. Match Context's
-			// ClipRoundRect transform semantics: transform the two diagonal
-			// corners into an axis-aligned box and scale the corner radius.
-			x1, y1 := transform.TransformPoint(c.X, c.Y)
-			x2, y2 := transform.TransformPoint(c.X+c.W, c.Y+c.H)
-			x := math.Min(x1, x2)
-			y := math.Min(y1, y2)
-			w := math.Abs(x2 - x1)
-			h := math.Abs(y2 - y1)
-			radius := 0.0
-			if c.Radius > 0 {
-				radius = c.Radius * transform.ScaleFactor()
-				radius = math.Min(radius, math.Min(w, h)/2)
-			}
-			rrPath := gg.BuildPath().RoundRect(x, y, w, h, radius).Build()
+			rrPath := buildClipRoundRectPath(c, transform)
 			setPlaybackClip(backend, rrPath, FillRuleNonZero, transform)
 		case FillPathCommand:
 			path := r.resources.GetPath(c.Path)
@@ -236,6 +221,54 @@ func setPlaybackClip(backend Backend, path *gg.Path, rule FillRule, transform Ma
 	backend.SetTransform(Identity())
 	backend.SetClip(path, rule)
 	backend.SetTransform(transform)
+}
+
+// buildClipRoundRectPath builds a world-space rounded-rectangle clip path.
+// For uniform axis-aligned transforms, uses the fast two-corner + scaled radius
+// path. For rotation/shear/non-uniform scale, builds the rounded rect in user
+// space and transforms the full path — matching Context.ClipRoundRect (#503).
+func buildClipRoundRectPath(c ClipRoundRectCommand, t Matrix) *gg.Path {
+	if isUniformAxisAligned(t) {
+		x1, y1 := t.TransformPoint(c.X, c.Y)
+		x2, y2 := t.TransformPoint(c.X+c.W, c.Y+c.H)
+		x := math.Min(x1, x2)
+		y := math.Min(y1, y2)
+		w := math.Abs(x2 - x1)
+		h := math.Abs(y2 - y1)
+		radius := 0.0
+		if c.Radius > 0 {
+			radius = c.Radius * t.ScaleFactor()
+			radius = math.Min(radius, math.Min(w, h)/2)
+		}
+		return gg.BuildPath().RoundRect(x, y, w, h, radius).Build()
+	}
+	px, py := c.X, c.Y
+	pw, ph := math.Abs(c.W), math.Abs(c.H)
+	if c.W < 0 {
+		px += c.W
+	}
+	if c.H < 0 {
+		py += c.H
+	}
+	userPath := gg.NewPath()
+	userPath.RoundedRectangle(px, py, pw, ph, c.Radius)
+	return userPath.Transform(gg.Matrix{
+		A: t.A, B: t.B, C: t.C,
+		D: t.D, E: t.E, F: t.F,
+	})
+}
+
+// isUniformAxisAligned reports whether the transform keeps rounded rectangles
+// axis-aligned with circular (not elliptical) corners.
+func isUniformAxisAligned(t Matrix) bool {
+	switch {
+	case t.B == 0 && t.D == 0:
+		return math.Abs(t.A) == math.Abs(t.E)
+	case t.A == 0 && t.E == 0:
+		return math.Abs(t.B) == math.Abs(t.D)
+	default:
+		return false
+	}
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
7 bug fixes from @besmpl (all reviewed and approved) + recording ClipRoundRect transform parity fix for #499/#503 interaction. See CHANGELOG for details.