### PR TITLE
fix(text): prevent font face cache collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Text-outline glyph cache collision between font faces** — Font IDs used by
+  `Context`'s glyph-outline cache now include the full face name, preventing
+  regular and bold faces in the same family from sharing cached outlines.
+
 ## [0.52.3] - 2026-08-13
 
 ### Added

--- a/text.go
+++ b/text.go
@@ -938,14 +938,19 @@ func (c *Context) ensureGlyphCache() *text.GlyphCache {
 }
 
 // computeTextFontID generates a stable hash identifier for a font source.
-// Uses FNV-1a hash of font name and glyph count as a lightweight fingerprint.
-// Same algorithm as internal/gpu/gpu_text.go:computeFontID.
+// The full name includes the face variant (for example, Regular or Bold),
+// preventing glyph-cache collisions between faces in the same family.
 func computeTextFontID(source *text.FontSource) uint64 {
 	if source == nil {
 		return 0
 	}
 	h := fnv.New64a()
-	_, _ = fmt.Fprintf(h, "%s:%d", source.Name(), source.Parsed().NumGlyphs())
+	parsed := source.Parsed()
+	fullName := parsed.FullName()
+	if fullName == "" {
+		fullName = source.Name()
+	}
+	_, _ = fmt.Fprintf(h, "%s:%d", fullName, parsed.NumGlyphs())
 	return h.Sum64()
 }
 

--- a/text_font_id_test.go
+++ b/text_font_id_test.go
@@ -1,0 +1,38 @@
+package gg
+
+import (
+	"testing"
+
+	"github.com/gogpu/gg/text"
+	"golang.org/x/image/font/gofont/gobold"
+	"golang.org/x/image/font/gofont/goregular"
+)
+
+func TestComputeTextFontID_DifferentFacesInSameFamily(t *testing.T) {
+	regular, err := text.NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("load Go Regular: %v", err)
+	}
+	bold, err := text.NewFontSource(gobold.TTF)
+	if err != nil {
+		t.Fatalf("load Go Bold: %v", err)
+	}
+
+	if regular.Name() != bold.Name() {
+		t.Skipf("fonts have different family names (%q vs %q), test not applicable", regular.Name(), bold.Name())
+	}
+	if regular.Parsed().NumGlyphs() != bold.Parsed().NumGlyphs() {
+		t.Skipf("fonts have different glyph counts (%d vs %d), test not applicable",
+			regular.Parsed().NumGlyphs(), bold.Parsed().NumGlyphs())
+	}
+
+	regularID := computeTextFontID(regular)
+	boldID := computeTextFontID(bold)
+	if regularID == boldID {
+		t.Errorf("Go Regular and Go Bold must have different FontIDs to avoid atlas cache collision\n"+
+			"  Go Regular: name=%q fullName=%q numGlyphs=%d fontID=%d\n"+
+			"  Go Bold:    name=%q fullName=%q numGlyphs=%d fontID=%d",
+			regular.Name(), regular.Parsed().FullName(), regular.Parsed().NumGlyphs(), regularID,
+			bold.Name(), bold.Parsed().FullName(), bold.Parsed().NumGlyphs(), boldID)
+	}
+}


### PR DESCRIPTION
## Summary

- derive root Context glyph-outline cache IDs from the full font face name
- distinguish regular and bold faces that share a family name and glyph count
- add a regression test using Go Regular and Go Bold
- document the fix in the Unreleased changelog

## Root cause

The root text-outline path hashed FontSource.Name, which is the family name, together with the glyph count. Faces such as Go Regular and Go Bold have the same family name and glyph count, so their cached outlines could overwrite each other. The GPU text and glyph-mask paths already avoid this by using ParsedFont.FullName.

## Testing

- go test -race ./...
- golangci-lint run --timeout=5m
- go build ./...
- reproduced and visually verified the fix in Goro with mixed regular and bold UI labels

## Checklist

- [x] Tests pass
- [x] Linter passes
- [x] Code formatted
- [x] Changelog updated