### PR TITLE
perf(text): cache CPU glyph rasterization results

### DIFF
--- a/text/cpu_glyph_mask_cache.go
+++ b/text/cpu_glyph_mask_cache.go
@@ -1,0 +1,78 @@
+package text
+
+import (
+	"math"
+
+	"github.com/gogpu/gg/internal/cache"
+)
+
+// cpuGlyphMaskCacheCapacity is per shard. The cache holds up to 512 masks
+// per font source, enough for several sizes and subpixel variants while
+// keeping memory bounded for applications that load many fonts.
+const cpuGlyphMaskCacheCapacity = 32
+
+type cpuGlyphMaskCacheKey struct {
+	glyphID       GlyphID
+	sizeBits      uint64
+	subpixelXBits uint64
+	subpixelYBits uint64
+	hinting       Hinting
+	mode          glyphRasterMode
+}
+
+type cpuGlyphMaskCacheValue struct {
+	result *GlyphMaskResult
+	err    error
+}
+
+func makeCPUGlyphMaskCacheKey(
+	glyphID GlyphID,
+	size, subpixelX, subpixelY float64,
+	hinting Hinting,
+	mode glyphRasterMode,
+) cpuGlyphMaskCacheKey {
+	return cpuGlyphMaskCacheKey{
+		glyphID:       glyphID,
+		sizeBits:      math.Float64bits(size),
+		subpixelXBits: math.Float64bits(subpixelX),
+		subpixelYBits: math.Float64bits(subpixelY),
+		hinting:       hinting,
+		mode:          mode,
+	}
+}
+
+func hashCPUGlyphMaskCacheKey(key cpuGlyphMaskCacheKey) uint64 {
+	h := key.sizeBits ^ mixCPUGlyphMaskHash(key.subpixelXBits)
+	h ^= mixCPUGlyphMaskHash(key.subpixelYBits)
+	h ^= uint64(key.glyphID) * 0x9e3779b97f4a7c15
+	h ^= uint64(key.hinting+1) * 0xbf58476d1ce4e5b9
+	h ^= uint64(key.mode+1) * 0x94d049bb133111eb
+	return mixCPUGlyphMaskHash(h)
+}
+
+func mixCPUGlyphMaskHash(value uint64) uint64 {
+	value ^= value >> 30
+	value *= 0xbf58476d1ce4e5b9
+	value ^= value >> 27
+	value *= 0x94d049bb133111eb
+	return value ^ (value >> 31)
+}
+
+func (s *FontSource) cpuGlyphMaskCache() *cache.ShardedCache[cpuGlyphMaskCacheKey, cpuGlyphMaskCacheValue] {
+	s.cpuGlyphMasksOnce.Do(func() {
+		s.cpuGlyphMasks = cache.NewSharded[cpuGlyphMaskCacheKey, cpuGlyphMaskCacheValue](
+			cpuGlyphMaskCacheCapacity,
+			hashCPUGlyphMaskCacheKey,
+		)
+	})
+	return s.cpuGlyphMasks
+}
+
+func (s *FontSource) clearCPUGlyphMaskCache() {
+	// Synchronize with the first lazy initialization without allocating a cache
+	// solely to close a source that was never used by the software text path.
+	s.cpuGlyphMasksOnce.Do(func() {})
+	if s.cpuGlyphMasks != nil {
+		s.cpuGlyphMasks.Clear()
+	}
+}

--- a/text/cpu_glyph_mask_cache_test.go
+++ b/text/cpu_glyph_mask_cache_test.go
@@ -1,0 +1,39 @@
+package text
+
+import "testing"
+
+func TestCPUGlyphMaskCacheKeyIncludesRenderingParameters(t *testing.T) {
+	base := makeCPUGlyphMaskCacheKey(1, 16, 0.25, 0.5, HintingFull, rasterModeAA)
+	tests := []struct {
+		name string
+		key  cpuGlyphMaskCacheKey
+	}{
+		{"glyph", makeCPUGlyphMaskCacheKey(2, 16, 0.25, 0.5, HintingFull, rasterModeAA)},
+		{"size", makeCPUGlyphMaskCacheKey(1, 17, 0.25, 0.5, HintingFull, rasterModeAA)},
+		{"subpixel X", makeCPUGlyphMaskCacheKey(1, 16, 0.5, 0.5, HintingFull, rasterModeAA)},
+		{"subpixel Y", makeCPUGlyphMaskCacheKey(1, 16, 0.25, 0.75, HintingFull, rasterModeAA)},
+		{"hinting", makeCPUGlyphMaskCacheKey(1, 16, 0.25, 0.5, HintingNone, rasterModeAA)},
+		{"raster mode", makeCPUGlyphMaskCacheKey(1, 16, 0.25, 0.5, HintingFull, rasterModeAliased)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.key == base {
+				t.Fatal("changing rendering parameter did not change cache key")
+			}
+		})
+	}
+}
+
+func TestCPUGlyphMaskCacheIsBounded(t *testing.T) {
+	source := &FontSource{}
+	cache := source.cpuGlyphMaskCache()
+	for glyphID := range cache.TotalCapacity() * 4 {
+		key := makeCPUGlyphMaskCacheKey(GlyphID(glyphID), 16, 0, 0, HintingFull, rasterModeAA)
+		cache.Set(key, cpuGlyphMaskCacheValue{})
+	}
+
+	if got, limit := cache.Len(), cache.TotalCapacity(); got > limit {
+		t.Fatalf("cache length = %d, want at most %d", got, limit)
+	}
+}

--- a/text/draw.go
+++ b/text/draw.go
@@ -71,6 +71,7 @@ func drawGlyphs(
 	text string,
 	x, y float64,
 	col color.Color,
+	mode glyphRasterMode,
 	rasterize glyphRasterizeFunc,
 ) {
 	if vars := sf.Variations(); len(vars) > 0 {
@@ -115,7 +116,12 @@ func drawGlyphs(
 		subpixelX := glyphX - intX
 		subpixelY := glyphY - intY
 
-		result, err := rasterize(rast, parsed, glyph.GID, ppem, subpixelX, subpixelY, hinting)
+		key := makeCPUGlyphMaskCacheKey(glyph.GID, ppem, subpixelX, subpixelY, hinting, mode)
+		cached := sf.source.cpuGlyphMaskCache().GetOrCreate(key, func() cpuGlyphMaskCacheValue {
+			result, err := rasterize(rast, parsed, glyph.GID, ppem, subpixelX, subpixelY, hinting)
+			return cpuGlyphMaskCacheValue{result: result, err: err}
+		})
+		result, err := cached.result, cached.err
 		if err != nil || result == nil {
 			advanceX += hintedOrRawAdvance(ttCache, glyph, ppem)
 			continue
@@ -304,7 +310,7 @@ func rasterizeAliasedGlyph(
 // HintingNone advances (ADR-039), while outline rasterization still uses
 // the face's configured hinting for crisp stems.
 func drawSourceFace(dst draw.Image, text string, sf *sourceFace, x, y float64, col color.Color) {
-	drawGlyphs(dst, sf, text, x, y, col, rasterizeHintedGlyph)
+	drawGlyphs(dst, sf, text, x, y, col, rasterModeAA, rasterizeHintedGlyph)
 }
 
 // drawMultiFace renders text using a MultiFace, selecting the appropriate font for each rune.

--- a/text/draw_aliased.go
+++ b/text/draw_aliased.go
@@ -32,5 +32,5 @@ func DrawAliased(dst draw.Image, text string, face Face, x, y float64, col color
 		return
 	}
 
-	drawGlyphs(dst, sf, text, x, y, col, rasterizeAliasedGlyph)
+	drawGlyphs(dst, sf, text, x, y, col, rasterModeAliased, rasterizeAliasedGlyph)
 }

--- a/text/draw_test.go
+++ b/text/draw_test.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"image/color"
 	"os"
+	"sync"
 	"testing"
 )
 
@@ -64,6 +65,65 @@ func TestDrawEmpty(t *testing.T) {
 
 	// Draw empty string (should not panic)
 	Draw(dst, "", face, 10, 30, color.Black)
+}
+
+func TestDrawCachesCPUGlyphMasksPerFontSource(t *testing.T) {
+	source := loadTestFont(t)
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(16)
+	dst := image.NewRGBA(image.Rect(0, 0, 200, 50))
+	Draw(dst, "Repeated text", face, 10, 30, color.Black)
+
+	cache := source.cpuGlyphMaskCache()
+	if cache.Len() == 0 {
+		t.Fatal("CPU glyph mask cache is empty after drawing text")
+	}
+	cache.ResetStats()
+
+	Draw(dst, "Repeated text", face, 10, 30, color.Black)
+	stats := cache.Stats()
+	if stats.Hits == 0 {
+		t.Fatal("second draw did not reuse cached CPU glyph masks")
+	}
+	if stats.Misses != 0 {
+		t.Fatalf("second draw cache misses = %d, want 0", stats.Misses)
+	}
+}
+
+func TestDrawCPUGlyphMaskCacheSeparatesRasterModes(t *testing.T) {
+	source := loadTestFont(t)
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(16)
+	dst := image.NewRGBA(image.Rect(0, 0, 100, 50))
+	Draw(dst, "A", face, 10, 30, color.Black)
+	entriesAfterAA := source.cpuGlyphMaskCache().Len()
+
+	DrawAliased(dst, "A", face, 10, 30, color.Black)
+	if got := source.cpuGlyphMaskCache().Len(); got <= entriesAfterAA {
+		t.Fatalf("cache entries after aliased draw = %d, want more than AA entries %d", got, entriesAfterAA)
+	}
+}
+
+func TestDrawCPUGlyphMaskCacheConcurrent(t *testing.T) {
+	source := loadTestFont(t)
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(16)
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			dst := image.NewRGBA(image.Rect(0, 0, 200, 50))
+			for range 10 {
+				Draw(dst, "Concurrent text", face, 10, 30, color.Black)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestDrawNilFace(t *testing.T) {
@@ -798,6 +858,25 @@ func BenchmarkDraw(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Draw(dst, text, face, 10, 50, color.Black)
+	}
+}
+
+func BenchmarkDrawCPUGlyphMaskCacheHit(b *testing.B) {
+	source, err := NewFontSource(requireTestFont(b))
+	if err != nil {
+		b.Fatalf("NewFontSource: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	face := source.Face(16)
+	dst := image.NewRGBA(image.Rect(0, 0, 400, 100))
+	const value = "The quick brown fox jumps over the lazy dog"
+	Draw(dst, value, face, 10, 50, color.Black)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		Draw(dst, value, face, 10, 50, color.Black)
 	}
 }
 

--- a/text/source.go
+++ b/text/source.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"sync"
+
+	"github.com/gogpu/gg/internal/cache"
 )
 
 // FontSource represents a loaded font file.
@@ -28,7 +30,13 @@ type FontSource struct {
 	// Mutex protects caches and internal state
 	mu sync.RWMutex
 
-	// Caches (to be implemented in TASK-044)
+	// cpuGlyphMasks caches final rasterized masks for the software text path.
+	// It is initialized lazily because many FontSources are only used by GPU
+	// text paths that have their own atlas.
+	cpuGlyphMasksOnce sync.Once
+	cpuGlyphMasks     *cache.ShardedCache[cpuGlyphMaskCacheKey, cpuGlyphMaskCacheValue]
+
+	// Other caches (to be implemented in TASK-044)
 	// shapingCache  *Cache[shapingKey, []Glyph]
 	// glyphCache    *Cache[glyphKey, *GlyphImage]
 	// hasGlyphCache *runeToBoolMap
@@ -147,6 +155,7 @@ func (s *FontSource) Close() error {
 	// Clear data
 	s.data = nil
 	s.parsed = nil
+	s.clearCPUGlyphMaskCache()
 
 	// Clear caches (when implemented in TASK-044)
 

--- a/text/tt_glyph_test.go
+++ b/text/tt_glyph_test.go
@@ -418,6 +418,26 @@ func TestTTHintedOutlineToGlyphOutline(t *testing.T) {
 	}
 }
 
+func TestTTHintCacheReusesHintedOutline(t *testing.T) {
+	data := loadTTTestFont(t, "tthint_subset.ttf")
+	cache := newTTHintCache(data)
+	if cache == nil {
+		t.Fatal("expected non-nil cache")
+	}
+
+	first, err := cache.hintGlyphOutline(1, 16)
+	if err != nil || first == nil {
+		t.Fatalf("first hintGlyphOutline() = (%v, %v), want outline", first, err)
+	}
+	second, err := cache.hintGlyphOutline(1, 16)
+	if err != nil {
+		t.Fatalf("second hintGlyphOutline() error = %v", err)
+	}
+	if second != first {
+		t.Fatal("second hintGlyphOutline() did not reuse the cached outline")
+	}
+}
+
 func TestParseGlyfFlags(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/text/tt_integrate.go
+++ b/text/tt_integrate.go
@@ -21,7 +21,11 @@ package text
 
 import (
 	"sync"
+
+	"github.com/gogpu/gg/internal/cache"
 )
+
+const ttHintOutlineCacheCapacity = 32
 
 // ttHintCache provides cached TT hint instances per font+size combination.
 // Thread-safe via sync.Map for concurrent access from multiple goroutines.
@@ -43,6 +47,11 @@ type ttHintCacheEntry struct {
 	instance *ttHintInstance
 	err      error // non-nil if instance creation failed
 
+	// outlines caches final hinted outlines per glyph. Face measurement asks
+	// for hinted advances before Draw rasterizes the same glyphs; retaining the
+	// immutable result avoids running the loader and TT interpreter twice.
+	outlines *cache.ShardedCache[uint16, *ttCachedOutline]
+
 	// advances caches hinted advance widths per glyph ID.
 	// Key: glyphID (uint16), Value: ttCachedAdvance.
 	// Avoids re-running the full TT bytecode interpreter for advance-only
@@ -55,6 +64,12 @@ type ttHintCacheEntry struct {
 type ttCachedAdvance struct {
 	width float64
 	ok    bool
+}
+
+type ttCachedOutline struct {
+	once    sync.Once
+	outline *ttGlyphOutline
+	err     error
 }
 
 // newTTHintCache creates a hint cache for the given font data.
@@ -101,9 +116,27 @@ func (c *ttHintCache) getInstance(ppem int32) (*ttHintInstance, error) {
 //
 //nolint:nilnil // nil result = "no hintable outline"
 func (c *ttHintCache) hintGlyphOutline(glyphID uint16, ppem int32) (*ttGlyphOutline, error) {
-	instance, err := c.getInstance(ppem)
-	if err != nil {
-		return nil, err
+	entry := c.getEntry(ppem)
+	if entry == nil {
+		return nil, nil
+	}
+
+	cached := entry.outlines.GetOrCreate(glyphID, func() *ttCachedOutline {
+		return &ttCachedOutline{}
+	})
+	cached.once.Do(func() {
+		cached.outline, cached.err = c.hintGlyphOutlineUncached(entry.instance, entry.err, glyphID)
+	})
+	return cached.outline, cached.err
+}
+
+func (c *ttHintCache) hintGlyphOutlineUncached(
+	instance *ttHintInstance,
+	instanceErr error,
+	glyphID uint16,
+) (*ttGlyphOutline, error) {
+	if instanceErr != nil {
+		return nil, instanceErr
 	}
 	if instance == nil {
 		return nil, nil
@@ -200,7 +233,14 @@ func (c *ttHintCache) getEntry(ppem int32) *ttHintCacheEntry {
 
 	// Create new instance (fpgm + prep execution).
 	instance, err := newTTHintInstance(c.font, ppem, ttTargetSmooth)
-	entry := &ttHintCacheEntry{instance: instance, err: err}
+	entry := &ttHintCacheEntry{
+		instance: instance,
+		err:      err,
+		outlines: cache.NewSharded[uint16, *ttCachedOutline](
+			ttHintOutlineCacheCapacity,
+			func(glyphID uint16) uint64 { return uint64(glyphID) },
+		),
+	}
 
 	// Store in cache (LoadOrStore handles races).
 	actual, _ := c.entries.LoadOrStore(ppem, entry)


### PR DESCRIPTION
## Summary

- cache final AA and aliased CPU glyph masks per `FontSource`
- cache immutable TrueType-hinted outlines per font size and glyph
- reuse the hinted outline between advance measurement and rasterization
- bound both new caches to 512 entries per owning cache

## Correctness and lifecycle

The final-mask key includes the glyph ID, exact size and subpixel coordinates, hinting mode, and raster mode. Each `FontSource` owns its cache, so different fonts and weights cannot contaminate one another. `FontSource.Close` synchronizes with lazy cache initialization before clearing it. Errors and successful masks are deterministic and cached together.

Hinted outlines are immutable after construction. A per-entry `sync.Once` coalesces concurrent work, while the sharded LRU bounds retained glyphs.

## Benchmarks

Upstream `main`:

```
BenchmarkDrawCPUGlyphMaskCacheHit       1.90-2.02 ms/op   1,173,345-1,173,356 B/op   5766 allocs/op
BenchmarkFontTTHint_GlyphOutline         847-875 us/op       74,338 B/op             18 allocs/op
```

This branch:

```
BenchmarkDrawCPUGlyphMaskCacheHit       16.9-17.5 us/op       3,408 B/op             39 allocs/op
BenchmarkFontTTHint_GlyphOutline        51.2-53.5 ns/op           0 B/op              0 allocs/op
```

## Validation

- `go test ./text -count=1`
- `go test -race ./text -count=1`
- `go vet ./...`
- `staticcheck ./text/...`
