### PR TITLE
fix(image): preserve premultiplied stdlib RGBA

### DIFF
--- a/internal/image/io.go
+++ b/internal/image/io.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"image/color"
 	"image/jpeg"
 	"image/png"
 	"io"
@@ -183,16 +184,17 @@ func (b *ImageBuf) EncodeJPEG(w io.Writer, quality int) error {
 }
 
 // FromStdImage creates an ImageBuf from a standard library image.Image.
-// The resulting ImageBuf will be in RGBA8 format.
+// Premultiplied RGBA inputs retain their native representation; all other
+// images are converted to straight RGBA8.
 func FromStdImage(img image.Image) *ImageBuf {
 	bounds := img.Bounds()
 	width := bounds.Dx()
 	height := bounds.Dy()
 
-	buf, _ := NewImageBuf(width, height, FormatRGBA8)
-
-	// Fast path for RGBA images
+	// image.RGBA stores premultiplied color channels. Preserve that format so
+	// callers of PremultipliedData do not multiply the channels a second time.
 	if rgba, ok := img.(*image.RGBA); ok {
+		buf, _ := NewImageBuf(width, height, FormatRGBAPremul)
 		// Direct copy if stride matches
 		if rgba.Stride == buf.Stride() {
 			copy(buf.Data(), rgba.Pix)
@@ -205,6 +207,8 @@ func FromStdImage(img image.Image) *ImageBuf {
 		}
 		return buf
 	}
+
+	buf, _ := NewImageBuf(width, height, FormatRGBA8)
 
 	// Fast path for NRGBA images
 	if nrgba, ok := img.(*image.NRGBA); ok {
@@ -222,11 +226,8 @@ func FromStdImage(img image.Image) *ImageBuf {
 	// Generic slow path for any image type
 	for y := range height {
 		for x := range width {
-			c := img.At(bounds.Min.X+x, bounds.Min.Y+y)
-			r, g, b, a := c.RGBA()
-			// RGBA() returns 16-bit values, scale to 8-bit
-			// Right shift by 8 guarantees result fits in uint8
-			_ = buf.SetRGBA(x, y, byte(r>>8), byte(g>>8), byte(b>>8), byte(a>>8))
+			c := color.NRGBAModel.Convert(img.At(bounds.Min.X+x, bounds.Min.Y+y)).(color.NRGBA)
+			_ = buf.SetRGBA(x, y, c.R, c.G, c.B, c.A)
 		}
 	}
 

--- a/internal/image/io_test.go
+++ b/internal/image/io_test.go
@@ -28,6 +28,39 @@ func TestFromStdImage_RGBA(t *testing.T) {
 	}
 }
 
+func TestFromStdImage_RGBAPreservesPremultiplication(t *testing.T) {
+	rgba := &image.RGBA{
+		Pix:    []byte{100, 50, 25, 128},
+		Stride: 4,
+		Rect:   image.Rect(0, 0, 1, 1),
+	}
+
+	buf := FromStdImage(rgba)
+
+	if buf.Format() != FormatRGBAPremul {
+		t.Fatalf("Format = %v, want %v", buf.Format(), FormatRGBAPremul)
+	}
+	if got := buf.PremultipliedData(); !bytes.Equal(got, rgba.Pix) {
+		t.Errorf("PremultipliedData() = %v, want %v", got, rgba.Pix)
+	}
+}
+
+func TestFromStdImage_GenericConvertsToStraightRGBA(t *testing.T) {
+	nrgba := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+	nrgba.SetNRGBA(0, 0, color.NRGBA{R: 200, G: 100, B: 50, A: 128})
+	generic := struct{ image.Image }{Image: nrgba}
+
+	buf := FromStdImage(generic)
+
+	if buf.Format() != FormatRGBA8 {
+		t.Fatalf("Format = %v, want %v", buf.Format(), FormatRGBA8)
+	}
+	r, g, b, a := buf.GetRGBA(0, 0)
+	if r != 200 || g != 100 || b != 50 || a != 128 {
+		t.Errorf("Pixel = (%d, %d, %d, %d), want (200, 100, 50, 128)", r, g, b, a)
+	}
+}
+
 func TestFromStdImage_NRGBA(t *testing.T) {
 	nrgba := image.NewNRGBA(image.Rect(0, 0, 10, 10))
 	nrgba.Set(3, 3, color.NRGBA{R: 128, G: 64, B: 32, A: 200})


### PR DESCRIPTION
## Summary

- preserve image.RGBA input as FormatRGBAPremul
- convert generic image.Image colors to straight RGBA8
- add regression coverage for both alpha representations

## Problem

Go image.RGBA stores premultiplied color channels. FromStdImage copied those bytes into a straight FormatRGBA8 buffer, so PremultipliedData multiplied them by alpha a second time. This made translucent images too dark and muted. The generic conversion path had the same issue because color.Color.RGBA returns premultiplied components.

## Validation

- go test ./...
- go test -race ./internal/image
- go vet ./...
- staticcheck ./internal/image