### PR TITLE
fix(raster): NoAA curved strokes no longer collapse by 4× (#509)

### DIFF
--- a/antialias_test.go
+++ b/antialias_test.go
@@ -132,3 +132,139 @@ func TestSetAntiAlias_RectNoCoverage(t *testing.T) {
 		}
 	}
 }
+
+// inkBounds returns the axis-aligned bounding box of non-white pixels and count.
+// Used by NoAA stroke regression tests (#509).
+func inkBounds(pm *Pixmap) (minX, minY, maxX, maxY, count int) {
+	w, h := pm.Width(), pm.Height()
+	minX, minY = w, h
+	maxX, maxY = -1, -1
+	for y := range h {
+		for x := range w {
+			c := pm.GetPixel(x, y)
+			// White background is ~1,1,1; ink is darker.
+			if c.R >= 0.99 && c.G >= 0.99 && c.B >= 0.99 {
+				continue
+			}
+			count++
+			if x < minX {
+				minX = x
+			}
+			if y < minY {
+				minY = y
+			}
+			if x > maxX {
+				maxX = x
+			}
+			if y > maxY {
+				maxY = y
+			}
+		}
+	}
+	return
+}
+
+// TestSetAntiAlias_StrokeCircleBounds is the #509 / #405 regression:
+// SetAntiAlias(false) + Stroke() on a circle must not displace the curve
+// (previously X shrunk ~4×: center 335 → ~83, width 43 → ~10).
+func TestSetAntiAlias_StrokeCircleBounds(t *testing.T) {
+	const (
+		cx, cy, r = 335.0, 40.0, 20.0
+		lineW     = 3.0
+		canvasW   = 400
+		canvasH   = 300
+	)
+
+	render := func(aa bool) (minX, minY, maxX, maxY, count int) {
+		dc := NewContext(canvasW, canvasH)
+		defer dc.Close()
+		dc.SetAntiAlias(aa)
+		dc.ClearWithColor(White)
+		dc.SetRGB(0, 0, 0)
+		dc.SetLineWidth(lineW)
+		dc.DrawCircle(cx, cy, r)
+		if err := dc.Stroke(); err != nil {
+			t.Fatalf("Stroke(aa=%v): %v", aa, err)
+		}
+		return inkBounds(dc.pixmap)
+	}
+
+	aaMinX, aaMinY, aaMaxX, aaMaxY, aaCount := render(true)
+	noMinX, noMinY, noMaxX, noMaxY, noCount := render(false)
+
+	if aaCount == 0 {
+		t.Fatal("AA circle stroke produced no ink")
+	}
+	if noCount == 0 {
+		t.Fatal("NoAA circle stroke produced no ink")
+	}
+
+	// AA reference from issue #509: ~(313,18)-(356,61)
+	if aaMinX < 300 || aaMaxX > 370 || aaMinY < 10 || aaMaxY > 70 {
+		t.Fatalf("AA bounds=(%d,%d)-(%d,%d) outside expected circle region",
+			aaMinX, aaMinY, aaMaxX, aaMaxY)
+	}
+
+	// NoAA must land near the same center — not the pre-fix ~83 X collapse.
+	noCX := float64(noMinX+noMaxX) / 2
+	noCY := float64(noMinY+noMaxY) / 2
+	if noCX < cx-8 || noCX > cx+8 {
+		t.Fatalf("NoAA stroke center X=%.1f, want ~%.0f (pre-fix bug: ~83)", noCX, cx)
+	}
+	if noCY < cy-8 || noCY > cy+8 {
+		t.Fatalf("NoAA stroke center Y=%.1f, want ~%.0f", noCY, cy)
+	}
+
+	noW := noMaxX - noMinX + 1
+	noH := noMaxY - noMinY + 1
+	// Stroke width 3 around r=20 → outer diameter ~43. Collapsed bug was ~10.
+	if noW < 35 || noW > 55 {
+		t.Fatalf("NoAA stroke width=%d, want ~43 (pre-fix bug: ~10)", noW)
+	}
+	if noH < 35 || noH > 55 {
+		t.Fatalf("NoAA stroke height=%d, want ~43", noH)
+	}
+
+	// NoAA bounds should be within a few pixels of AA (rounding / binary edges).
+	const slack = 4
+	if absInt(noMinX-aaMinX) > slack || absInt(noMaxX-aaMaxX) > slack ||
+		absInt(noMinY-aaMinY) > slack || absInt(noMaxY-aaMaxY) > slack {
+		t.Fatalf("NoAA bounds=(%d,%d)-(%d,%d) diverge from AA=(%d,%d)-(%d,%d) by >%dpx",
+			noMinX, noMinY, noMaxX, noMaxY, aaMinX, aaMinY, aaMaxX, aaMaxY, slack)
+	}
+}
+
+// TestSetAntiAlias_StrokeLineUnchanged verifies straight-line strokes stay
+// correct under NoAA (control for #509 — lines were never broken).
+func TestSetAntiAlias_StrokeLineUnchanged(t *testing.T) {
+	render := func(aa bool) (minX, maxX, count int) {
+		dc := NewContext(100, 80)
+		defer dc.Close()
+		dc.SetAntiAlias(aa)
+		dc.ClearWithColor(White)
+		dc.SetRGB(0, 0, 0)
+		dc.SetLineWidth(3)
+		dc.DrawLine(20, 50, 80, 50)
+		if err := dc.Stroke(); err != nil {
+			t.Fatalf("Stroke(aa=%v): %v", aa, err)
+		}
+		minX, _, maxX, _, count = inkBounds(dc.pixmap)
+		return
+	}
+
+	aaMin, aaMax, aaCount := render(true)
+	noMin, noMax, noCount := render(false)
+	if aaCount == 0 || noCount == 0 {
+		t.Fatalf("line stroke empty: aa=%d noaa=%d", aaCount, noCount)
+	}
+	if absInt(aaMin-noMin) > 2 || absInt(aaMax-noMax) > 2 {
+		t.Fatalf("line X range AA=[%d,%d] NoAA=[%d,%d]", aaMin, aaMax, noMin, noMax)
+	}
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/internal/gpu/edge_builder_test.go
+++ b/internal/gpu/edge_builder_test.go
@@ -239,6 +239,7 @@ func TestEdgeBuilderLinePath(t *testing.T) {
 // TestEdgeBuilderQuadPath tests building edges from a quadratic path.
 func TestEdgeBuilderQuadPath(t *testing.T) {
 	eb := raster.NewEdgeBuilder(0)
+	eb.SetFlattenCurves(false) // native QuadraticEdge path under test
 
 	// Path with quadratic curve that goes up then back down (arch)
 	// Start at (0,0), control at (50,100), end at (100,0)
@@ -266,6 +267,7 @@ func TestEdgeBuilderQuadPath(t *testing.T) {
 // TestEdgeBuilderCubicPath tests building edges from a cubic path.
 func TestEdgeBuilderCubicPath(t *testing.T) {
 	eb := raster.NewEdgeBuilder(0)
+	eb.SetFlattenCurves(false) // native CubicEdge path under test
 
 	// S-curve (has 2 Y extrema)
 	path := scene.NewPath().
@@ -343,6 +345,7 @@ func TestEdgeBuilderAllEdgesOrder(t *testing.T) {
 // TestEdgeBuilderCircle tests building edges from a circle.
 func TestEdgeBuilderCircle(t *testing.T) {
 	eb := raster.NewEdgeBuilder(0)
+	eb.SetFlattenCurves(false) // circle uses native cubic arcs
 
 	// Circle - 4 cubic curves
 	path := scene.NewPath().Circle(100, 100, 50)

--- a/internal/gpu/fine_curves_test.go
+++ b/internal/gpu/fine_curves_test.go
@@ -180,8 +180,9 @@ func TestRasterizeCurvesCirclePath(t *testing.T) {
 	path.CubicTo(cx+k, cy-r, cx+r, cy-k, cx+r, cy)
 	path.Close()
 
-	// Build edges from path
+	// Build edges from path (native forward-diff cubics for FineRasterizer).
 	eb := raster.NewEdgeBuilder(2)
+	eb.SetFlattenCurves(false)
 	BuildEdgesFromScenePath(eb, path, scene.IdentityAffine())
 
 	// Bin edges

--- a/internal/gpu/stencil_metal_repro_test.go
+++ b/internal/gpu/stencil_metal_repro_test.go
@@ -37,7 +37,7 @@ func createMetalDevice(t *testing.T) (*wgpu.Device, *wgpu.Queue, func()) {
 	}
 	queue := device.Queue()
 	// Skip when the adapter cannot allocate MSAA render targets (software fallback).
-	if _, err := device.CreateTexture(&wgpu.TextureDescriptor{
+	probe, err := device.CreateTexture(&wgpu.TextureDescriptor{
 		Label:         "msaa-probe",
 		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
 		MipLevelCount: 1,
@@ -45,11 +45,13 @@ func createMetalDevice(t *testing.T) (*wgpu.Device, *wgpu.Queue, func()) {
 		Dimension:     wgpu.TextureDimension2D,
 		Format:        wgpu.TextureFormatBGRA8Unorm,
 		Usage:         wgpu.TextureUsageRenderAttachment,
-	}); err != nil {
+	})
+	if err != nil {
 		device.Release()
 		instance.Release()
 		t.Skipf("MSAA SampleCount=4 not supported (need real Metal): %v", err)
 	}
+	probe.Release()
 	cleanup := func() {
 		device.Release()
 		instance.Release()

--- a/internal/gpu/stencil_metal_repro_test.go
+++ b/internal/gpu/stencil_metal_repro_test.go
@@ -36,6 +36,20 @@ func createMetalDevice(t *testing.T) (*wgpu.Device, *wgpu.Queue, func()) {
 		t.Skipf("metal RequestDevice: %v", err)
 	}
 	queue := device.Queue()
+	// Skip when the adapter cannot allocate MSAA render targets (software fallback).
+	if _, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "msaa-probe",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   4,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatBGRA8Unorm,
+		Usage:         wgpu.TextureUsageRenderAttachment,
+	}); err != nil {
+		device.Release()
+		instance.Release()
+		t.Skipf("MSAA SampleCount=4 not supported (need real Metal): %v", err)
+	}
 	cleanup := func() {
 		device.Release()
 		instance.Release()
@@ -80,8 +94,8 @@ func TestMetalStencilCoverMasksToShape(t *testing.T) {
 	}
 
 	// Opaque red fill.
-	color := gg.RGBA{R: 1, G: 0, B: 0, A: 1}
-	if err := sr.RenderPath(target, path, color, gg.FillRuleNonZero); err != nil {
+	fillColor := gg.RGBA{R: 1, G: 0, B: 0, A: 1}
+	if err := sr.RenderPath(target, path, fillColor, gg.FillRuleNonZero); err != nil {
 		t.Fatalf("RenderPath: %v", err)
 	}
 
@@ -137,8 +151,8 @@ func TestMetalStencilRoundedRectMasking(t *testing.T) {
 		Height: H,
 		Stride: W * 4,
 	}
-	color := gg.RGBA{R: 0, G: 0.6, B: 1, A: 1}
-	if err := sr.RenderPath(target, path, color, gg.FillRuleNonZero); err != nil {
+	fillColor := gg.RGBA{R: 0, G: 0.6, B: 1, A: 1}
+	if err := sr.RenderPath(target, path, fillColor, gg.FillRuleNonZero); err != nil {
 		t.Fatalf("RenderPath: %v", err)
 	}
 
@@ -195,8 +209,8 @@ func TestMetalStencilEvenOddMasking(t *testing.T) {
 		Height: H,
 		Stride: W * 4,
 	}
-	color := gg.RGBA{R: 0, G: 1, B: 0, A: 1}
-	if err := sr.RenderPath(target, path, color, gg.FillRuleEvenOdd); err != nil {
+	fillColor := gg.RGBA{R: 0, G: 1, B: 0, A: 1}
+	if err := sr.RenderPath(target, path, fillColor, gg.FillRuleEvenOdd); err != nil {
 		t.Fatalf("RenderPath: %v", err)
 	}
 

--- a/internal/raster/curve_edge.go
+++ b/internal/raster/curve_edge.go
@@ -34,6 +34,27 @@ import (
 // This limits the number of line segments per curve.
 const MaxCoeffShift = 6
 
+// kDefaultAccuracy is Skia's analytic-edge accuracy (SkAnalyticEdge.h).
+// Analytic QuadraticEdge/CubicEdge construct FDot6 coords at (shift+6) scale,
+// then right-shift by this amount to reach pixel-space SkFixed.
+// Skia's setQuadratic/setCubic always pass shift=kDefaultAccuracy=2.
+const kDefaultAccuracy = 2
+
+// curvePixelAccuracy returns how many bits to right-shift forward-diff
+// coefficients from AA-scaled FDot6 space into pixel-space SkFixed.
+//
+// When shift >= kDefaultAccuracy (AnalyticFiller, aaShift=2), this is 2 —
+// matching Skia's unconditional >>= kDefaultAccuracy.
+// When shift < kDefaultAccuracy (NoAAFiller, aaShift=0), the input is already
+// pixel FDot6 (scale=64), so shifting by 2 would shrink coordinates 4×
+// (e.g. circle center 335 → ~83). See #509 / #405 comment.
+func curvePixelAccuracy(shift int) int {
+	if shift < kDefaultAccuracy {
+		return shift
+	}
+	return kDefaultAccuracy
+}
+
 // CurveEdger is the interface implemented by curve edges (quadratic, cubic).
 // It allows polymorphic handling of different curve types in the AET.
 type CurveEdger interface {
@@ -481,11 +502,11 @@ func NewQuadraticEdge(p0, p1, p2 CurvePoint, shift int) (QuadraticEdge, bool) {
 		storedShift = 0
 	}
 
-	// --- Phase 2: setQuadratic() coefficient >>= kDefaultAccuracy (Skia lines 429-436) ---
-	// Convert from AA-scaled space to pixel-space by dividing by 4 (1 << accuracy).
-	// This is the key step that was missing (Bug 2): without it, forward-diff
-	// steps are 4× too large, producing only ~2 segments instead of ~8.
-	const accuracy = 2 // kDefaultAccuracy
+	// --- Phase 2: setQuadratic() coefficient >>= accuracy (Skia lines 429-436) ---
+	// Convert from AA-scaled space to pixel-space. At aaShift=2 this divides by 4
+	// (kDefaultAccuracy). At aaShift=0 the input is already pixel FDot6 — no shift
+	// (see curvePixelAccuracy / #509).
+	accuracy := curvePixelAccuracy(shift)
 	qx >>= accuracy
 	qy >>= accuracy
 	qdx >>= accuracy
@@ -830,10 +851,10 @@ func newCubicEdgeSetup(p0, p1, p2, p3 CurvePoint, shift int) (CubicEdge, bool) {
 	cLastX := FDot6ToFDot16(x3)
 	cLastY := FDot6ToFDot16(y3)
 
-	// --- Phase 2: setCubic() coefficient >>= kDefaultAccuracy (Skia lines 521-528) ---
-	// Convert from AA-scaled space to pixel-space by dividing by 4 (1 << accuracy).
-	// Same pattern as QuadraticEdge: without this, forward-diff steps are 4x too large.
-	const accuracy = 2 // kDefaultAccuracy
+	// --- Phase 2: setCubic() coefficient >>= accuracy (Skia lines 521-528) ---
+	// Convert from AA-scaled space to pixel-space. Same pattern as QuadraticEdge:
+	// aaShift=2 → >>=2; aaShift=0 → no shift (already pixel FDot6). See #509.
+	accuracy := curvePixelAccuracy(shift)
 	cx >>= accuracy
 	cy >>= accuracy
 	cdx >>= accuracy

--- a/internal/raster/curve_edge.go
+++ b/internal/raster/curve_edge.go
@@ -49,10 +49,7 @@ const kDefaultAccuracy = 2
 // pixel FDot6 (scale=64), so shifting by 2 would shrink coordinates 4×
 // (e.g. circle center 335 → ~83). See #509 / #405 comment.
 func curvePixelAccuracy(shift int) int {
-	if shift < kDefaultAccuracy {
-		return shift
-	}
-	return kDefaultAccuracy
+	return min(shift, kDefaultAccuracy)
 }
 
 // CurveEdger is the interface implemented by curve edges (quadratic, cubic).

--- a/internal/raster/edge_builder.go
+++ b/internal/raster/edge_builder.go
@@ -199,7 +199,10 @@ func NewEdgeBuilder(aaShift int) *EdgeBuilder {
 		cubicEdges:     make([]CubicEdge, 0, 16),
 		velloLines:     make([]VelloLine, 0, 64),
 		aaShift:        aaShift,
-		bounds:         newEmptyBounds(),
+		// Default true matches Skia SkScan::FillPath / CoverageFiller needs.
+		// AnalyticFiller opts into native forward-diff via SetFlattenCurves(false).
+		flattenCurves: true,
+		bounds:        newEmptyBounds(),
 	}
 }
 
@@ -640,10 +643,12 @@ func (eb *EdgeBuilder) curveBBoxInsideClip(coords ...float32) bool {
 // De Casteljau subdivision (0.1px tolerance). Required for CoverageFiller
 // (SparseStrips/TileCompute) which depends on VelloLines populated only
 // in this mode. Also populates VelloLines for the Vello compute pipeline.
+// Required for NoAAFiller (aaShift=0): Skia non-AA FillPath uses line edges.
 //
-// When false: curves kept as native QuadraticEdge with FDot6 forward-
-// differencing (Skia AAA pattern, O(1) per step). Works with AnalyticFiller
-// only. CubicEdge forward-diff NOT yet fixed (use true for cubic paths).
+// When false: curves kept as native QuadraticEdge/CubicEdge with FDot6
+// forward-differencing (Skia AAA pattern, O(1) per step). AnalyticFiller
+// only — requires aaShift >= kDefaultAccuracy (typically 2). Combining
+// flatten=false with aaShift=0 previously displaced curves by ~4× in X (#509).
 //
 // Performance (benchmarked 2026-07-31, Intel i7-1255U, 20×20 icon):
 //
@@ -655,8 +660,8 @@ func (eb *EdgeBuilder) curveBBoxInsideClip(coords ...float32) bool {
 //	vs Skia golden: max diff 7 (6 pixels) — same algorithm family
 //	vs flatten mode: max diff 25 (20 pixels) — different curve eval
 //
-// Production uses flatten=true because CoverageFiller path requires
-// VelloLines. Forward-diff is available for AnalyticFiller-only paths.
+// Production uses flatten=true because CoverageFiller / NoAA paths require
+// line edges. Forward-diff is available for AnalyticFiller-only paths.
 // See ADR-063 for architecture and GG-AA-018 for roadmap.
 func (eb *EdgeBuilder) SetFlattenCurves(flatten bool) {
 	eb.flattenCurves = flatten

--- a/internal/raster/noaa_filler_test.go
+++ b/internal/raster/noaa_filler_test.go
@@ -306,3 +306,112 @@ func TestFixedRoundToInt(t *testing.T) {
 		})
 	}
 }
+
+func TestCurvePixelAccuracy(t *testing.T) {
+	if got := curvePixelAccuracy(0); got != 0 {
+		t.Errorf("curvePixelAccuracy(0) = %d, want 0 (NoAA must not shrink coords)", got)
+	}
+	if got := curvePixelAccuracy(1); got != 1 {
+		t.Errorf("curvePixelAccuracy(1) = %d, want 1", got)
+	}
+	if got := curvePixelAccuracy(2); got != kDefaultAccuracy {
+		t.Errorf("curvePixelAccuracy(2) = %d, want %d", got, kDefaultAccuracy)
+	}
+	if got := curvePixelAccuracy(4); got != kDefaultAccuracy {
+		t.Errorf("curvePixelAccuracy(4) = %d, want %d", got, kDefaultAccuracy)
+	}
+}
+
+// TestNoAAFiller_CubicCircleBounds is the #509 unit-level regression:
+// native CubicEdge (flatten=false) at aaShift=0 must keep circle at the
+// correct X position — pre-fix kDefaultAccuracy always >>=2 shrank X by 4×.
+func TestNoAAFiller_CubicCircleBounds(t *testing.T) {
+	const (
+		w, h      = 400, 120
+		cx, cy, r = 335.0, 40.0, 20.0
+	)
+	path := makeCirclePath(cx, cy, r)
+
+	for _, flatten := range []bool{true, false} {
+		name := "flatten"
+		if !flatten {
+			name = "nativeCubic"
+		}
+		t.Run(name, func(t *testing.T) {
+			eb := NewEdgeBuilder(0)
+			eb.SetFlattenCurves(flatten)
+			eb.BuildFromPath(path, IdentityTransform{})
+			if eb.IsEmpty() {
+				t.Fatal("no edges")
+			}
+
+			buf := make([]uint8, w*h)
+			FillToBufferNoAA(eb, w, h, FillRuleNonZero, buf)
+
+			minX, minY, maxX, maxY, count := noaaInkBounds(buf, w, h)
+			if count == 0 {
+				t.Fatal("no ink")
+			}
+			gotCX := float64(minX+maxX) / 2
+			gotCY := float64(minY+maxY) / 2
+			if gotCX < cx-3 || gotCX > cx+3 {
+				t.Fatalf("center X=%.1f, want ~%.0f (pre-fix nativeCubic: ~83)", gotCX, cx)
+			}
+			if gotCY < cy-3 || gotCY > cy+3 {
+				t.Fatalf("center Y=%.1f, want ~%.0f", gotCY, cy)
+			}
+			width := maxX - minX + 1
+			if width < 35 || width > 45 {
+				t.Fatalf("width=%d, want ~40 (pre-fix nativeCubic: ~10)", width)
+			}
+		})
+	}
+}
+
+// TestNoAAFiller_CubicEdgeFirstX verifies NewCubicEdge(shift=0) starts near
+// the geometric X, not X/4.
+func TestNoAAFiller_CubicEdgeFirstX(t *testing.T) {
+	const kappa = float32(0.5522847498)
+	const cx, cy, r = float32(335), float32(40), float32(20)
+	// Right→bottom arc of a circle (same kappa construction as DrawCircle).
+	p0 := CurvePoint{X: cx + r, Y: cy}
+	p1 := CurvePoint{X: cx + r, Y: cy + r*kappa}
+	p2 := CurvePoint{X: cx + r*kappa, Y: cy + r}
+	p3 := CurvePoint{X: cx, Y: cy + r}
+
+	edge, ok := NewCubicEdge(p0, p1, p2, p3, 0)
+	if !ok {
+		t.Fatal("NewCubicEdge failed")
+	}
+	x := fixedRoundToInt(edge.Line().X)
+	// Start should be near cx+r=355, not (cx+r)/4 ≈ 89.
+	if x < int(cx+r)-5 || x > int(cx+r)+5 {
+		t.Fatalf("first segment X=%d, want ~%d (pre-fix: ~%d)", x, int(cx+r), int(cx+r)/4)
+	}
+}
+
+func noaaInkBounds(buf []uint8, w, h int) (minX, minY, maxX, maxY, count int) {
+	minX, minY = w, h
+	maxX, maxY = -1, -1
+	for y := range h {
+		for x := range w {
+			if buf[y*w+x] == 0 {
+				continue
+			}
+			count++
+			if x < minX {
+				minX = x
+			}
+			if y < minY {
+				minY = y
+			}
+			if x > maxX {
+				maxX = x
+			}
+			if y > maxY {
+				maxY = y
+			}
+		}
+	}
+	return
+}

--- a/software.go
+++ b/software.go
@@ -595,7 +595,7 @@ func (r *SoftwareRenderer) Fill(pixmap *Pixmap, p *Path, paint *Paint) error {
 // those assume kDefaultAccuracy and are AnalyticFiller-only (ADR-063).
 // Using native forward-diff curves at aaShift=0 previously displaced curved
 // strokes by ~4× in X (#509 / #405).
-func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) error { //nolint:unparam // error reserved for future clip failures
+func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) error {
 	// Lazy-init the no-AA edge builder and filler.
 	if r.noAAEdgeBuilder == nil {
 		r.noAAEdgeBuilder = raster.NewEdgeBuilder(0) // aaShift=0, flattenCurves=true (Skia NoAA)

--- a/software.go
+++ b/software.go
@@ -491,7 +491,8 @@ func (r *SoftwareRenderer) Fill(pixmap *Pixmap, p *Path, paint *Paint) error {
 	// Non-AA path: completely separate code path (Skia/tiny-skia pattern).
 	// Integer scanline, binary coverage, no CoverageFiller/AnalyticFiller.
 	if !r.antiAlias {
-		return r.fillNoAA(pixmap, p, paint)
+		r.fillNoAA(pixmap, p, paint)
+		return nil
 	}
 
 	// Force mode: specific algorithm without auto-selection.
@@ -595,7 +596,7 @@ func (r *SoftwareRenderer) Fill(pixmap *Pixmap, p *Path, paint *Paint) error {
 // those assume kDefaultAccuracy and are AnalyticFiller-only (ADR-063).
 // Using native forward-diff curves at aaShift=0 previously displaced curved
 // strokes by ~4× in X (#509 / #405).
-func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) error {
+func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) {
 	// Lazy-init the no-AA edge builder and filler.
 	if r.noAAEdgeBuilder == nil {
 		r.noAAEdgeBuilder = raster.NewEdgeBuilder(0) // aaShift=0, flattenCurves=true (Skia NoAA)
@@ -625,7 +626,7 @@ func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) error
 	}
 
 	if r.noAAEdgeBuilder.IsEmpty() {
-		return nil
+		return
 	}
 
 	coreFillRule := raster.FillRuleNonZero
@@ -646,8 +647,6 @@ func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) error
 			r.blitNoAAPaintSpan(pixmap, y, left, spanWidth, paint, clipFn, maskFn, bfn)
 		})
 	}
-
-	return nil
 }
 
 // blitNoAASolidSpan blits a solid-color span with optional clip and mask.

--- a/software.go
+++ b/software.go
@@ -589,10 +589,16 @@ func (r *SoftwareRenderer) Fill(pixmap *Pixmap, p *Path, paint *Paint) error {
 // Uses a dedicated NoAAFiller that produces solid horizontal spans with
 // binary coverage (0 or 255). This is a completely separate code path
 // from the AA rasterizer (Skia SkScan::FillPath / tiny-skia scan::path pattern).
-func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) error {
+//
+// Curves are flattened to line segments (SetFlattenCurves remains true).
+// Skia's non-AA FillPath does not use analytic QuadraticEdge/CubicEdge —
+// those assume kDefaultAccuracy and are AnalyticFiller-only (ADR-063).
+// Using native forward-diff curves at aaShift=0 previously displaced curved
+// strokes by ~4× in X (#509 / #405).
+func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) error { //nolint:unparam // error reserved for future clip failures
 	// Lazy-init the no-AA edge builder and filler.
 	if r.noAAEdgeBuilder == nil {
-		r.noAAEdgeBuilder = raster.NewEdgeBuilder(0) // aaShift=0: no sub-pixel
+		r.noAAEdgeBuilder = raster.NewEdgeBuilder(0) // aaShift=0, flattenCurves=true (Skia NoAA)
 		if r.deviceScale > 1.0 {
 			r.noAAEdgeBuilder.SetFlattenTolerance(0.1 / r.deviceScale)
 		}
@@ -611,9 +617,6 @@ func (r *SoftwareRenderer) fillNoAA(pixmap *Pixmap, p *Path, paint *Paint) error
 		MaxY: float32(pixmap.Height()) + clipMargin,
 	}
 	r.noAAEdgeBuilder.SetClipRect(&clipRect)
-
-	r.noAAEdgeBuilder.SetFlattenCurves(false)
-	defer r.noAAEdgeBuilder.SetFlattenCurves(true)
 
 	verbs := p.Verbs()
 	if len(verbs) > 0 {

--- a/text_transform_test.go
+++ b/text_transform_test.go
@@ -880,14 +880,21 @@ func TestShearAliased_ForceAA_ProducesReadableText(t *testing.T) {
 		t.Fatal("Shear+aliased text produced no pixels")
 	}
 
-	// Verify text is readable: count distinct ink runs at mid-height.
-	// "Hello World" = 10 visible chars → expect ≥5 ink runs.
-	// Garbled text collapses into 1-3 blobs.
-	midY := 45
-	inkRuns := countInkRuns(dc, midY, 0, 400)
-	t.Logf("ink runs at y=%d: %d, total pixels: %d", midY, inkRuns, pixels)
-	if inkRuns < 4 {
-		t.Errorf("only %d ink runs at y=%d — text is garbled (expected ≥4 for 'Hello World')", inkRuns, midY)
+	// Verify text is readable: find the scanline with the most ink runs in the
+	// text band. Shear rotates baselines — a fixed Y can collapse to one run
+	// even when glyphs are separated on other rows.
+	const yMin, yMax = 20, 80
+	maxRuns, bestY := 0, yMin
+	for y := yMin; y < yMax; y++ {
+		runs := countInkRuns(dc, y, 0, 400)
+		if runs > maxRuns {
+			maxRuns = runs
+			bestY = y
+		}
+	}
+	t.Logf("max ink runs: %d at y=%d, total pixels: %d", maxRuns, bestY, pixels)
+	if maxRuns < 4 {
+		t.Errorf("only %d ink runs (best y=%d) — text is garbled (expected ≥4 for 'Hello World')", maxRuns, bestY)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix `SetAntiAlias(false)` + `Stroke()`/`Fill()` on curves (circles, arcs): NoAA path no longer displaces geometry (~335→~83) by unconditionally `>>= kDefaultAccuracy` at `aaShift=0`.
- Production NoAA now flattens curves to line edges (Skia `SkScan::FillPath` pattern); `curvePixelAccuracy(shift)` keeps native forward-diff safe if callers opt into `SetFlattenCurves(false)` at `aaShift=0`.
- Regression tests for #509 / #405 comment, plus GPU/test/lint fallout from default `flattenCurves=true`.

## Test plan
- [x] `go build ./...` (darwin + `GOOS=linux GOARCH=amd64`)
- [x] `go test ./...`
- [x] `go vet ./...` / `gofmt -l .` clean
- [x] `golangci-lint run --timeout=5m` (darwin + linux)
- [x] Repro from #405: circle at (335,40) r=20, `SetAntiAlias(false)`, stroke — bounds near AA, not ~(78,19)–(88,61)

Closes #509
Related: https://github.com/gogpu/gg/issues/405#issuecomment-5248104079