### PR TITLE
chore: update examples to gg v0.52.2

### DIFF
--- a/examples/blit_only/go.mod
+++ b/examples/blit_only/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/blit_only
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 )
 

--- a/examples/blit_only/go.sum
+++ b/examples/blit_only/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/cjk_text/go.mod
+++ b/examples/cjk_text/go.mod
@@ -2,7 +2,7 @@ module cjk_text
 
 go 1.25.5
 
-require github.com/gogpu/gg v0.52.0
+require github.com/gogpu/gg v0.52.2
 
 require (
 	github.com/gogpu/gpucontext v0.27.0 // indirect

--- a/examples/cjk_text/go.sum
+++ b/examples/cjk_text/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=
 github.com/gogpu/gpucontext v0.27.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/clip_demo/go.mod
+++ b/examples/clip_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 	github.com/gogpu/gpucontext v0.27.0
 )

--- a/examples/clip_demo/go.sum
+++ b/examples/clip_demo/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/clip_path/go.mod
+++ b/examples/clip_path/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/clip_path
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 )
 

--- a/examples/clip_path/go.sum
+++ b/examples/clip_path/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/compositing/go.mod
+++ b/examples/compositing/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/compositing
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 	github.com/gogpu/gpucontext v0.27.0
 )

--- a/examples/compositing/go.sum
+++ b/examples/compositing/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/damage_demo/go.mod
+++ b/examples/damage_demo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/damage_demo
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 	github.com/gogpu/gpucontext v0.27.0
 )

--- a/examples/damage_demo/go.sum
+++ b/examples/damage_demo/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/gogpu_integration/go.mod
+++ b/examples/gogpu_integration/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/gogpu_integration
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 	github.com/gogpu/gpucontext v0.27.0
 )

--- a/examples/gogpu_integration/go.sum
+++ b/examples/gogpu_integration/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/lcd_text/go.mod
+++ b/examples/lcd_text/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/lcd_text
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 )
 

--- a/examples/lcd_text/go.sum
+++ b/examples/lcd_text/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/multi_damage_demo/go.mod
+++ b/examples/multi_damage_demo/go.mod
@@ -3,7 +3,7 @@ module multi_damage_demo
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 	github.com/gogpu/gpucontext v0.27.0
 )

--- a/examples/multi_damage_demo/go.sum
+++ b/examples/multi_damage_demo/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/scene_gpu_visual/go.mod
+++ b/examples/scene_gpu_visual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/scene_gpu_visual
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 )
 

--- a/examples/scene_gpu_visual/go.sum
+++ b/examples/scene_gpu_visual/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/sdf/go.mod
+++ b/examples/sdf/go.mod
@@ -2,7 +2,7 @@ module github.com/gogpu/gg/examples/sdf
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.52.0
+require github.com/gogpu/gg v0.52.2
 
 require (
 	github.com/gogpu/gpucontext v0.27.0 // indirect

--- a/examples/sdf/go.sum
+++ b/examples/sdf/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=
 github.com/gogpu/gpucontext v0.27.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/examples/software_overlay/go.mod
+++ b/examples/software_overlay/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/software_overlay
 go 1.25.0
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 	github.com/gogpu/gpucontext v0.27.0
 )

--- a/examples/software_overlay/go.sum
+++ b/examples/software_overlay/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/zero_readback/go.mod
+++ b/examples/zero_readback/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 )
 

--- a/examples/zero_readback/go.sum
+++ b/examples/zero_readback/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=

--- a/examples/zero_readback_manual/go.mod
+++ b/examples/zero_readback_manual/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/gg/examples/zero_readback_manual
 go 1.25.5
 
 require (
-	github.com/gogpu/gg v0.52.0
+	github.com/gogpu/gg v0.52.2
 	github.com/gogpu/gogpu v0.52.0
 )
 

--- a/examples/zero_readback_manual/go.sum
+++ b/examples/zero_readback_manual/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
-github.com/gogpu/gg v0.52.0 h1:H8e4TfNFgx1K8MXekzrsdF6wFbSsLfsHCMUmvT4aooc=
-github.com/gogpu/gg v0.52.0/go.mod h1:OiE5oy96xWk/X5+MKvIr1IQmbW9qjRpajweBTD9MhRI=
+github.com/gogpu/gg v0.52.2 h1:zW6uUnJH5iwD1auzTxNsOEIEpL/2vqRGcVLMLy4RDw8=
+github.com/gogpu/gg v0.52.2/go.mod h1:DkSaPtl9pBAlsAbMjzan/czzITR7ObwQtv+gB5MGd4Q=
 github.com/gogpu/gogpu v0.52.0 h1:RHMgqv18p74gpxeJnel+lwt2nuec8/VNy6qc29c/Xks=
 github.com/gogpu/gogpu v0.52.0/go.mod h1:GN5pq1zO/0X3+4JF8XwtFjBtDENAyRX1ZFloUkehAz0=
 github.com/gogpu/gpucontext v0.27.0 h1:iTEN2xcjcEivk6kIwX1mnAvEK2rGCjzGRlfnnn8Uphg=


### PR DESCRIPTION
Update all 14 examples to gg v0.52.2. All build verified.