### PR TITLE
perf(clip): cache rasterized coverage masks

### DIFF
--- a/clip_architecture_test.go
+++ b/clip_architecture_test.go
@@ -210,6 +210,59 @@ func TestClipMask_RectOnly_NoMask(t *testing.T) {
 	}
 }
 
+func TestApplyClipToPaint_ReusesMaskAcrossSavedClipState(t *testing.T) {
+	if AcceleratorCanRenderDirect() {
+		t.Skip("pre-rasterized masks are only used by CPU dispatch")
+	}
+
+	dc := NewContext(200, 200)
+	dc.ClipRoundRect(20, 30, 100, 80, 10)
+	dc.applyClipToPaint()
+	first := dc.paint.ClipMask
+	if len(first) == 0 {
+		t.Fatal("first rounded clip did not produce a mask")
+	}
+	dc.clearClipFromPaint()
+
+	dc.applyClipToPaint()
+	second := dc.paint.ClipMask
+	if len(second) == 0 || &first[0] != &second[0] {
+		t.Fatal("unchanged rounded clip did not reuse its mask")
+	}
+	dc.clearClipFromPaint()
+
+	dc.Push()
+	dc.ClipRoundRect(25, 35, 40, 30, 5)
+	dc.applyClipToPaint()
+	nested := dc.paint.ClipMask
+	if len(nested) == 0 || &first[0] == &nested[0] {
+		t.Fatal("nested clip did not receive an independent mask")
+	}
+	dc.clearClipFromPaint()
+	dc.Pop()
+
+	dc.applyClipToPaint()
+	restored := dc.paint.ClipMask
+	if len(restored) == 0 || &first[0] != &restored[0] {
+		t.Fatal("restored clip state did not recover its cached mask")
+	}
+	dc.clearClipFromPaint()
+}
+
+func BenchmarkApplyClipToPaint_CachedRoundedClip(b *testing.B) {
+	dc := NewContext(800, 600)
+	dc.ClipRoundRect(10, 10, 780, 580, 8)
+	dc.applyClipToPaint() // Populate the cache outside the timed loop.
+	dc.clearClipFromPaint()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		dc.applyClipToPaint()
+		dc.clearClipFromPaint()
+	}
+}
+
 // TestClipMask_OutOfBounds verifies correct handling of mask lookups for
 // pixels outside the mask bounds.
 func TestClipMask_OutOfBounds(t *testing.T) {

--- a/context.go
+++ b/context.go
@@ -1929,22 +1929,13 @@ func (c *Context) applyClipToPaint() {
 	// Only needed on rasterAtlas (CPU dispatch). GPU uses hardware scissor + depth clip.
 	needsMask := !cs.IsRectOnly() && !AcceleratorCanRenderDirect()
 	if needsMask {
-		w := int(bounds.W + 0.5)
-		h := int(bounds.H + 0.5)
-		if w > 0 && h > 0 {
-			mask := make([]uint8, w*h)
-			originX := int(bounds.X)
-			originY := int(bounds.Y)
-			for py := 0; py < h; py++ {
-				for px := 0; px < w; px++ {
-					mask[py*w+px] = cs.Coverage(float64(originX+px)+0.5, float64(originY+py)+0.5)
-				}
-			}
-			c.paint.ClipMask = mask
-			c.paint.ClipMaskW = w
-			c.paint.ClipMaskH = h
-			c.paint.ClipMaskX = originX
-			c.paint.ClipMaskY = originY
+		mask := cs.RasterizedMask()
+		if len(mask.Pixels) > 0 {
+			c.paint.ClipMask = mask.Pixels
+			c.paint.ClipMaskW = mask.Width
+			c.paint.ClipMaskH = mask.Height
+			c.paint.ClipMaskX = mask.OriginX
+			c.paint.ClipMaskY = mask.OriginY
 		}
 	}
 

--- a/internal/clip/stack.go
+++ b/internal/clip/stack.go
@@ -1,6 +1,9 @@
 package clip
 
-import "math"
+import (
+	"math"
+	"sync"
+)
 
 // RRectClip describes a rounded rectangle clip region.
 // The Rect field holds the bounding rectangle in device coordinates,
@@ -14,8 +17,25 @@ type RRectClip struct {
 // It maintains a stack of clip entries, where each entry can be either a
 // rectangular clip, a rounded rectangle clip, or a path-based mask clip.
 type ClipStack struct {
-	entries []clipEntry
-	bounds  Rect
+	entries        []clipEntry
+	bounds         Rect
+	rasterizedMask *rasterizedMaskCache
+}
+
+// CoverageMask is a read-only, pixel-aligned clip coverage mask.
+type CoverageMask struct {
+	Pixels           []uint8
+	Width, Height    int
+	OriginX, OriginY int
+}
+
+// rasterizedMaskCache holds the immutable coverage mask for one clip-stack
+// state. Clones share the cache while their entries are identical. Each pushed
+// entry retains the previous cache so Pop can restore it without rerasterizing;
+// the new state receives a separate cache so queued paint commands stay valid.
+type rasterizedMaskCache struct {
+	once sync.Once
+	mask CoverageMask
 }
 
 // Clone returns an independent copy of the clip stack. Clip masks and rounded
@@ -26,17 +46,19 @@ func (cs *ClipStack) Clone() *ClipStack {
 		return nil
 	}
 	return &ClipStack{
-		entries: append([]clipEntry(nil), cs.entries...),
-		bounds:  cs.bounds,
+		entries:        append([]clipEntry(nil), cs.entries...),
+		bounds:         cs.bounds,
+		rasterizedMask: cs.rasterizedMask,
 	}
 }
 
 // clipEntry represents a single clip operation in the stack.
 type clipEntry struct {
-	prevBounds Rect
-	mask       *MaskClipper
-	rrect      *RRectClip // non-nil for rounded rectangle clips
-	antiAlias  bool
+	prevBounds         Rect
+	prevRasterizedMask *rasterizedMaskCache
+	mask               *MaskClipper
+	rrect              *RRectClip // non-nil for rounded rectangle clips
+	antiAlias          bool
 }
 
 // NewClipStack creates a new clip stack with the given bounds.
@@ -56,13 +78,17 @@ func (cs *ClipStack) PushRect(r Rect) {
 
 	// Push entry onto stack
 	cs.entries = append(cs.entries, clipEntry{
-		prevBounds: cs.bounds,
-		mask:       nil, // No mask for rectangular clips
-		antiAlias:  false,
+		prevBounds:         cs.bounds,
+		prevRasterizedMask: cs.rasterizedMask,
+		mask:               nil, // No mask for rectangular clips
+		antiAlias:          false,
 	})
 
 	// Update current bounds
 	cs.bounds = newBounds
+	if cs.rasterizedMask != nil {
+		cs.rasterizedMask = &rasterizedMaskCache{}
+	}
 }
 
 // PushRRect pushes a rounded rectangle clip region onto the stack.
@@ -85,12 +111,14 @@ func (cs *ClipStack) PushRRect(r Rect, radius float64) {
 
 	// Push entry with rrect data.
 	cs.entries = append(cs.entries, clipEntry{
-		prevBounds: cs.bounds,
-		rrect:      &RRectClip{Rect: r, Radius: radius},
+		prevBounds:         cs.bounds,
+		prevRasterizedMask: cs.rasterizedMask,
+		rrect:              &RRectClip{Rect: r, Radius: radius},
 	})
 
 	// Update current bounds.
 	cs.bounds = newBounds
+	cs.rasterizedMask = &rasterizedMaskCache{}
 }
 
 // PushPath pushes a path-based clip region onto the stack.
@@ -113,13 +141,15 @@ func (cs *ClipStack) PushPathWithRule(verbs []PathVerb, coords []float64, antiAl
 
 	// Push entry onto stack
 	cs.entries = append(cs.entries, clipEntry{
-		prevBounds: cs.bounds,
-		mask:       mask,
-		antiAlias:  antiAlias,
+		prevBounds:         cs.bounds,
+		prevRasterizedMask: cs.rasterizedMask,
+		mask:               mask,
+		antiAlias:          antiAlias,
 	})
 
 	// Update current bounds
 	cs.bounds = newBounds
+	cs.rasterizedMask = &rasterizedMaskCache{}
 
 	return nil
 }
@@ -137,6 +167,7 @@ func (cs *ClipStack) Pop() {
 
 	// Restore previous bounds
 	cs.bounds = entry.prevBounds
+	cs.rasterizedMask = entry.prevRasterizedMask
 
 	// Remove entry from stack
 	cs.entries = cs.entries[:lastIdx]
@@ -222,6 +253,40 @@ func (cs *ClipStack) Coverage(x, y float64) byte {
 	}
 
 	return byte(coverage)
+}
+
+// RasterizedMask returns a read-only, pixel-aligned coverage mask for the
+// current clip-stack state. Repeated calls reuse the same backing array until
+// the stack is mutated. The mask is sampled at pixel centers and uses the same
+// bounds rounding as the software rendering pipeline.
+func (cs *ClipStack) RasterizedMask() CoverageMask {
+	if cs == nil || cs.IsRectOnly() {
+		return CoverageMask{}
+	}
+	if cs.rasterizedMask == nil {
+		cs.rasterizedMask = &rasterizedMaskCache{}
+	}
+	cache := cs.rasterizedMask
+	cache.once.Do(func() {
+		bounds := cs.bounds
+		mask := &cache.mask
+		mask.Width = int(bounds.W + 0.5)
+		mask.Height = int(bounds.H + 0.5)
+		mask.OriginX = int(bounds.X)
+		mask.OriginY = int(bounds.Y)
+		if mask.Width > 0 && mask.Height > 0 {
+			mask.Pixels = make([]uint8, mask.Width*mask.Height)
+			for py := 0; py < mask.Height; py++ {
+				for px := 0; px < mask.Width; px++ {
+					mask.Pixels[py*mask.Width+px] = cs.Coverage(
+						float64(mask.OriginX+px)+0.5,
+						float64(mask.OriginY+py)+0.5,
+					)
+				}
+			}
+		}
+	})
+	return cache.mask
 }
 
 // rrectSDF computes the signed distance from point (px, py) to the rounded
@@ -312,4 +377,5 @@ func (cs *ClipStack) Depth() int {
 func (cs *ClipStack) Reset(bounds Rect) {
 	cs.entries = cs.entries[:0]
 	cs.bounds = bounds
+	cs.rasterizedMask = nil
 }

--- a/internal/clip/stack_test.go
+++ b/internal/clip/stack_test.go
@@ -617,6 +617,72 @@ func TestClipStack_PushRRect(t *testing.T) {
 	}
 }
 
+func TestClipStack_RasterizedMaskCache(t *testing.T) {
+	stack := NewClipStack(NewRect(0, 0, 200, 200))
+	stack.PushRRect(NewRect(20, 30, 100, 80), 10)
+
+	first := stack.RasterizedMask()
+	if len(first.Pixels) != 100*80 || first.Width != 100 || first.Height != 80 || first.OriginX != 20 || first.OriginY != 30 {
+		t.Fatalf(
+			"RasterizedMask() = len %d, %dx%d at %d,%d; want len 8000, 100x80 at 20,30",
+			len(first.Pixels), first.Width, first.Height, first.OriginX, first.OriginY,
+		)
+	}
+	second := stack.RasterizedMask()
+	if &first.Pixels[0] != &second.Pixels[0] {
+		t.Fatal("unchanged clip stack did not reuse its rasterized mask")
+	}
+
+	clone := stack.Clone()
+	fromClone := clone.RasterizedMask()
+	if &first.Pixels[0] != &fromClone.Pixels[0] {
+		t.Fatal("clone of unchanged clip stack did not share its rasterized mask")
+	}
+
+	clone.PushRect(NewRect(25, 35, 40, 30))
+	mutated := clone.RasterizedMask()
+	if len(mutated.Pixels) == 0 {
+		t.Fatal("mutated clip stack produced an empty rasterized mask")
+	}
+	if &first.Pixels[0] == &mutated.Pixels[0] {
+		t.Fatal("mutating clone reused the previous clip state's mask")
+	}
+	clone.Pop()
+	restored := clone.RasterizedMask()
+	if len(restored.Pixels) == 0 || &first.Pixels[0] != &restored.Pixels[0] {
+		t.Fatal("popping clone did not restore the previous clip state's mask")
+	}
+	afterMutation := stack.RasterizedMask()
+	if &first.Pixels[0] != &afterMutation.Pixels[0] {
+		t.Fatal("mutating clone invalidated the original clip stack's mask")
+	}
+}
+
+func TestClipStack_RasterizedMaskCacheConcurrentClones(t *testing.T) {
+	stack := NewClipStack(NewRect(0, 0, 200, 200))
+	stack.PushRRect(NewRect(20, 30, 100, 80), 10)
+
+	const workers = 16
+	results := make(chan CoverageMask, workers)
+	for range workers {
+		clone := stack.Clone()
+		go func() {
+			results <- clone.RasterizedMask()
+		}()
+	}
+
+	first := <-results
+	if len(first.Pixels) == 0 {
+		t.Fatal("concurrent mask generation produced an empty mask")
+	}
+	for range workers - 1 {
+		mask := <-results
+		if len(mask.Pixels) == 0 || &first.Pixels[0] != &mask.Pixels[0] {
+			t.Fatal("clones did not share one concurrently initialized mask")
+		}
+	}
+}
+
 func TestClipStack_PushRRect_ZeroRadius(t *testing.T) {
 	stack := NewClipStack(NewRect(0, 0, 200, 200))
 


### PR DESCRIPTION
## Summary

- cache the immutable pixel coverage mask for each non-rectangular clip-stack state
- share cached masks across unchanged clones and restore the previous cache on `Pop`
- reuse the cached mask from `Context.applyClipToPaint` instead of rasterizing the complete clip for every fill

## Motivation

`Context.applyClipToPaint` rebuilt the entire non-rectangular clip mask on every fill. A downstream fullscreen UI repaint containing a rounded window regressed to about 553 ms at 1.333x scaling after the new clip architecture; reusing the mask brings the same repaint back to about 58 ms.

The cache is state-local, bounded by the live clip stack, immutable after initialization, and synchronized so unchanged clones can rasterize concurrently. Mutations receive a new cache, while `Pop` restores the previous state and its mask.

## Validation

- `go test . ./internal/clip -count=1`
- `go test -race . ./internal/clip -count=1`
- `go vet ./...`
- `staticcheck . ./internal/clip`
- cached `applyClipToPaint`: 105-106 ns/op, 16 B/op, 1 alloc/op
