### PR TITLE
refactor: unify font ID computation into text.ComputeFontID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Text-outline glyph cache collision between font faces** — Font IDs used by
-  `Context`'s glyph-outline cache now include the full face name, preventing
-  regular and bold faces in the same family from sharing cached outlines.
+- **Text-outline glyph cache collision between font faces** ([#514](https://github.com/gogpu/gg/pull/514), @kivutar) —
+  Font IDs now include the full face name, preventing regular and bold faces
+  in the same family from sharing cached outlines. Font ID computation unified
+  into `text.ComputeFontID` — single source of truth for CPU, MSDF, and glyph
+  mask pipelines.
 
 ## [0.52.3] - 2026-08-13
 

--- a/internal/gpu/glyph_mask_engine.go
+++ b/internal/gpu/glyph_mask_engine.go
@@ -4,7 +4,6 @@ package gpu
 
 import (
 	"fmt"
-	"hash/fnv"
 	"math"
 	"os"
 	"sync"
@@ -729,17 +728,7 @@ func selectGlyphMaskLCD(_ float64, _ gg.Matrix) bool {
 }
 
 // computeGlyphMaskFontID generates a stable hash identifier for a font source.
-// Uses the same approach as computeFontID in gpu_text.go.
+// Delegates to text.ComputeFontID — single source of truth for font hashing.
 func computeGlyphMaskFontID(source *text.FontSource) uint64 {
-	if source == nil {
-		return 0
-	}
-	h := fnv.New64a()
-	parsed := source.Parsed()
-	fullName := parsed.FullName()
-	if fullName == "" {
-		fullName = source.Name()
-	}
-	_, _ = fmt.Fprintf(h, "%s:%d", fullName, parsed.NumGlyphs())
-	return h.Sum64()
+	return text.ComputeFontID(source)
 }

--- a/internal/gpu/gpu_text.go
+++ b/internal/gpu/gpu_text.go
@@ -4,7 +4,6 @@ package gpu
 
 import (
 	"fmt"
-	"hash/fnv"
 	"sync"
 
 	"github.com/gogpu/gg"
@@ -316,20 +315,8 @@ func (e *GPUTextEngine) GlyphCount() int {
 }
 
 // computeFontID generates a stable hash identifier for a font source.
-// Uses the full font name (includes subfamily like "Regular"/"Bold") and
-// number of glyphs as a lightweight fingerprint. The full name is critical
-// to distinguish fonts within the same family (e.g., "Go Regular" vs "Go Bold")
-// that share the same family name and glyph count.
+// Delegates to text.ComputeFontID which uses FullName to prevent cache
+// collisions between faces in the same family (e.g., Regular vs Bold).
 func computeFontID(source *text.FontSource) uint64 {
-	if source == nil {
-		return 0
-	}
-	h := fnv.New64a()
-	parsed := source.Parsed()
-	fullName := parsed.FullName()
-	if fullName == "" {
-		fullName = source.Name() // fallback to family name
-	}
-	_, _ = fmt.Fprintf(h, "%s:%d", fullName, parsed.NumGlyphs())
-	return h.Sum64()
+	return text.ComputeFontID(source)
 }

--- a/text.go
+++ b/text.go
@@ -1,8 +1,6 @@
 package gg
 
 import (
-	"fmt"
-	"hash/fnv"
 	"image"
 	"math"
 	"os"
@@ -938,20 +936,10 @@ func (c *Context) ensureGlyphCache() *text.GlyphCache {
 }
 
 // computeTextFontID generates a stable hash identifier for a font source.
-// The full name includes the face variant (for example, Regular or Bold),
-// preventing glyph-cache collisions between faces in the same family.
+// Delegates to text.ComputeFontID which uses FullName to prevent cache
+// collisions between faces in the same family (e.g., Regular vs Bold).
 func computeTextFontID(source *text.FontSource) uint64 {
-	if source == nil {
-		return 0
-	}
-	h := fnv.New64a()
-	parsed := source.Parsed()
-	fullName := parsed.FullName()
-	if fullName == "" {
-		fullName = source.Name()
-	}
-	_, _ = fmt.Fprintf(h, "%s:%d", fullName, parsed.NumGlyphs())
-	return h.Sum64()
+	return text.ComputeFontID(source)
 }
 
 // fontHeight returns the font's natural line height (ascent + descent + line gap).

--- a/text/fontid.go
+++ b/text/fontid.go
@@ -1,0 +1,25 @@
+package text
+
+import (
+	"fmt"
+	"hash/fnv"
+)
+
+// ComputeFontID generates a stable hash identifier for a font source.
+// Uses the full font name (includes subfamily like "Regular"/"Bold") and
+// number of glyphs as a lightweight fingerprint. The full name prevents
+// glyph-cache collisions between faces in the same family (e.g., "Go Regular"
+// vs "Go Bold") that share the same family name and glyph count.
+func ComputeFontID(source *FontSource) uint64 {
+	if source == nil {
+		return 0
+	}
+	h := fnv.New64a()
+	parsed := source.Parsed()
+	fullName := parsed.FullName()
+	if fullName == "" {
+		fullName = source.Name()
+	}
+	_, _ = fmt.Fprintf(h, "%s:%d", fullName, parsed.NumGlyphs())
+	return h.Sum64()
+}

--- a/text/fontid_test.go
+++ b/text/fontid_test.go
@@ -1,0 +1,58 @@
+package text
+
+import (
+	"testing"
+
+	"golang.org/x/image/font/gofont/gobold"
+	"golang.org/x/image/font/gofont/goregular"
+)
+
+func TestComputeFontID_Nil(t *testing.T) {
+	if id := ComputeFontID(nil); id != 0 {
+		t.Errorf("ComputeFontID(nil) = %d, want 0", id)
+	}
+}
+
+func TestComputeFontID_Deterministic(t *testing.T) {
+	src, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("NewFontSource: %v", err)
+	}
+	id1 := ComputeFontID(src)
+	id2 := ComputeFontID(src)
+	if id1 != id2 {
+		t.Errorf("same source produced different IDs: %d vs %d", id1, id2)
+	}
+	if id1 == 0 {
+		t.Error("non-nil source produced zero ID")
+	}
+}
+
+func TestComputeFontID_DistinguishesRegularAndBold(t *testing.T) {
+	regular, err := NewFontSource(goregular.TTF)
+	if err != nil {
+		t.Fatalf("load Go Regular: %v", err)
+	}
+	bold, err := NewFontSource(gobold.TTF)
+	if err != nil {
+		t.Fatalf("load Go Bold: %v", err)
+	}
+
+	if regular.Name() != bold.Name() {
+		t.Skipf("fonts have different family names (%q vs %q)", regular.Name(), bold.Name())
+	}
+	if regular.Parsed().NumGlyphs() != bold.Parsed().NumGlyphs() {
+		t.Skipf("fonts have different glyph counts (%d vs %d)",
+			regular.Parsed().NumGlyphs(), bold.Parsed().NumGlyphs())
+	}
+
+	regularID := ComputeFontID(regular)
+	boldID := ComputeFontID(bold)
+	if regularID == boldID {
+		t.Errorf("Go Regular and Go Bold must have different FontIDs\n"+
+			"  Regular: fullName=%q id=%d\n"+
+			"  Bold:    fullName=%q id=%d",
+			regular.Parsed().FullName(), regularID,
+			bold.Parsed().FullName(), boldID)
+	}
+}


### PR DESCRIPTION
## Summary

- Consolidate three identical `computeFontID` functions into a single exported `text.ComputeFontID`
- Remove code duplication across CPU (`text.go`), MSDF (`gpu_text.go`), and glyph mask (`glyph_mask_engine.go`) pipelines
- Add comprehensive tests: nil safety, deterministic output, Regular vs Bold distinction
- Remove unused `hash/fnv` imports from all three source files

Follow-up to #514 (@kivutar) — ensures future font ID changes apply to all pipelines uniformly.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt` — clean